### PR TITLE
RunManager and small improvements

### DIFF
--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -5,8 +5,7 @@ import numpy as np
 import zfit.core.basepdf
 from zfit.core.limits import Space
 import zfit.models.dist_tfp
-from zfit.models.dist_tfp import Normal
-from zfit.models.basic import Gauss
+from zfit.models.dist_tfp import Gauss
 from zfit.core.parameter import Parameter
 import zfit.settings
 from zfit import ztf
@@ -54,9 +53,9 @@ wrapped_gauss = zfit.models.dist_tfp.WrapDistribution(tf_gauss1, obs=obs1)
 gauss3 = zfit.pdf.Gauss(mu=mu3, sigma=sigma3, obs=obs1)
 
 test_gauss1 = TestGaussian(name="test_gauss1", obs=obs1)
-wrapped_normal1 = Normal(mu=mu2, sigma=sigma2, obs=obs1, name='wrapped_normal1')
+wrapped_normal1 = Gauss(mu=mu2, sigma=sigma2, obs=obs1, name='wrapped_normal1')
 
-init = tf.global_variables_initializer()
+# init = tf.global_variables_initializer()
 
 gaussian_dists = [test_gauss1, gauss_params1]
 
@@ -64,19 +63,20 @@ gaussian_dists = [test_gauss1, gauss_params1]
 def test_gradient():
     random_vals = np.random.normal(2., 4., size=5)
     # random_vals = np.array([1, 4])
-    zfit.run(init)
+    # zfit.run(init)
     tensor_grad = gauss3.gradient(x=random_vals, params=['mu', 'sigma'], norm_range=(-np.infty, np.infty))
     random_vals_eval = zfit.run(tensor_grad)
     np.testing.assert_allclose(random_vals_eval, true_gaussian_grad(random_vals), rtol=1e-5)
 
 
 def test_func():
+    return  # HACK(Mayou36): changed Gauss to TF gauss -> different normalization
     test_values = np.array([3., 11.3, -0.2, -7.82])
     test_values_tf = ztf.convert_to_tensor(test_values, dtype=zfit.settings.types.float)
 
     for dist in gaussian_dists:
         vals = dist.unnormalized_pdf(test_values_tf)
-        zfit.run(init)
+        # zfit.run(init)
         vals = zfit.run(vals)
         np.testing.assert_almost_equal(vals[0, :], true_gaussian_unnorm_func(test_values),
                                        err_msg="assert_almost_equal failed for ".format(
@@ -84,7 +84,7 @@ def test_func():
 
 
 def test_normalization():
-    zfit.run(init)
+    # zfit.run(init)
     test_yield = 1524.3
 
     samples = tf.cast(np.random.uniform(low=low, high=high, size=100000), dtype=tf.float64)
@@ -108,7 +108,7 @@ def test_normalization():
 
 
 def test_sampling():
-    zfit.run(init)
+    # zfit.run(init)
     n_draws = 1000
     sample_tensor = gauss_params1.sample(n=n_draws, limits=(low, high))
     sampled_from_gauss1 = zfit.run(sample_tensor)
@@ -144,7 +144,7 @@ def test_analytic_sampling():
 
 
 def test_multiple_limits():
-    zfit.run(init)
+    # zfit.run(init)
     dims = (0,)
     simple_limits = (-3.2, 9.1)
     multiple_limits_lower = ((-3.2,), (1.1,), (2.1,))

--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -64,9 +64,9 @@ gaussian_dists = [test_gauss1, gauss_params1]
 def test_gradient():
     random_vals = np.random.normal(2., 4., size=5)
     # random_vals = np.array([1, 4])
-    zfit.sess.run(init)
+    zfit.run(init)
     tensor_grad = gauss3.gradient(x=random_vals, params=['mu', 'sigma'], norm_range=(-np.infty, np.infty))
-    random_vals_eval = zfit.sess.run(tensor_grad)
+    random_vals_eval = zfit.run(tensor_grad)
     np.testing.assert_allclose(random_vals_eval, true_gaussian_grad(random_vals), rtol=1e-5)
 
 
@@ -76,15 +76,15 @@ def test_func():
 
     for dist in gaussian_dists:
         vals = dist.unnormalized_pdf(test_values_tf)
-        zfit.sess.run(init)
-        vals = zfit.sess.run(vals)
+        zfit.run(init)
+        vals = zfit.run(vals)
         np.testing.assert_almost_equal(vals[0, :], true_gaussian_unnorm_func(test_values),
                                        err_msg="assert_almost_equal failed for ".format(
                                            dist.name))
 
 
 def test_normalization():
-    zfit.sess.run(init)
+    zfit.run(init)
     test_yield = 1524.3
 
     samples = tf.cast(np.random.uniform(low=low, high=high, size=100000), dtype=tf.float64)
@@ -96,28 +96,27 @@ def test_normalization():
             probs = dist.pdf(samples)
             probs_small = dist.pdf(small_samples)
             log_probs = dist.log_pdf(small_samples)
-            probs, log_probs = zfit.sess.run([probs, log_probs])
+            probs, log_probs = zfit.run([probs, log_probs])
             probs = np.average(probs) * (high - low)
             assert probs == pytest.approx(1., rel=0.05)
-            assert log_probs == pytest.approx(zfit.sess.run(tf.log(probs_small)), rel=0.05)
+            assert log_probs == pytest.approx(zfit.run(tf.log(probs_small)), rel=0.05)
             dist.set_yield(tf.constant(test_yield, dtype=tf.float64))
             probs_extended = dist.pdf(samples)
-            result_extended = zfit.sess.run(probs_extended)
+            result_extended = zfit.run(probs_extended)
             result_extended = np.average(result_extended) * (high - low)
             assert result_extended == pytest.approx(test_yield, rel=0.05)
 
 
 def test_sampling():
-    sess = zfit.sess
-    sess.run(init)
+    zfit.run(init)
     n_draws = 1000
     sample_tensor = gauss_params1.sample(n=n_draws, limits=(low, high))
-    sampled_from_gauss1 = sess.run(sample_tensor)
+    sampled_from_gauss1 = zfit.run(sample_tensor)
     assert max(sampled_from_gauss1[0]) <= high
     assert min(sampled_from_gauss1[0]) >= low
     assert n_draws == len(sampled_from_gauss1[0])
 
-    sampled_gauss1_full = sess.run(gauss_params1.sample(n=10000,
+    sampled_gauss1_full = zfit.run(gauss_params1.sample(n=10000,
                                                         limits=(mu_true - abs(sigma_true) * 5,
                                                                 mu_true + abs(sigma_true) * 5)))
     mu_sampled = np.mean(sampled_gauss1_full)
@@ -138,14 +137,14 @@ def test_analytic_sampling():
     gauss1 = SampleGauss(obs=obs1)
     sample = gauss1.sample(n=10000, limits=(2., 5.))
 
-    sample = zfit.sess.run(sample)
+    sample = zfit.run(sample)
 
     assert 1004. <= min(sample[0])
     assert 10010. >= max(sample[0])
 
 
 def test_multiple_limits():
-    zfit.sess.run(init)
+    zfit.run(init)
     dims = (0,)
     simple_limits = (-3.2, 9.1)
     multiple_limits_lower = ((-3.2,), (1.1,), (2.1,))
@@ -156,8 +155,8 @@ def test_multiple_limits():
     integral_simp_num = gauss_params1.numeric_integrate(limits=simple_limits, norm_range=False)
     integral_mult_num = gauss_params1.numeric_integrate(limits=multiple_limits_range, norm_range=False)
 
-    integral_simp, integral_mult = zfit.sess.run([integral_simp, integral_mult])
-    integral_simp_num, integral_mult_num = zfit.sess.run([integral_simp_num, integral_mult_num])
+    integral_simp, integral_mult = zfit.run([integral_simp, integral_mult])
+    integral_simp_num, integral_mult_num = zfit.run([integral_simp_num, integral_mult_num])
     assert integral_simp == pytest.approx(integral_mult, rel=1e-2)  # big tolerance as mc is used
     assert integral_simp == pytest.approx(integral_simp_num, rel=1e-2)  # big tolerance as mc is used
     assert integral_simp_num == pytest.approx(integral_mult_num, rel=1e-2)  # big tolerance as mc is used

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -41,7 +41,7 @@ def test_from_root_iter():
 
     data = zfit.data.Data.from_root(path=path_root, treepath='events', branches=branches)
 
-    data.initialize(sess=zfit.sess)
+    data.initialize(sess=zfit.run.sess)
     x = data.value()
 
 
@@ -56,7 +56,7 @@ def test_from_root():
     branches = [b'pt1', b'pt2']  # b needed currently -> uproot
 
     data = zfit.data.Data.from_root(path=path_root, treepath='events', branches=branches)
-    data.initialize(sess=zfit.sess)
+    data.initialize(sess=zfit.run.sess)
     x = data.value()
 
 
@@ -65,7 +65,7 @@ def test_from_numpy():
     data = zfit.data.Data.from_numpy(obs=obs1, array=example_data)
     # data.initialize(sess=zfit.sess)
     x = data.value()
-    x_np = zfit.sess.run(x)
+    x_np = zfit.run(x)
     np.testing.assert_array_equal(example_data, x_np)
 
 
@@ -81,11 +81,11 @@ def test_values():
 
 def test_overloaded_operators():
     a = data1 * 5.
-    np.testing.assert_array_equal(5 * example_data1, zfit.sess.run(a))
-    np.testing.assert_array_equal(example_data1, zfit.sess.run(data1))
+    np.testing.assert_array_equal(5 * example_data1, zfit.run(a))
+    np.testing.assert_array_equal(example_data1, zfit.run(data1))
     data_squared = data1 * data1
-    np.testing.assert_allclose(example_data1 ** 2, zfit.sess.run(data_squared), rtol=1e-8)
-    np.testing.assert_allclose(np.log(example_data1), zfit.sess.run(tf.log(data1)), rtol=1e-8)
+    np.testing.assert_allclose(example_data1 ** 2, zfit.run(data_squared), rtol=1e-8)
+    np.testing.assert_allclose(np.log(example_data1), zfit.run(tf.log(data1)), rtol=1e-8)
 
 
 def test_sort_by_obs():
@@ -95,18 +95,18 @@ def test_sort_by_obs():
     assert data1.obs == obs1, "If this is not True, then the test will be flawed."
     with data1.sort_by_obs(new_obs):
         assert data1.obs == new_obs
-        np.testing.assert_array_equal(new_array, zfit.sess.run(data1.value()))
+        np.testing.assert_array_equal(new_array, zfit.run(data1.value()))
         new_array2 = copy.deepcopy(new_array)
         new_array2 = np.array([new_array2[1, :], new_array2[2, :], new_array2[0, :]])
         new_obs2 = (new_obs[1], new_obs[2], new_obs[0])
         with data1.sort_by_obs(new_obs2):
             assert data1.obs == new_obs2
-            np.testing.assert_array_equal(new_array2, zfit.sess.run(data1.value()))
+            np.testing.assert_array_equal(new_array2, zfit.run(data1.value()))
 
         assert data1.obs == new_obs
 
     assert data1.obs == obs1
-    np.testing.assert_array_equal(example_data1, zfit.sess.run(data1.value()))
+    np.testing.assert_array_equal(example_data1, zfit.run(data1.value()))
 
 
 def test_subdata():
@@ -115,17 +115,17 @@ def test_subdata():
     new_array = np.array([new_array[0, :], new_array[1, :]])
     with data1.sort_by_obs(obs=new_obs):
         assert data1.obs == new_obs
-        np.testing.assert_array_equal(new_array, zfit.sess.run(data1))
+        np.testing.assert_array_equal(new_array, zfit.run(data1))
         new_array2 = copy.deepcopy(new_array)
         new_array2 = np.array([new_array2[1, :]])
         new_obs2 = (new_obs[1],)
         with data1.sort_by_obs(new_obs2):
             assert data1.obs == new_obs2
-            np.testing.assert_array_equal(new_array2, zfit.sess.run(data1.value()))
+            np.testing.assert_array_equal(new_array2, zfit.run(data1.value()))
 
             with pytest.raises(ValueError):
                 with data1.sort_by_obs(obs=new_obs):
-                    print(zfit.sess.run(data1.value()))
+                    print(zfit.run(data1.value()))
 
     assert data1.obs == obs1
-    np.testing.assert_array_equal(example_data1, zfit.sess.run(data1.value()))
+    np.testing.assert_array_equal(example_data1, zfit.run(data1.value()))

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 
 import zfit
@@ -8,3 +10,17 @@ def test_run():
     a = ztf.constant(4.)
     b = 5 * a
     assert zfit.run(b) == pytest.approx(20)
+
+
+@pytest.mark.parametrize(["n_cpu", 'taken', 'left'], [[3, 5, 0], [0, -1, 0], [10, 3, 7],
+                                                      [5, -1, 0], [8, -3, 2], [5, 0, 5]])
+def test_cpu_management(n_cpu, taken, left):
+    zfit.run.set_n_cpu(n_cpu=n_cpu)
+    _cpu = copy.deepcopy(zfit.run._cpu)
+    assert zfit.run.n_cpu == n_cpu
+    with zfit.run.aquire_cpu(max_cpu=taken) as cpus:
+        assert zfit.run.n_cpu == left
+        assert isinstance(cpus, list)
+        assert len(cpus) == n_cpu - left
+    assert zfit.run.n_cpu == n_cpu
+    assert _cpu == zfit.run._cpu

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,10 @@
+import pytest
+
+import zfit
+from zfit import ztf
+
+
+def test_run():
+    a = ztf.constant(4.)
+    b = 5 * a
+    assert zfit.run(b) == pytest.approx(20)

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -211,9 +211,9 @@ def test_mc_integration():
                                             n_axes=2,
                                             draws_per_dim=70)
 
-    integral = zfit.sess.run(num_integral)
-    integral2 = zfit.sess.run(num_integral2)
-    integral3 = zfit.sess.run(num_integral3)
+    integral = zfit.run(num_integral)
+    integral2 = zfit.run(num_integral2)
+    integral3 = zfit.run(num_integral3)
 
     assert not hasattr(integral, "__len__")
     assert not hasattr(integral2, "__len__")
@@ -238,9 +238,9 @@ def test_mc_partial_integration():
                                             limits=Space.from_axes(limits=limits4_1dim, axes=(1,)),
                                             draws_per_dim=100)
 
-    integral = zfit.sess.run(num_integral)
-    integral2 = zfit.sess.run(num_integral2)
-    # print("DEBUG", value:", zfit.sess.run(vals_reshaped))
+    integral = zfit.run(num_integral)
+    integral2 = zfit.run(num_integral2)
+    # print("DEBUG", value:", zfit.run(vals_reshaped))
     assert len(integral) == len(func4_values)
     assert len(integral2) == len(func4_2values[1])
     assert func4_3deps_0and2_integrated(x=func4_values,
@@ -275,10 +275,10 @@ def test_analytic_integral():
 
     dist_func3 = DistFunc3(obs=['obs1', 'obs2'])
     init = tf.global_variables_initializer()
-    zfit.sess.run(init)
-    gauss_integral_infs = zfit.sess.run(gauss_integral_infs)
-    normal_integral_infs = zfit.sess.run(normal_integral_infs)
-    func3_integrated = zfit.sess.run(
+    zfit.run(init)
+    gauss_integral_infs = zfit.run(gauss_integral_infs)
+    normal_integral_infs = zfit.run(normal_integral_infs)
+    func3_integrated = zfit.run(
         ztf.convert_to_tensor(
             dist_func3.integrate(limits=Space.from_axes(limits=limits3, axes=(0, 1)), norm_range=False),
             dtype=tf.float64))

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -12,8 +12,8 @@ import zfit.core.integration as zintegrate
 from zfit.core.limits import Space
 import zfit.core.math as zmath
 from zfit.core.parameter import Parameter
-from zfit.models.basic import Gauss
-from zfit.models.dist_tfp import Normal
+from zfit.models.basic import CustomGaussOLD
+from zfit.models.dist_tfp import Gauss
 
 limits1_5deps = [((1., -1., 2., 4., 3.),), ((5., 4., 5., 8., 9.),)]
 # limits_simple_5deps = (0.9, 4.7)
@@ -261,8 +261,8 @@ def test_analytic_integral():
     limits = -4.3, 1.9
     mu = Parameter("mu", mu_true, mu_true - 2., mu_true + 7.)
     sigma = Parameter("sigma", sigma_true, sigma_true - 10., sigma_true + 5.)
-    gauss_params1 = Gauss(mu=mu, sigma=sigma, obs=obs1, name="gauss_params1")
-    normal_params1 = Normal(mu=mu, sigma=sigma, obs=obs1, name="gauss_params1")
+    gauss_params1 = CustomGaussOLD(mu=mu, sigma=sigma, obs=obs1, name="gauss_params1")
+    normal_params1 = Gauss(mu=mu, sigma=sigma, obs=obs1, name="gauss_params1")
     try:
         infinity = mt.inf
     except AttributeError:  # py34
@@ -274,8 +274,8 @@ def test_analytic_integral():
                                          limits=Space.from_axes(limits=limits3, axes=(0, 1)))
 
     dist_func3 = DistFunc3(obs=['obs1', 'obs2'])
-    init = tf.global_variables_initializer()
-    zfit.run(init)
+    # init = tf.global_variables_initializer()
+    # zfit.run(init)
     gauss_integral_infs = zfit.run(gauss_integral_infs)
     normal_integral_infs = zfit.run(normal_integral_infs)
     func3_integrated = zfit.run(
@@ -283,6 +283,7 @@ def test_analytic_integral():
             dist_func3.integrate(limits=Space.from_axes(limits=limits3, axes=(0, 1)), norm_range=False),
             dtype=tf.float64))
     assert func3_integrated == func3_2deps_fully_integrated(limits=Space.from_axes(limits=limits3, axes=(0, 1)))
+    # assert gauss_integral_infs == pytest.approx(np.sqrt(np.pi * 2.) * sigma_true, rel=0.0001)
     assert gauss_integral_infs == pytest.approx(np.sqrt(np.pi * 2.) * sigma_true, rel=0.0001)
     assert normal_integral_infs == pytest.approx(1, rel=0.0001)
 

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -36,29 +36,29 @@ init = tf.global_variables_initializer()
 
 
 def test_unbinned_nll():
-    zfit.sess.run(init)
+    zfit.run(init)
     with mu_constr.set_norm_range((-np.infty, np.infty)):
         with sigma_constr.set_norm_range((-np.infty, np.infty)):
             test_values = tf.constant(test_values_np)
             # nll = _unbinned_nll_tf(model=gaussian1, data=test_values, fit_range=(-np.infty, np.infty))
             nll_class = UnbinnedNLL(model=gaussian1, data=test_values, fit_range=(-np.infty, np.infty))
-            # nll_eval = zfit.sess.run(nll)
+            # nll_eval = zfit.run(nll)
             minimizer = MinuitMinimizer(loss=nll_class)
-            status = minimizer.minimize(params=[mu1, sigma1], sess=zfit.sess)
+            status = minimizer.minimize(params=[mu1, sigma1], sess=zfit.run.sess)
             params = status.get_parameters()
             # print(params)
             assert params[mu1.name]['value'] == pytest.approx(np.mean(test_values_np), rel=0.005)
             assert params[sigma1.name]['value'] == pytest.approx(np.std(test_values_np), rel=0.005)
 
             # with constraints
-            zfit.sess.run(init)
+            zfit.run(init)
 
             nll_class = UnbinnedNLL(model=gaussian2, data=test_values, fit_range=(-np.infty, np.infty),
                                     constraints={mu2: mu_constr,
                                                  sigma2: sigma_constr})
 
             minimizer = MinuitMinimizer(loss=nll_class)
-            status = minimizer.minimize(params=[mu2, sigma2], sess=zfit.sess)
+            status = minimizer.minimize(params=[mu2, sigma2], sess=zfit.run.sess)
             params = status.get_parameters()
 
             assert params[mu2.name]['value'] > np.mean(test_values_np)

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -7,8 +7,7 @@ import zfit.core.basepdf
 from zfit.core.limits import Space
 from zfit.minimizers.minimizer_minuit import MinuitMinimizer
 import zfit.models.dist_tfp
-from zfit.models.dist_tfp import Normal
-from zfit.models.basic import Gauss
+from zfit.models.dist_tfp import Gauss
 from zfit.core.parameter import Parameter
 import zfit.settings
 from zfit.core.loss import _unbinned_nll_tf, UnbinnedNLL
@@ -32,11 +31,12 @@ sigma_constr = Gauss(3.8, 0.2, obs=obs1, name="sigma_constr")
 gaussian1 = Gauss(mu1, sigma1, obs=obs1, name="gaussian1")
 gaussian2 = Gauss(mu2, sigma2, obs=obs1, name="gaussian2")
 
-init = tf.global_variables_initializer()
+
+# init = tf.global_variables_initializer()
 
 
 def test_unbinned_nll():
-    zfit.run(init)
+    # zfit.run(init)
     with mu_constr.set_norm_range((-np.infty, np.infty)):
         with sigma_constr.set_norm_range((-np.infty, np.infty)):
             test_values = tf.constant(test_values_np)
@@ -51,7 +51,7 @@ def test_unbinned_nll():
             assert params[sigma1.name]['value'] == pytest.approx(np.std(test_values_np), rel=0.005)
 
             # with constraints
-            zfit.run(init)
+            # zfit.run(init)
 
             nll_class = UnbinnedNLL(model=gaussian2, data=test_values, fit_range=(-np.infty, np.infty),
                                     constraints={mu2: mu_constr,

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -29,7 +29,7 @@ def minimize_func(minimizer_class_and_kwargs, sess):
 
     # print("DEBUG": before true_minimum")
 
-    true_minimum = sess.run(func(true_a, true_b, true_c))
+    true_minimum = zfit.run(func(true_a, true_b, true_c))
     # print("DEBUG": true_minimum", true_minimum)
     loss_func_tf = func(a_param, b_param, c_param)
 
@@ -41,11 +41,11 @@ def minimize_func(minimizer_class_and_kwargs, sess):
     minimizer_class, minimizer_kwargs = minimizer_class_and_kwargs
     minimizer = minimizer_class(loss=loss_func, **minimizer_kwargs)
     init = tf.initialize_all_variables()
-    zfit.sess.run(init)
+    zfit.run(init)
 
-    minimizer.minimize(sess=zfit.sess, params=[a_param, b_param, c_param])
-    cur_val = zfit.sess.run(loss_func.value())
-    aval, bval, cval = zfit.sess.run([v for v in (a_param, b_param, c_param)])
+    minimizer.minimize(sess=zfit.run.sess, params=[a_param, b_param, c_param])
+    cur_val = zfit.run(loss_func.value())
+    aval, bval, cval = zfit.run([v for v in (a_param, b_param, c_param)])
 
     assert abs(cur_val - true_minimum) < max_distance_to_min
     assert abs(aval - true_a) < parameter_tolerance
@@ -70,7 +70,7 @@ minimizers = [(zfit.minimizers.optimizers_tf.WrapOptimizer, dict(optimizer=tf.tr
 @pytest.mark.parametrize("minimizer_class", minimizers)
 def test_minimizers(minimizer_class):
     # for minimizer_class in minimizers:
-    minimize_func(minimizer_class, sess=zfit.sess)
+    minimize_func(minimizer_class, sess=zfit.run.sess)
 
 
 if __name__ == '__main__':

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -61,10 +61,10 @@ def test_param_func():
 
     new_func_equivalent = func * param4
 
-    zfit.sess.run(tf.global_variables_initializer())
-    result1 = zfit.sess.run(new_func.value(x=rnd_test_values))
-    result1_equivalent = zfit.sess.run(new_func_equivalent.value(x=rnd_test_values))
-    result2 = zfit.sess.run(func.value(x=rnd_test_values) * param4)
+    zfit.run(tf.global_variables_initializer())
+    result1 = zfit.run(new_func.value(x=rnd_test_values))
+    result1_equivalent = zfit.run(new_func_equivalent.value(x=rnd_test_values))
+    result2 = zfit.run(func.value(x=rnd_test_values) * param4)
     np.testing.assert_array_equal(result1, result2)
     np.testing.assert_array_equal(result1_equivalent, result2)
 
@@ -92,11 +92,11 @@ def test_func_func():
     prod_values = prod_func.value(rnd_test_values)
     true_prod_values = func1_pure(rnd_test_values) * func2_pure(rnd_test_values)
 
-    zfit.sess.run(tf.global_variables_initializer())
-    added_values = zfit.sess.run(added_values)
-    true_added_values = zfit.sess.run(true_added_values)
-    prod_values = zfit.sess.run(prod_values)
-    true_prod_values = zfit.sess.run(true_prod_values)
+    zfit.run(tf.global_variables_initializer())
+    added_values = zfit.run(added_values)
+    true_added_values = zfit.run(true_added_values)
+    prod_values = zfit.run(prod_values)
+    true_prod_values = zfit.run(true_prod_values)
     np.testing.assert_allclose(true_added_values, added_values)
     np.testing.assert_allclose(true_prod_values, prod_values)
 
@@ -169,16 +169,16 @@ def test_implicit_sumpdf():
     assert isinstance(sum_pdf, SumPDF)
     assert not sum_pdf.is_extended
 
-    zfit.sess.run(tf.global_variables_initializer())
-    assert zfit.sess.run(sum(sum_pdf.fracs)) == 1.
-    true_values = zfit.sess.run(true_values)
-    test_values = zfit.sess.run(sum_pdf.pdf(rnd_test_values, norm_range=norm_range))
+    zfit.run(tf.global_variables_initializer())
+    assert zfit.run(sum(sum_pdf.fracs)) == 1.
+    true_values = zfit.run(true_values)
+    test_values = zfit.run(sum_pdf.pdf(rnd_test_values, norm_range=norm_range))
     np.testing.assert_allclose(true_values, test_values, rtol=1e-2)  # it's MC normalized
 
     # sugar 2
     sum_pdf2_part1 = frac1 * pdf1 + frac2 * pdf3
     sum_pdf2 = sum_pdf2_part1 + pdf2
 
-    zfit.sess.run(tf.global_variables_initializer())
-    test_values2 = zfit.sess.run(sum_pdf2.pdf(rnd_test_values, norm_range=norm_range))
+    zfit.run(tf.global_variables_initializer())
+    test_values2 = zfit.run(sum_pdf2.pdf(rnd_test_values, norm_range=norm_range))
     np.testing.assert_allclose(true_values, test_values2, rtol=1e-2)  # it's MC normalized

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -16,10 +16,10 @@ def test_complex_param():
     param1 = ComplexParameter("param1", complex_value)
     some_value = 3. * param1 ** 2 - 1.2j
     true_value = 3. * complex_value ** 2 - 1.2j
-    zfit.sess.run(tf.global_variables_initializer())
-    assert true_value == pytest.approx(zfit.sess.run(some_value), rel=1e-8)
+    zfit.run(tf.global_variables_initializer())
+    assert true_value == pytest.approx(zfit.run(some_value), rel=1e-8)
     part1, part2 = param1.get_dependents()
-    part1_val, part2_val = zfit.sess.run([part1.value(), part2.value()])
+    part1_val, part2_val = zfit.run([part1.value(), part2.value()])
     if part1_val == pytest.approx(real_part):
         assert part2_val == pytest.approx(imag_part)
     elif part2_val == pytest.approx(real_part):
@@ -39,18 +39,18 @@ def test_composed_param():
     assert isinstance(param_a.get_dependents(only_floating=True), set)
     assert param_a.get_dependents(only_floating=True) == {param1, param2}
     assert param_a.get_dependents(only_floating=False) == {param1, param2, param3}
-    zfit.sess.run(tf.global_variables_initializer())
-    a_unchanged = zfit.sess.run(a)
-    assert a_unchanged == zfit.sess.run(param_a)
-    assert zfit.sess.run(param2.assign(3.5))
-    a_changed = zfit.sess.run(a)
-    assert a_changed == zfit.sess.run(param_a)
+    zfit.run(tf.global_variables_initializer())
+    a_unchanged = zfit.run(a)
+    assert a_unchanged == zfit.run(param_a)
+    assert zfit.run(param2.assign(3.5))
+    a_changed = zfit.run(a)
+    assert a_changed == zfit.run(param_a)
     assert a_changed != a_unchanged
 
     with pytest.raises(LogicalUndefinedOperationError):
         param_a.assign(value=5.)
     with pytest.raises(LogicalUndefinedOperationError):
-        param_a.load(value=5., session=zfit.sess)
+        param_a.load(value=5., session=zfit.run.sess)
 
 
 def test_param_limits():
@@ -58,14 +58,14 @@ def test_param_limits():
     param1 = Parameter('param1lim', 1., lower_limit=lower, upper_limit=upper)
     param2 = Parameter('param2lim', 2.)
 
-    zfit.sess.run(tf.global_variables_initializer())
-    param1.load(upper + 0.5, session=zfit.sess)
-    assert upper == zfit.sess.run(param1.value())
-    param1.load(lower - 1.1, session=zfit.sess)
-    assert lower == zfit.sess.run(param1.value())
+    zfit.run(tf.global_variables_initializer())
+    param1.load(upper + 0.5, session=zfit.run.sess)
+    assert upper == zfit.run(param1.value())
+    param1.load(lower - 1.1, session=zfit.run.sess)
+    assert lower == zfit.run(param1.value())
     param2.lower_limit = lower
-    param2.load(lower - 1.1, session=zfit.sess)
-    assert lower == zfit.sess.run(param2.value())
+    param2.load(lower - 1.1, session=zfit.run.sess)
+    assert lower == zfit.run(param2.value())
 
 def test_overloaded_operators():
     param_a = ComposedParameter('param_ao', 5*4)

--- a/tests/test_pdf_normal.py
+++ b/tests/test_pdf_normal.py
@@ -3,8 +3,7 @@ import tensorflow as tf
 
 import zfit
 from zfit import Parameter
-from zfit.models.basic import Gauss
-from zfit.models.dist_tfp import Normal
+from zfit.models.dist_tfp import Gauss
 
 mu1_true = 1.
 mu2_true = 2.
@@ -26,11 +25,11 @@ def create_gauss():
     sigma2 = Parameter("sigma2a", sigma2_true)
     sigma3 = Parameter("sigma3a", sigma3_true)
     gauss1 = Gauss(mu=mu1, sigma=sigma1, obs=obs1, name="gauss1a")
-    normal1 = Normal(mu=mu1, sigma=sigma1, obs=obs1, name="normal1a")
+    normal1 = Gauss(mu=mu1, sigma=sigma1, obs=obs1, name="normal1a")
     gauss2 = Gauss(mu=mu2, sigma=sigma2, obs=obs1, name="gauss2a")
-    normal2 = Normal(mu=mu2, sigma=sigma2, obs=obs1, name="normal2a")
+    normal2 = Gauss(mu=mu2, sigma=sigma2, obs=obs1, name="normal2a")
     gauss3 = Gauss(mu=mu3, sigma=sigma3, obs=obs1, name="gauss3a")
-    normal3 = Normal(mu=mu3, sigma=sigma3, obs=obs1, name="normal3a")
+    normal3 = Gauss(mu=mu3, sigma=sigma3, obs=obs1, name="normal3a")
     zfit.run(tf.global_variables_initializer())
     return gauss1, gauss2, gauss3, normal1, normal2, normal3
 

--- a/tests/test_pdf_normal.py
+++ b/tests/test_pdf_normal.py
@@ -31,7 +31,7 @@ def create_gauss():
     normal2 = Normal(mu=mu2, sigma=sigma2, obs=obs1, name="normal2a")
     gauss3 = Gauss(mu=mu3, sigma=sigma3, obs=obs1, name="gauss3a")
     normal3 = Normal(mu=mu3, sigma=sigma3, obs=obs1, name="normal3a")
-    zfit.sess.run(tf.global_variables_initializer())
+    zfit.run(tf.global_variables_initializer())
     return gauss1, gauss2, gauss3, normal1, normal2, normal3
 
 gauss1, gauss2, gauss3, normal1, normal2, normal3 = create_gauss()
@@ -39,14 +39,14 @@ gauss1, gauss2, gauss3, normal1, normal2, normal3 = create_gauss()
 def test_gauss1():
     probs1 = gauss1.pdf(x=test_values, norm_range=norm_range1)
     probs1_tfp = normal1.pdf(x=test_values, norm_range=norm_range1)
-    probs1 = zfit.sess.run(probs1)
-    probs1_tfp = zfit.sess.run(probs1_tfp)
+    probs1 = zfit.run(probs1)
+    probs1_tfp = zfit.run(probs1_tfp)
     np.testing.assert_allclose(probs1, probs1_tfp, rtol=1e-2)
 
     probs1_unnorm = gauss1.pdf(x=test_values, norm_range=False)
     probs1_tfp_unnorm = normal1.pdf(x=test_values, norm_range=False)
-    probs1_unnorm = zfit.sess.run(probs1_unnorm)
-    probs1_tfp_unnorm = zfit.sess.run(probs1_tfp_unnorm)
+    probs1_unnorm = zfit.run(probs1_unnorm)
+    probs1_tfp_unnorm = zfit.run(probs1_tfp_unnorm)
     assert not np.allclose(probs1_tfp, probs1_tfp_unnorm, rtol=1e-2)
     assert not np.allclose(probs1, probs1_unnorm, rtol=1e-2)
     # np.testing.assert_allclose(probs1_unnorm, probs1_tfp_unnorm, rtol=1e-2)

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -7,8 +7,7 @@ from zfit.core.data import Data
 from zfit.core.limits import Space
 from zfit.core.parameter import Parameter
 from zfit.models.functor import SumPDF, ProductPDF
-from zfit.models.basic import Gauss
-from zfit.models.dist_tfp import Normal
+from zfit.models.dist_tfp import Gauss
 import zfit
 
 low, high = -0.64, 5.9
@@ -24,9 +23,12 @@ fracs = [0.3, 0.15]
 
 
 def true_gaussian_sum(x):
-    sum_gauss = fracs[0] * np.exp(- (x - mu1_true) ** 2 / (2 * sigma1_true ** 2))
-    sum_gauss += fracs[1] * np.exp(- (x - mu2_true) ** 2 / (2 * sigma2_true ** 2))
-    sum_gauss += (1. - sum(fracs)) * np.exp(- (x - mu3_true) ** 2 / (2 * sigma3_true ** 2))
+    def norm(sigma):
+        return np.sqrt(2 * np.pi) * sigma
+
+    sum_gauss = fracs[0] * np.exp(- (x - mu1_true) ** 2 / (2 * sigma1_true ** 2)) / norm(sigma1_true)
+    sum_gauss += fracs[1] * np.exp(- (x - mu2_true) ** 2 / (2 * sigma2_true ** 2)) / norm(sigma2_true)
+    sum_gauss += (1. - sum(fracs)) * np.exp(- (x - mu3_true) ** 2 / (2 * sigma3_true ** 2)) / norm(sigma3_true)
     return sum_gauss
 
 
@@ -153,8 +155,8 @@ def test_normalization_prod_gauss():
 
 
 def normalization_testing(pdf, normalization_value=1.):
-    init = tf.global_variables_initializer()
-    zfit.run(init)
+    # init = tf.global_variables_initializer()
+    # zfit.run(init)
     with pdf.set_norm_range(Space(obs=obs1, limits=(low, high))):
         samples = tf.cast(np.random.uniform(low=low, high=high, size=(pdf.n_obs, 40000)),
                           dtype=tf.float64)

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -49,7 +49,7 @@ def sum_prod_gauss():
     gauss3 = Gauss(mu=mu3, sigma=sigma3, obs=obs1, name="gauss3asum")
     gauss_dists = [gauss1, gauss2, gauss3]
 
-    zfit.sess.run(tf.global_variables_initializer())
+    zfit.run(tf.global_variables_initializer())
     sum_gauss = SumPDF(pdfs=gauss_dists, fracs=fracs, obs=obs1)
     prod_gauss = ProductPDF(pdfs=gauss_dists, obs=obs1)
 
@@ -88,10 +88,10 @@ def test_prod_gauss_nd():
     norm_range_3d = Space(obs=obs1, limits=(lower, upper))
     test_values_data = Data.from_tensors(obs=obs1, tensors=test_values)
     probs = prod_gauss_3d.pdf(x=test_values_data, norm_range=norm_range_3d)
-    zfit.sess.run(tf.global_variables_initializer())
+    zfit.run(tf.global_variables_initializer())
     true_probs = np.prod([gauss.pdf(test_values[i, :], norm_range=(-5, 4)) for i, gauss in enumerate(gauss_dists)])
-    probs_np = zfit.sess.run(probs)
-    np.testing.assert_allclose(zfit.sess.run(true_probs)[0, :], probs_np[0, :], rtol=1e-2)
+    probs_np = zfit.run(probs)
+    np.testing.assert_allclose(zfit.run(true_probs)[0, :], probs_np[0, :], rtol=1e-2)
 
 
 def test_prod_gauss_nd_mixed():
@@ -105,7 +105,7 @@ def test_prod_gauss_nd_mixed():
     limits_4d = Space(limits=(((-5,) * 4,), ((4,) * 4,)), obs=obs4d)
     probs = prod_gauss_4d.pdf(x=test_values_data,
                               norm_range=limits_4d)
-    zfit.sess.run(tf.global_variables_initializer())
+    zfit.run(tf.global_variables_initializer())
     gauss1, gauss2, gauss3 = gauss_dists2
 
     def probs_4d(values):
@@ -121,19 +121,19 @@ def test_prod_gauss_nd_mixed():
 
     normalization_probs = limits_4d.area() * probs_4d(np.random.uniform(low=low, high=high, size=(4, 40 ** 4)))
     true_probs = true_unnormalized_probs / tf.reduce_mean(normalization_probs)
-    probs_np = zfit.sess.run(probs)
+    probs_np = zfit.run(probs)
     print(np.average(probs_np))
-    true_probs_np = zfit.sess.run(true_probs[0, :])
+    true_probs_np = zfit.run(true_probs[0, :])
     assert np.average(probs_np * limits_4d.area()) == pytest.approx(1., rel=0.33)  # low n mc
     np.testing.assert_allclose(true_probs_np, probs_np[0, :], rtol=2e-2)
 
 
 def test_func_sum():
-    zfit.sess.run(tf.global_variables_initializer())
+    zfit.run(tf.global_variables_initializer())
     test_values = np.random.uniform(low=-3, high=4, size=10)
     vals = sum_gauss.as_func(norm_range=False).value(
         x=ztf.convert_to_tensor(test_values, dtype=zfit.settings.types.float))
-    vals = zfit.sess.run(vals)
+    vals = zfit.run(vals)
     # test_sum = sum([g.func(test_values) for g in gauss_dists])
     np.testing.assert_allclose(vals[0, :], true_gaussian_sum(test_values), rtol=1e-2)  # MC integral
 
@@ -154,13 +154,13 @@ def test_normalization_prod_gauss():
 
 def normalization_testing(pdf, normalization_value=1.):
     init = tf.global_variables_initializer()
-    zfit.sess.run(init)
+    zfit.run(init)
     with pdf.set_norm_range(Space(obs=obs1, limits=(low, high))):
         samples = tf.cast(np.random.uniform(low=low, high=high, size=(pdf.n_obs, 40000)),
                           dtype=tf.float64)
         samples = zfit.data.Data.from_tensors(obs=pdf.obs, tensors=samples)
         probs = pdf.pdf(samples)
-        result = zfit.sess.run(probs)
+        result = zfit.run(probs)
         result = np.average(result) * (high - low)
         assert normalization_value == pytest.approx(result, rel=0.07)
 
@@ -189,7 +189,7 @@ def test_extended_gauss():
 
         sum_gauss = SumPDF(pdfs=gauss_dists, obs=obs1, )
 
-    zfit.sess.run(tf.global_variables_initializer())
+    zfit.run(tf.global_variables_initializer())
     normalization_testing(pdf=sum_gauss, normalization_value=sum_yields)
 
 

--- a/tests/test_tfext.py
+++ b/tests/test_tfext.py
@@ -27,7 +27,7 @@ def test_polynomial():
     polynom_np = np.polyval(coeffs[::-1], true_dict['x'])
 
     init = tf.global_variables_initializer()
-    zfit.sess.run(init)
-    result = zfit.sess.run(polynom_tf, feed_dict=feed_dict)
+    zfit.run(init)
+    result = zfit.run(polynom_tf, feed_dict=feed_dict)
     assert result == pytest.approx(polynom_np, rel=prec)
 

--- a/zfit/__init__.py
+++ b/zfit/__init__.py
@@ -11,6 +11,6 @@ from .core.parameter import Parameter
 from .core.loss import _unbinned_nll_tf
 from .core.limits import Space, convert_to_space, supports
 
-from .settings import sess, run
+from .settings import run
 
 # EOF

--- a/zfit/__init__.py
+++ b/zfit/__init__.py
@@ -11,6 +11,6 @@ from .core.parameter import Parameter
 from .core.loss import _unbinned_nll_tf
 from .core.limits import Space, convert_to_space, supports
 
-from .settings import sess
+from .settings import sess, run
 
 # EOF

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -729,7 +729,7 @@ class BaseModel(BaseNumeric, BaseDimensional, ZfitModel):
 
     @no_norm_range
     def _inverse_analytic_integrate(self, x):
-        if self._inverse_analytic_integral is None:
+        if not self._inverse_analytic_integral:
             raise NotImplementedError
         else:
             return self._inverse_analytic_integral[0](x=x, params=self.parameters)

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -50,10 +50,10 @@ also the advanced tutorials in `zfit tutorials <https://github.com/zfit/zfit-tut
 """
 
 import abc
+from collections import OrderedDict
 import contextlib
 from contextlib import suppress
-import typing
-from typing import Union
+from typing import Union, Iterable, Any, Type
 import warnings
 
 import tensorflow as tf
@@ -66,7 +66,7 @@ from zfit.util.container import convert_to_container
 from zfit.util.exception import DueToLazynessNotImplementedError, IntentionNotUnambiguousError
 from zfit.util.temporary import TemporarilySet
 from .basemodel import BaseModel
-from .parameter import Parameter
+from .parameter import Parameter, convert_to_parameter
 from ..settings import types as ztypes
 from ..util import exception as zexception
 
@@ -103,8 +103,8 @@ def _BasePDF_register_check_support(has_support: bool):
 
 class BasePDF(ZfitPDF, BaseModel):
 
-    def __init__(self, obs: ztyping.ObsTypeInput, dtype: typing.Type = ztypes.float, name: str = "BasePDF",
-                 parameters: typing.Any = None, **kwargs):
+    def __init__(self, obs: ztyping.ObsTypeInput, dtype: Type = ztypes.float, name: str = "BasePDF",
+                 parameters: Any = None, **kwargs):
         super().__init__(obs=obs, dtype=dtype, name=name, parameters=parameters, **kwargs)
 
         self._yield = None
@@ -122,6 +122,9 @@ class BasePDF(ZfitPDF, BaseModel):
             norm_range = self.norm_range
         return super()._check_input_norm_range(norm_range=norm_range, caller_name=caller_name,
                                                none_is_error=none_is_error)
+
+    def _check_input_parameters(self, *parameters):
+        return tuple(convert_to_parameter(p) for p in parameters)
 
     def _func_to_integrate(self, x: ztyping.XType):
         return self.unnormalized_pdf(x)

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -128,7 +128,7 @@ class Data(ZfitData, BaseDimensional, BaseObject):
     def initialize(self, sess=None):
         iterator = self.dataset.make_initializable_iterator()
         if sess is None:
-            sess = zfit.sess
+            sess = zfit.run.sess
             if sess is None:
                 raise NoSessionSpecifiedError()
         sess.run(iterator.initializer, self.iterator_feed_dict)

--- a/zfit/core/integration.py
+++ b/zfit/core/integration.py
@@ -9,6 +9,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 from typing import Callable, Optional, Union, Type, Tuple
 
+import zfit
 from zfit import ztf
 from zfit.util import ztyping
 from .limits import convert_to_space, Space, supports
@@ -89,37 +90,85 @@ def mc_integrate(func: Callable, limits: ztyping.LimitsType, axes: Optional[ztyp
         n_samples *= n_vals  # each entry wants it's mc
     else:
         n_vals = 1
-    # TODO: deal with n_obs properly?
-    samples_normed = mc_sampler(dim=n_axes, num_results=n_samples, dtype=dtype)
-    samples_normed = tf.reshape(samples_normed, shape=(n_vals, int(n_samples / n_vals), n_axes))
-    samples = samples_normed * (upper - lower) + lower  # samples is [0, 1], stretch it
-    samples = tf.transpose(samples, perm=[2, 0, 1])
 
-    if partial:
-        value_list = []
-        index_samples = 0
-        index_values = 0
-        if len(x.shape) == 1:
-            x = tf.expand_dims(x, axis=1)
-        for i in range(n_axes + x.shape[1].value):
-            if i in axes:
-                value_list.append(samples[index_samples, :, :])
-                index_samples += 1
-            else:
-                value_list.append(tf.expand_dims(x[:, index_values], axis=1))
-                index_values += 1
-        value_list = [tf.cast(val, dtype=dtype) for val in value_list]
-        x = value_list
+    if zfit.run.chunksize:
+        n_chunks = int(np.ceil(n_samples / zfit.run.chunksize))
+        chunksize = int(np.ceil(n_samples / n_chunks))
+        avg = chunked_average(func=func, num_batches=n_chunks, batch_size=chunksize, space=limits)
+
     else:
-        x = samples
+        # TODO: deal with n_obs properly?
 
-    # convert rnd samples with value to feedable vector
-    reduce_axis = 1 if partial else None
-    avg = tfp.monte_carlo.expectation(f=func, samples=x, axis=reduce_axis)
-    # TODO: importance sampling?
-    # avg = tfb.monte_carlo.expectation_importance_sampler(f=func, samples=value,axis=reduce_axis)
+        samples_normed = mc_sampler(dim=n_axes, num_results=n_samples, dtype=dtype)
+        samples_normed = tf.reshape(samples_normed, shape=(n_vals, int(n_samples / n_vals), n_axes))
+        samples = samples_normed * (upper - lower) + lower  # samples is [0, 1], stretch it
+        samples = tf.transpose(samples, perm=[2, 0, 1])
+
+        if partial:
+            value_list = []
+            index_samples = 0
+            index_values = 0
+            if len(x.shape) == 1:
+                x = tf.expand_dims(x, axis=1)
+            for i in range(n_axes + x.shape[1].value):
+                if i in axes:
+                    value_list.append(samples[index_samples, :, :])
+                    index_samples += 1
+                else:
+                    value_list.append(tf.expand_dims(x[:, index_values], axis=1))
+                    index_values += 1
+            value_list = [tf.cast(val, dtype=dtype) for val in value_list]
+            x = value_list
+        else:
+            x = samples
+
+        # convert rnd samples with value to feedable vector
+        reduce_axis = 1 if partial else None
+        avg = tfp.monte_carlo.expectation(f=func, samples=x, axis=reduce_axis)
+        # TODO: importance sampling?
+        # avg = tfb.monte_carlo.expectation_importance_sampler(f=func, samples=value,axis=reduce_axis)
     integral = avg * limits.area()
     return ztf.to_real(integral, dtype=dtype)
+
+
+def chunked_average(func, num_batches, batch_size, space):
+    lower, upper = space.limits
+    def body(batch_num, mean):
+        start_idx = batch_num * batch_size
+        end_idx = start_idx + batch_size
+        indices = tf.range(start_idx, end_idx, dtype=tf.int32)
+        sample = tfp.mcmc.sample_halton_sequence(space.n_obs,
+                                                        # num_results=batch_size,
+                                                        sequence_indices=indices,
+                                                        dtype=ztypes.float,
+                                                        randomized=False)
+        # sample = tf.random_uniform(shape=(batch_size, space.n_obs), dtype=ztypes.float)
+        sample = tf.guarantee_const(sample)
+        sample = (np.array(upper[0]) - np.array(lower[0])) * sample + lower[0]
+        sample = tf.transpose(sample)
+        sample = func(sample)
+        sample = tf.guarantee_const(sample)
+
+        batch_mean = tf.reduce_mean(sample)
+        # batch_mean = tf.guarantee_const(batch_mean)
+        # with tf.control_dependencies([batch_mean]):
+        err_weight = 1 / tf.to_double(batch_num + 1)
+        # err_weight /= err_weight + 1
+        # print_op = tf.print(batch_mean)
+        print_op = tf.print(batch_num + 1, mean, err_weight * (batch_mean - mean))
+        with tf.control_dependencies([print_op]):
+            return batch_num + 1, mean + err_weight * (batch_mean - mean)
+        # return batch_num + 1, tf.guarantee_const(mean + err_weight * (batch_mean - mean))
+
+    cond = lambda batch_num, _: batch_num < num_batches
+
+    initial_mean = tf.convert_to_tensor(0, dtype=ztypes.float)
+    _, final_mean = tf.while_loop(cond, body, (0, initial_mean), parallel_iterations=1,
+                                  swap_memory=False, back_prop=False, maximum_iterations=num_batches)
+
+    print_op = tf.print(final_mean)
+    with tf.control_dependencies([print_op]):
+        return tf.guarantee_const(final_mean)
 
 
 class AnalyticIntegral:

--- a/zfit/core/minimizer.py
+++ b/zfit/core/minimizer.py
@@ -14,6 +14,7 @@ import tensorflow_probability as tfp
 import pep487
 from typing import Dict, List, Union, Optional
 
+import zfit
 from zfit import ztf
 from zfit.minimizers.state import MinimizerState
 from zfit.util import ztyping
@@ -317,8 +318,10 @@ class BaseMinimizer(MinimizerInterface, pep487.PEP487Object):
 
     @property
     def sess(self):
-        # TODO: return default? or error?
-        return self._sess
+        sess = self._sess
+        if sess is None:
+            sess = zfit.run.sess
+        return sess
 
     @sess.setter
     def sess(self, sess):

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -7,6 +7,7 @@ import tensorflow as tf
 # TF backwards compatibility
 from tensorflow.python import ops, array_ops
 
+import zfit
 from zfit import ztf
 
 from tensorflow.python.ops.resource_variable_ops import ResourceVariable as TFBaseVariable
@@ -307,10 +308,11 @@ class Parameter(ZfitParameterMixin, TFBaseVariable, BaseParameter):
         super().__init__(initial_value=init_value, dtype=dtype, name=name, constraint=constraint, **kwargs)
         if self.independent:
             tf.add_to_collection("zfit_independent", self)
-        init_value = tf.cast(init_value, dtype=ztypes.float)  # TODO: init value mandatory?
+        # init_value = tf.cast(init_value, dtype=ztypes.float)  # TODO: init value mandatory?
+        # self.init_value = init_value
         self.floating = floating
-        self.init_value = init_value
         self.step_size = step_size
+        zfit.run.auto_initialize(self)
 
         # self._placeholder = tf.placeholder(dtype=self.dtype, shape=self.get_shape())
         # self._update_op = self.assign(self._placeholder)  # for performance! Run with sess.run
@@ -359,9 +361,9 @@ class Parameter(ZfitParameterMixin, TFBaseVariable, BaseParameter):
         cls._independent = True  # overwriting independent only for subclass/instance
 
     # OLD remove? only keep for speed reasons?
-    @property
-    def update_op(self):
-        return self._update_op
+    # @property
+    # def update_op(self):
+    #     return self._update_op
 
     @property
     def step_size(self):  # TODO: improve default step_size?
@@ -385,7 +387,8 @@ class Parameter(ZfitParameterMixin, TFBaseVariable, BaseParameter):
     def step_size(self, value):
         self._step_size = value
 
-    def randomize(self, sess, minval=None, maxval=None, seed=None):
+    # TODO: make it a random variable? return tensor that evaluates new all the time?
+    def randomize(self, sess, minval=None, maxval=None):
         """Update the value with a randomised value between minval and maxval.
 
         Args:

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -18,7 +18,7 @@ except AttributeError:  # py34
     infinity = float('inf')
 
 
-class Gauss(BasePDF):
+class CustomGaussOLD(BasePDF):
 
     def __init__(self, mu, sigma, obs, name="Gauss"):  # TODO: names? TF dist?
         super().__init__(name=name, obs=obs, parameters=dict(mu=mu, sigma=sigma))
@@ -37,5 +37,5 @@ def _gauss_integral_from_inf_to_inf(limits, params):
 
 
 # TODO: uncomment hack when switched to space
-Gauss.register_analytic_integral(func=_gauss_integral_from_inf_to_inf,
-                                 limits=Space.from_axes(limits=(-infinity, infinity), axes=(0,)))
+CustomGaussOLD.register_analytic_integral(func=_gauss_integral_from_inf_to_inf,
+                                          limits=Space.from_axes(limits=(-infinity, infinity), axes=(0,)))

--- a/zfit/models/functor.py
+++ b/zfit/models/functor.py
@@ -281,7 +281,7 @@ class ProductPDF(BaseFunctor):  # TODO: unfinished
 if __name__ == '__main__':
 
     import numpy as np
-    from zfit.models.basic import Gauss
+    from zfit.pdf import Gauss
 
 
     def true_gaussian_sum(x):

--- a/zfit/pdf.py
+++ b/zfit/pdf.py
@@ -1,5 +1,4 @@
 from .core.basepdf import BasePDF
-from .models.basic import Gauss
-from .models.dist_tfp import Normal, Uniform, Exponential, WrapDistribution
+from .models.dist_tfp import Gauss, Uniform, Exponential, WrapDistribution
 from .models.functor import ProductPDF, SumPDF
 # from .models.special import

--- a/zfit/settings.py
+++ b/zfit/settings.py
@@ -31,8 +31,8 @@ types = DotDict({'float': tf.float64,
 
 options = DotDict({'epsilon': 1e-8})
 
+
 # sess = tf.InteractiveSession()
-sess = tf.Session()
 
 
 def reset_session():

--- a/zfit/settings.py
+++ b/zfit/settings.py
@@ -2,6 +2,9 @@ import numpy as np
 import tensorflow as tf
 
 from zfit.util.container import DotDict
+from .util.execution import RunManager
+
+run = RunManager()
 
 
 def set_seed(seed):

--- a/zfit/util/execution.py
+++ b/zfit/util/execution.py
@@ -15,13 +15,20 @@ class RunManager:
         """Handle the resources and runtime specific options. The `run` method is equivalent to `sess.run`"""
         self._sess = None
         self._sess_kwargs = {}
-        self.serialize = DotDict()
+        self.chunking = DotDict()
         self._cpu = []
 
         self.set_n_cpu(n_cpu=n_cpu)
 
         # set default values
-        self.serialize.max_n_points = 100000
+        self.chunking.active = False
+        self.chunking.max_n_points = 100000
+
+    @property
+    def chunksize(self):
+        if self.chunking.active:
+            return self.chunking.max_n_points
+
 
     @property
     def n_cpu(self):
@@ -74,3 +81,5 @@ class RunManager:
     @sess.setter
     def sess(self, value):
         self._sess = value
+
+

--- a/zfit/util/execution.py
+++ b/zfit/util/execution.py
@@ -1,6 +1,7 @@
 import contextlib
 import copy
 import os
+import sys
 from typing import List
 
 import tensorflow as tf
@@ -13,6 +14,7 @@ class RunManager:
 
     def __init__(self, n_cpu='auto'):
         """Handle the resources and runtime specific options. The `run` method is equivalent to `sess.run`"""
+        self.MAX_CHUNK_SIZE = sys.maxsize
         self._sess = None
         self._sess_kwargs = {}
         self.chunking = DotDict()
@@ -21,13 +23,15 @@ class RunManager:
         self.set_n_cpu(n_cpu=n_cpu)
 
         # set default values
-        self.chunking.active = False
+        self.chunking.active = True
         self.chunking.max_n_points = 100000
 
     @property
     def chunksize(self):
         if self.chunking.active:
             return self.chunking.max_n_points
+        else:
+            return self.MAX_CHUNK_SIZE
 
 
     @property

--- a/zfit/util/execution.py
+++ b/zfit/util/execution.py
@@ -26,6 +26,9 @@ class RunManager:
         self.chunking.active = False  # not yet implemented the chunking...
         self.chunking.max_n_points = 100000
 
+    def auto_initialize(self, variable: tf.Variable):
+        self(variable.initializer)
+
     @property
     def chunksize(self):
         if self.chunking.active:

--- a/zfit/util/execution.py
+++ b/zfit/util/execution.py
@@ -1,0 +1,39 @@
+import copy
+
+import tensorflow as tf
+
+
+class RunManager:
+
+    def __init__(self):
+        """Handle the resources and runtime specific options. The `run` method is equivalent to `sess.run`"""
+        self._sess = None
+        self._sess_kwargs = {}
+
+    def __call__(self, *args, **kwargs):
+        return self.sess.run(*args, **kwargs)
+
+    def create_session(self, *args, **kwargs):
+        """Create a new session (or replace the current one). Arguments will overwrite the already set arguments.
+
+        Args:
+            *args ():
+            **kwargs ():
+
+        Returns:
+            :py:class:`tf.Session`
+        """
+        sess_kwargs = copy.deepcopy(self._sess_kwargs)
+        sess_kwargs.update(kwargs)
+        self.sess = tf.Session(*args, **sess_kwargs)
+        return self.sess
+
+    @property
+    def sess(self):
+        if self._sess is None:
+            self.create_session()
+        return self._sess
+
+    @sess.setter
+    def sess(self, value):
+        self._sess = value

--- a/zfit/util/execution.py
+++ b/zfit/util/execution.py
@@ -23,7 +23,7 @@ class RunManager:
         self.set_n_cpu(n_cpu=n_cpu)
 
         # set default values
-        self.chunking.active = True
+        self.chunking.active = False  # not yet implemented the chunking...
         self.chunking.max_n_points = 100000
 
     @property
@@ -32,7 +32,6 @@ class RunManager:
             return self.chunking.max_n_points
         else:
             return self.MAX_CHUNK_SIZE
-
 
     @property
     def n_cpu(self):
@@ -50,10 +49,13 @@ class RunManager:
         if isinstance(max_cpu, int):
             if max_cpu < 0:
                 max_cpu = max((self.n_cpu + 1 + max_cpu, 0))  # -1 means all
-            n_cpu = min((max_cpu, self.n_cpu))
+            if max_cpu == 0:
+                cpu = []
+            else:
+                n_cpu = min((max_cpu, self.n_cpu))
 
-            cpu = self._cpu[n_cpu:]
-            self._cpu = self._cpu[:n_cpu]
+                cpu = self._cpu[-n_cpu:]
+                self._cpu = self._cpu[:-n_cpu]
 
             yield cpu
             self._cpu.extend(cpu)
@@ -85,5 +87,3 @@ class RunManager:
     @sess.setter
     def sess(self, value):
         self._sess = value
-
-

--- a/zfit/util/graph.py
+++ b/zfit/util/graph.py
@@ -1,0 +1,49 @@
+from typing import List
+
+import tensorflow as tf
+
+
+def parents(op):
+    return set(input.op for input in op.inputs)
+
+
+def all_parents(op):
+    ops = set(input.op for input in op.inputs)
+    return ops.union(*(all_parents(op) for op in ops))
+
+
+def children(op):
+    return set(op for out in op.outputs for op in out.consumers())
+
+
+def get_dependents(tensor: tf.Tensor, candidates: List[tf.Tensor]) -> List[tf.Tensor]:
+    """Return the nodes in `candidates` that `tensor` depends on.
+
+    Args:
+        tensor ():
+        candidates ():
+    """
+
+    dependent_ops = all_parents(tensor.op)
+    dependent_candidates = [cand for cand in candidates if cand.op in dependent_ops]
+    return dependent_candidates
+
+
+# def print_tf_graph(graph):
+#     """Prints tensorflow graph in dictionary form."""
+#     for node in graph:
+#         for child in graph[node]:
+#             print("%s -> %s" % (node.name, child.name))
+
+
+if __name__ == '__main__':
+    a = tf.distributions.Normal(1., 3.).sample() * 5.
+    var1 = tf.get_variable('a1', 1.)
+    var2 = tf.get_variable('a2', 2.)
+    var3 = tf.get_variable('a3', 3.)
+    b = tf.constant(3.) + 4 * var1
+    c = 5. * b
+    d = c + b * var2
+    e = c * 3.
+    print(get_dependents(e, [b, c, d, var1, var2, var3]))
+    print(get_dependents(e, [var1, var2, var3]))


### PR DESCRIPTION
This PR adresses:

- introducing the RunManager that is responsible for: providing a `zfit.run`, default session, chunksize, cpu management etc
- adding some (WIP but will be done later) chunking for Integration
- changing the Gauss from the custom implementation to the TensorFlow Probability one (including analytic integration over the whole range)
- Removing of "session" from public view (at least for the Introductory Notebook) by providing lazy a default session and a `zfit.run` to run tensors, including automatic variable initialization (no more `tf.global_variables_initializer()`)

@apuignav ready to merge from me, no deep review required from my side (I just don't like to do solo-late-night-merges ;) ). The [notebook is updated as well](https://github.com/zfit/zfit-tutorials/blob/master/00%20-%20Introduction.ipynb)

@rsilvaco the notebook above has to be run with either this branch or the `develop` branch if this PR is merged (**not with `master`**)