### PR TITLE
TF forward compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-tensorflow~=1.10.0
-tensorflow_probability~=0.3.0
+tensorflow>=1.10.0
+tensorflow_probability>=0.3.0
 scipy
 numpy
 iminuit

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -10,7 +10,8 @@ from zfit import ztf
 
 try:
     # from tensorflow.python.ops.variables import
-    from tensorflow.python.ops.variables import VariableV1
+    # from tensorflow.python.ops.variables import VariableV1
+    from tensorflow.python.ops.resource_variable_ops import ResourceVariable as VariableV1
 except ImportError:
     from tensorflow import Variable as VariableV1
 


### PR DESCRIPTION
We inherit know from the better `ResourceVariable` instead of `Variable`. This works with tf 0.10+. Byebye old versions!

(CI is ok, the failing test is fixed in another PR, tested locally)

It's mostly FYI