### PR TITLE
Add basic logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy
 iminuit
 typing
 pep487
+colorlog

--- a/zfit/util/logging.py
+++ b/zfit/util/logging.py
@@ -47,6 +47,8 @@ def get_logger(name, stdout_level=None, file_level=None, file_name=None):
     """
     if not name.startswith('zfit'):
         name = 'zfit.{}'.format(name.rstrip('.'))
+    if stdout_level is None:
+        stdout_level = logging.WARNING
     format_stream = ("%(asctime)s - %(name)s | "
                      "%(log_color)s%(levelname)-8s%(reset)s | "
                      "%(log_color)s%(message)s%(reset)s")
@@ -61,8 +63,7 @@ def get_logger(name, stdout_level=None, file_level=None, file_name=None):
         stream.setFormatter(formatter)
         logger.addHandler(stream)
     # The first handler is always the stream
-    if stdout_level is None:
-        stdout_level = logging.WARNING
+
     logger.handlers[0].setLevel(stdout_level)
     # Now the file handler
     file_handler = None

--- a/zfit/util/logging.py
+++ b/zfit/util/logging.py
@@ -1,0 +1,48 @@
+"""
+This module controls the zfit logging.
+
+The base logger for zfit is called `zfit`, and any subsequent logger has the
+form `zfit.XX`, where `XX` is its name.
+
+By default, time, name of the logger and message with the default
+colorlog color scheme are printed.
+
+"""
+
+import logging
+import colorlog
+
+
+def get_logger(name, lvl=logging.NOTSET, format_=None):
+    """Get logger, configuring it on first instantiation.
+
+    If the logger name doesn't start with "zfit", it is automatically added.
+
+    Note:
+        Default logging level at first instatiation is INFO.
+
+    Arguments:
+        name (str): Name of the logger.
+        lvl (int, optional): Logging level. Defaults to `logging.NOTSET`.
+        format_ (str): Logger formatting string
+
+    Return:
+        `logging.Logger`: The requested logger.
+
+    """
+    if not name.startswith('zfit'):
+        name = 'zfit.{}'.format(name.rstrip('.'))
+    if not format_:
+        format_ = ("%(asctime)s - %(name)s | "
+                   "%(log_color)s%(levelname)-8s%(reset)s | "
+                   "%(log_color)s%(message)s%(reset)s")
+
+    if not logging.root.handlers:
+        formatter = colorlog.ColoredFormatter(format_)
+        stream = logging.StreamHandler()
+        stream.setFormatter(formatter)
+        logging.root.addHandler(stream)
+        logging.root.setLevel(logging.INFO)
+    logger = logging.getLogger(name)
+    logger.setLevel(lvl)
+    return logger

--- a/zfit/util/logging.py
+++ b/zfit/util/logging.py
@@ -1,48 +1,92 @@
 """
 This module controls the zfit logging.
 
-The base logger for zfit is called `zfit`, and any subsequent logger has the
-form `zfit.XX`, where `XX` is its name.
+The base logger for zfit is called `zfit`, and all loggers created by this module
+have the form `zfit.XX`, where `XX` is their name.
 
 By default, time, name of the logger and message with the default
 colorlog color scheme are printed.
 
 """
 
+import os
+
 import logging
 import colorlog
 
 
-def get_logger(name, lvl=logging.NOTSET, format_=None):
-    """Get logger, configuring it on first instantiation.
+def get_logger(name, stdout_level=None, file_level=logging.WARNING, file_name=None):
+    """Get and configure logger.
 
-    If the logger name doesn't start with "zfit", it is automatically added.
+    This logger has two handlers:
+        - A stdout handler is always configured with `colorlog`.
+        - A file handler is configured if `file_name` is given. Once it has been configure, it is not
+        necessary to give it to modify its properties.
+
+    Once the logger has been created, `get_logger` can be called again to modify its log levels,
+    independently for the stream and file handlers.
 
     Note:
-        Default logging level at first instatiation is INFO.
+        If the logger name doesn't start with "zfit", it is automatically added.
+
+    Note:
+        Default logging level at first instatiation is WARNING.
 
     Arguments:
         name (str): Name of the logger.
-        lvl (int, optional): Logging level. Defaults to `logging.NOTSET`.
-        format_ (str): Logger formatting string
+        stdout_level (int, optional): Logging level for the stream handler. Defaults to `logging.WARNING`.
+        file_level (int, optional): Logging level for the file handler. Defaults to `logging.WARNING`.
+        file_name (str, optional): File to log to. If not given, no file logging is performed.
 
     Return:
         `logging.Logger`: The requested logger.
 
+    Raise:
+        ValueError if `file_level` has been specified without having configured the output file.
+
     """
     if not name.startswith('zfit'):
         name = 'zfit.{}'.format(name.rstrip('.'))
-    if not format_:
-        format_ = ("%(asctime)s - %(name)s | "
-                   "%(log_color)s%(levelname)-8s%(reset)s | "
-                   "%(log_color)s%(message)s%(reset)s")
-
-    if not logging.root.handlers:
-        formatter = colorlog.ColoredFormatter(format_)
+    format_stream = ("%(asctime)s - %(name)s | "
+                     "%(log_color)s%(levelname)-8s%(reset)s | "
+                     "%(log_color)s%(message)s%(reset)s")
+    format_file = ("%(asctime)s - %(name)s | "
+                   "%(levelname)-8s | "
+                   "%(message)s")
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        # Add Stream handler
+        formatter = colorlog.ColoredFormatter(format_stream)
         stream = logging.StreamHandler()
         stream.setFormatter(formatter)
-        logging.root.addHandler(stream)
-        logging.root.setLevel(logging.INFO)
-    logger = logging.getLogger(name)
-    logger.setLevel(lvl)
+        logger.addHandler(stream)
+    # The first handler is always the stream
+    if stdout_level is None:
+        stdout_level = logging.WARNING
+    logger.handlers[0].setLevel(stdout_level)
+    # Now the file handler
+    file_handler = None
+    # Find the file handler
+    for handler in logger.handlers:
+        if isinstance(handler, logging.FileHandler):
+            if not file_name or \
+                    os.path.abspath(file_name) == handler.baseFilename:
+                file_handler = handler
+                break
+    # If requested, create one
+    if file_name and not file_handler:
+        formatter = colorlog.ColoredFormatter(format_file)
+        file_handler = logging.FileHandler(file_name)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+    # Set its level
+    if file_level and not file_handler:
+        raise ValueError("Requested change in file log level but no file logger has been  configured")
+    if file_level is None:
+        file_level = logging.WARNING
+    if file_handler:
+        file_handler.setLevel(file_level)
+    # Set the logging level to the lowest level
+    logger_level = min(stdout_level, file_level)
+    logger.setLevel(logger_level)
     return logger

--- a/zfit/util/logging.py
+++ b/zfit/util/logging.py
@@ -15,7 +15,7 @@ import logging
 import colorlog
 
 
-def get_logger(name, stdout_level=None, file_level=logging.WARNING, file_name=None):
+def get_logger(name, stdout_level=None, file_level=None, file_name=None):
     """Get and configure logger.
 
     This logger has two handlers:
@@ -30,7 +30,7 @@ def get_logger(name, stdout_level=None, file_level=logging.WARNING, file_name=No
         If the logger name doesn't start with "zfit", it is automatically added.
 
     Note:
-        Default logging level at first instatiation is WARNING.
+        Default logging level at first instantiation is WARNING.
 
     Arguments:
         name (str): Name of the logger.
@@ -74,17 +74,17 @@ def get_logger(name, stdout_level=None, file_level=logging.WARNING, file_name=No
                 file_handler = handler
                 break
     # If requested, create one
-    if file_name and not file_handler:
+    if file_name and file_handler is None:
         formatter = colorlog.ColoredFormatter(format_file)
         file_handler = logging.FileHandler(file_name)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
     # Set its level
-    if file_level and not file_handler:
+    if file_level is not None and file_handler is None:
         raise ValueError("Requested change in file log level but no file logger has been  configured")
     if file_level is None:
         file_level = logging.WARNING
-    if file_handler:
+    if file_handler is not None:
         file_handler.setLevel(file_level)
     # Set the logging level to the lowest level
     logger_level = min(stdout_level, file_level)


### PR DESCRIPTION
Logger configuration is added.

Pending question: should we add a `to_file` option that enables streaming to file, together with `to_screen`? This would only work for first instantiation, so it could cause confusion when used by a user. A solution to this would be to have a separate method: `log_to_file(logger_name, file_name, log_level)` which would inspect the handlers and add whatever was necessary, and something like `log_to_screen(logger, log_level)` that could be used to hide the printing to screen.

What do you think? @mayou36 