### PR TITLE
Require >= instead of == for requirements

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,12 +1,12 @@
-pip==9.0.1
-bumpversion==0.5.3
+pip>=9.0.1
+bumpversion>=0.5.3
 wheel>=0.29.0
-watchdog==0.8.3
-flake8==3.5.0
-tox==2.9.1
-coverage==4.5.1
-Sphinx==1.7.1
-twine==1.10.0
+watchdog>=0.8.3
+flake8>=3.5.0
+tox>=2.9.1
+coverage>=4.5.1
+Sphinx>=1.7.1
+twine>=1.10.0
 
-pytest==3.4.2
-pytest-runner==2.11.1
+pytest>=3.4.2
+pytest-runner>=2.11.1


### PR DESCRIPTION
Makes dependency handling easier overall (no conflicting deps). And it's usually not required to have a ==.