### PR TITLE
Refactor shape of x

### DIFF
--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -103,9 +103,9 @@ def test_sampling():
     n_draws = 1000
     sample_tensor = gauss_params1.sample(n=n_draws, limits=(low, high))
     sampled_from_gauss1 = zfit.run(sample_tensor)
-    assert max(sampled_from_gauss1[0]) <= high
-    assert min(sampled_from_gauss1[0]) >= low
-    assert n_draws == len(sampled_from_gauss1[0])
+    assert max(sampled_from_gauss1[:, 0]) <= high
+    assert min(sampled_from_gauss1[:, 0]) >= low
+    assert n_draws == len(sampled_from_gauss1[:, 0])
 
     sampled_gauss1_full = zfit.run(gauss_params1.sample(n=10000,
                                                         limits=(mu_true - abs(sigma_true) * 5,

--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -59,7 +59,7 @@ gaussian_dists = [test_gauss1, gauss_params1]
 
 
 def test_gradient():
-    random_vals = np.random.normal(2., 4., size=5)
+    random_vals = np.random.normal(4., 2., size=5)
     tensor_grad = gauss3.gradient(x=random_vals, params=['mu', 'sigma'], norm_range=(-np.infty, np.infty))
     random_vals_eval = zfit.run(tensor_grad)
     np.testing.assert_allclose(random_vals_eval, true_gaussian_grad(random_vals), rtol=1e-5)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -127,7 +127,7 @@ def test_data_range():
     lower = ((0.5, 1), (-3, -2))
     upper = ((1.5, 2.5), (-1.5, 1.5))
     data_range = zfit.Space(obs=obs, limits=(lower, upper))
-    cut_data1 = data1[:, np.array((0, 2))]
+    cut_data1 = data1[np.array((0, 2, 3)), :]
 
     dataset = zfit.data.Data.from_tensors(obs=obs, tensors=data1)
     value_uncut = dataset.value()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -75,14 +75,14 @@ def test_overloaded_operators():
 
 def test_sort_by_obs():
     new_obs = (obs1[1], obs1[2], obs1[0])
-    new_array = copy.deepcopy(example_data1)
-    new_array = np.array([new_array[:, 1], new_array[:, 2], new_array[:, 0]])
+    new_array = copy.deepcopy(example_data1)[:, np.array((1, 2, 0))]
+    # new_array = np.array([new_array[:, 1], new_array[:, 2], new_array[:, 0]])
     assert data1.obs == obs1, "If this is not True, then the test will be flawed."
     with data1.sort_by_obs(new_obs):
         assert data1.obs == new_obs
         np.testing.assert_array_equal(new_array, zfit.run(data1.value()))
-        new_array2 = copy.deepcopy(new_array)
-        new_array2 = np.array([new_array2[:, 1], new_array2[:, 2], new_array2[:, 0]])
+        new_array2 = copy.deepcopy(new_array)[:, np.array((1, 2, 0))]
+        # new_array2 = np.array([new_array2[:, 1], new_array2[:, 2], new_array2[:, 0]])
         new_obs2 = (new_obs[1], new_obs[2], new_obs[0])
         with data1.sort_by_obs(new_obs2):
             assert data1.obs == new_obs2
@@ -96,17 +96,17 @@ def test_sort_by_obs():
 
 def test_subdata():
     new_obs = (obs1[0], obs1[1])
-    new_array = copy.deepcopy(example_data1)
-    new_array = np.array([new_array[:, 0], new_array[:, 1]])
+    new_array = copy.deepcopy(example_data1)[:, np.array((0, 1))]
+    # new_array = np.array([new_array[:, 0], new_array])
     with data1.sort_by_obs(obs=new_obs):
         assert data1.obs == new_obs
         np.testing.assert_array_equal(new_array, zfit.run(data1))
-        new_array2 = copy.deepcopy(new_array)
-        new_array2 = np.array([new_array2[:, 1]])
+        new_array2 = copy.deepcopy(new_array)[:, 1]
+        # new_array2 = np.array([new_array2[:, 1]])
         new_obs2 = (new_obs[1],)
         with data1.sort_by_obs(new_obs2):
             assert data1.obs == new_obs2
-            np.testing.assert_array_equal(new_array2, zfit.run(data1.value()))
+            np.testing.assert_array_equal(new_array2, zfit.run(data1.value())[:, 0])
 
             with pytest.raises(ValueError):
                 with data1.sort_by_obs(obs=new_obs):
@@ -122,12 +122,12 @@ def test_data_range():
                       [-2, 1],
                       [-1, -1],
                       [-5, 10]])
-    data1 = data1.transpose()
+    # data1 = data1.transpose()
     obs = ['obs1', 'obs2']
     lower = ((0.5, 1), (-3, -2))
     upper = ((1.5, 2.5), (-1.5, 1.5))
     data_range = zfit.Space(obs=obs, limits=(lower, upper))
-    cut_data1 = data1[np.array((0, 2, 3)), :]
+    cut_data1 = data1[np.array((0, 2)), :]
 
     dataset = zfit.data.Data.from_tensors(obs=obs, tensors=data1)
     value_uncut = dataset.value()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -9,7 +9,7 @@ import zfit
 
 obs1 = ('obs1', 'obs2', 'obs3')
 
-example_data1 = np.random.random(size=(len(obs1), 7))
+example_data1 = np.random.random(size=(7, len(obs1)))
 data1 = zfit.data.Data.from_numpy(obs=obs1, array=example_data1)
 
 
@@ -45,7 +45,7 @@ def test_from_root():
 
 
 def test_from_numpy():
-    example_data = np.random.random(size=(len(obs1), 1000))
+    example_data = np.random.random(size=(1000, len(obs1)))
     data = zfit.data.Data.from_numpy(obs=obs1, array=example_data)
     x = data.value()
     x_np = zfit.run(x)
@@ -76,13 +76,13 @@ def test_overloaded_operators():
 def test_sort_by_obs():
     new_obs = (obs1[1], obs1[2], obs1[0])
     new_array = copy.deepcopy(example_data1)
-    new_array = np.array([new_array[1, :], new_array[2, :], new_array[0, :]])
+    new_array = np.array([new_array[:, 1], new_array[:, 2], new_array[:, 0]])
     assert data1.obs == obs1, "If this is not True, then the test will be flawed."
     with data1.sort_by_obs(new_obs):
         assert data1.obs == new_obs
         np.testing.assert_array_equal(new_array, zfit.run(data1.value()))
         new_array2 = copy.deepcopy(new_array)
-        new_array2 = np.array([new_array2[1, :], new_array2[2, :], new_array2[0, :]])
+        new_array2 = np.array([new_array2[:, 1], new_array2[:, 2], new_array2[:, 0]])
         new_obs2 = (new_obs[1], new_obs[2], new_obs[0])
         with data1.sort_by_obs(new_obs2):
             assert data1.obs == new_obs2
@@ -97,12 +97,12 @@ def test_sort_by_obs():
 def test_subdata():
     new_obs = (obs1[0], obs1[1])
     new_array = copy.deepcopy(example_data1)
-    new_array = np.array([new_array[0, :], new_array[1, :]])
+    new_array = np.array([new_array[:, 0], new_array[:, 1]])
     with data1.sort_by_obs(obs=new_obs):
         assert data1.obs == new_obs
         np.testing.assert_array_equal(new_array, zfit.run(data1))
         new_array2 = copy.deepcopy(new_array)
-        new_array2 = np.array([new_array2[1, :]])
+        new_array2 = np.array([new_array2[:, 1]])
         new_obs2 = (new_obs[1],)
         with data1.sort_by_obs(new_obs2):
             assert data1.obs == new_obs2

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -23,7 +23,7 @@ obs1 = 'obs1'
 
 
 def func1_5deps(x):
-    a, b, c, d, e = tf.unstack(x)
+    a, b, c, d, e = ztf.unstack_x(x)
     return a + b * c ** 2 + d ** 2 * e ** 3
 
 

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -153,8 +153,11 @@ func4_2values = np.array([[-12., -4.5, 1.9, 4.1], [-11., 3.2, 7.4, -0.3]])
 
 
 def func4_3deps(x):
-    # a, b, c = tf.unstack(x)
-    a, b, c = x
+    if isinstance(x, np.ndarray):
+        a, b, c = x
+    else:
+        a, b, c = ztf.unstack_x(x)
+
     return a ** 2 + b ** 3 + 0.5 * c
 
 
@@ -217,12 +220,14 @@ def test_mc_integration():
 
 
 def test_mc_partial_integration():
-    num_integral = zintegrate.mc_integrate(x=ztf.convert_to_tensor(func4_values),
+    values = ztf.convert_to_tensor(func4_values)
+    num_integral = zintegrate.mc_integrate(x=tf.expand_dims(values, axis=-1),
                                            func=func4_3deps,
                                            limits=Space.from_axes(limits=limits4_2dim,
                                                                   axes=(0, 2)),
                                            draws_per_dim=70)
     vals_tensor = ztf.convert_to_tensor(func4_2values)
+
     vals_reshaped = tf.transpose(vals_tensor)
     num_integral2 = zintegrate.mc_integrate(x=vals_reshaped,
                                             func=func4_3deps,

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -127,7 +127,7 @@ limits3 = [((-1., -4.3),), ((2.3, -1.2),)]
 
 
 def func3_2deps(x):
-    a, b = tf.unstack(x)
+    a, b = ztf.unstack_x(x)
     return a ** 2 + b ** 2
 
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -134,10 +134,10 @@ def test_implicit_extended():
 
 
 def test_implicit_sumpdf():
-    return  # TODO(Mayou36): deps: impl_copy,
+    return  # TODO(Mayou36): deps: impl_copy, (mostly for Simple{PDF,Func})
     # tf.reset_default_graph()
     norm_range = (-5.7, 13.6)
-    param1 = Parameter('param23s', 1.1)
+    param1 = Parameter('param13s', 1.1)
     frac1 = 0.11
     frac1_param = Parameter('frac13s', frac1)
     frac2 = 0.66

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -72,9 +72,11 @@ def test_func_func():
     param4 = Parameter('param41sd', 4.)
 
     def func1_pure(x):
+        x = ztf.unstack_x(x)
         return param1 * x
 
     def func2_pure(x):
+        x = ztf.unstack_x(x)
         return param2 * x + param3
 
     func1 = SimpleFunc(func=func1_pure, obs=obs1, p1=param1)

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -91,9 +91,9 @@ def test_prod_gauss_nd():
     test_values_data = Data.from_tensors(obs=obs1, tensors=test_values)
     probs = prod_gauss_3d.pdf(x=test_values_data, norm_range=norm_range_3d)
     zfit.run(tf.global_variables_initializer())
-    true_probs = np.prod([gauss.pdf(test_values[i, :], norm_range=(-5, 4)) for i, gauss in enumerate(gauss_dists)])
+    true_probs = np.prod([gauss.pdf(test_values[:, i], norm_range=(-5, 4)) for i, gauss in enumerate(gauss_dists)])
     probs_np = zfit.run(probs)
-    np.testing.assert_allclose(zfit.run(true_probs)[:, 0], probs_np[:, 0], rtol=1e-2)
+    np.testing.assert_allclose(zfit.run(true_probs), probs_np, rtol=1e-2)
 
 
 @pytest.mark.flaky(reruns=3)
@@ -126,19 +126,19 @@ def test_prod_gauss_nd_mixed():
     true_probs = true_unnormalized_probs / tf.reduce_mean(normalization_probs)
     probs_np = zfit.run(probs)
     print(np.average(probs_np))
-    true_probs_np = zfit.run(true_probs[:, 0])
+    true_probs_np = zfit.run(true_probs)
     assert np.average(probs_np * limits_4d.area()) == pytest.approx(1., rel=0.33)  # low n mc
-    np.testing.assert_allclose(true_probs_np, probs_np[:, 0], rtol=2e-2)
+    np.testing.assert_allclose(true_probs_np, probs_np, rtol=2e-2)
 
 
 def test_func_sum():
     zfit.run(tf.global_variables_initializer())
     test_values = np.random.uniform(low=-3, high=4, size=10)
-    vals = sum_gauss.as_func(norm_range=False).value(
-        x=ztf.convert_to_tensor(test_values, dtype=zfit.settings.ztypes.float))
+    sum_gauss_as_func = sum_gauss.as_func(norm_range=False)
+    vals = sum_gauss_as_func.value(x=test_values)
     vals = zfit.run(vals)
     # test_sum = sum([g.func(test_values) for g in gauss_dists])
-    np.testing.assert_allclose(vals[:, 0], true_gaussian_sum(test_values), rtol=1e-2)  # MC integral
+    np.testing.assert_allclose(vals, true_gaussian_sum(test_values), rtol=1e-2)  # MC integral
 
 
 def test_normalization_sum_gauss():

--- a/zfit/core/basefunc.py
+++ b/zfit/core/basefunc.py
@@ -50,7 +50,7 @@ class BaseFunc(BaseModel, ZfitFunc):
         Returns:
             tf.Tensor:  # TODO(Mayou36): or dataset?
         """
-        with self._convert_sort_x(x):
+        with self._convert_sort_x(x) as x:
             return self._single_hook_value(x=x, name=name)
 
     def _single_hook_value(self, x, name):

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -169,19 +169,19 @@ class BaseModel(BaseNumeric, BaseDimensional, ZfitModel):
                     raise TypeError("Wrong type of x ({}). Has to be a `Data` or convertible to a tf.Tensor")
             # check dimension
             x = self._add_dim_to_x(x=x)
-            x_shape = x.shape.as_list()[0]
+            x_shape = x.shape.as_list()[-1]
             if x_shape != self.n_obs:
-                raise ShapeIncompatibleError("The shape of x (={}) (in the first dim) does not"
+                raise ShapeIncompatibleError("The shape of x (={}) (in the last dim) does not"
                                              "match the shape (={})of the model".format(x_shape, self.n_obs))
             x = Data.from_tensors(obs=self.obs, tensors=x)
             yield x
 
-    def _add_dim_to_x(self, x):
+    def _add_dim_to_x(self, x):  # TODO(Mayou36): remove function? unnecessary? dealt with in `Data`?
         if self.n_obs == 1:
             if len(x.shape.as_list()) == 0:
-                x = tf.expand_dims(x, 0)
+                x = tf.expand_dims(x, -1)
             if len(x.shape.as_list()) == 1:
-                x = tf.expand_dims(x, 0)
+                x = tf.expand_dims(x, -1)
         return x
 
     def set_integration_options(self, mc_options: dict = None, numeric_options: dict = None,

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -371,9 +371,9 @@ class BasePDF(ZfitPDF, BaseModel):
             params = self.get_parameters(only_floating=False, names=params)
 
         probs = self.pdf(x, norm_range=norm_range)
-        if probs.shape.as_list()[0] > 1:
-            raise DueToLazynessNotImplementedError()
-        gradients = [tf.gradients(prob, params) for prob in ztf.unstack_x(probs[0])]
+        # if probs.shape.as_list()[-1] > 1:
+        #     raise DueToLazynessNotImplementedError()
+        gradients = [tf.gradients(prob, params) for prob in ztf.unstack_x(probs)]
         return tf.stack(gradients)
 
     def _apply_yield(self, value: float, norm_range: ztyping.LimitsType, log: bool) -> Union[float, tf.Tensor]:

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -373,7 +373,7 @@ class BasePDF(ZfitPDF, BaseModel):
         probs = self.pdf(x, norm_range=norm_range)
         if probs.shape.as_list()[0] > 1:
             raise DueToLazynessNotImplementedError()
-        gradients = [tf.gradients(prob, params) for prob in tf.unstack(probs[0])]
+        gradients = [tf.gradients(prob, params) for prob in ztf.unstack_x(probs[0])]
         return tf.stack(gradients)
 
     def _apply_yield(self, value: float, norm_range: ztyping.LimitsType, log: bool) -> Union[float, tf.Tensor]:

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -89,7 +89,9 @@ class Data(SessionHolderMixin, ZfitData, BaseDimensional, BaseObject):
     @classmethod
     def from_root_iter(cls, path, treepath, branches=None, entrysteps=None, name=None, **kwargs):
         # branches = convert_to_container(branches)
-        warnings.warn("Using the iterator is hardcore! Don't do it if you don't fully understand what happens.")
+        warnings.warn(
+            "Using the iterator is hardcore and will most probably fail! Don't use it (yet) if you don't fully "
+            "understand what happens.")
 
         def uproot_generator():
             for data in uproot.iterate(path=path, treepath=treepath,
@@ -125,7 +127,7 @@ class Data(SessionHolderMixin, ZfitData, BaseDimensional, BaseObject):
     @classmethod
     def from_numpy(cls, obs, array, name=None):
         if not isinstance(array, np.ndarray):
-            raise TypeError("`array` has to be a `np..ndarray`. Is currently {}".format(type(array)))
+            raise TypeError("`array` has to be a `np.ndarray`. Is currently {}".format(type(array)))
         np_placeholder = tf.placeholder(dtype=array.dtype, shape=array.shape)
         iterator_feed_dict = {np_placeholder: array}
         dataset = tf.data.Dataset.from_tensors(np_placeholder)
@@ -158,7 +160,7 @@ class Data(SessionHolderMixin, ZfitData, BaseDimensional, BaseObject):
         if self.data_range.limits is not None:
 
             inside_limits = []
-            value = tf.transpose(value)
+            # value = tf.transpose(value)
             for lower, upper in self.data_range.iter_limits():
                 above_lower = tf.reduce_all(tf.less_equal(value, upper), axis=1)
                 below_upper = tf.reduce_all(tf.greater_equal(value, lower), axis=1)
@@ -166,7 +168,7 @@ class Data(SessionHolderMixin, ZfitData, BaseDimensional, BaseObject):
             inside_any_limit = tf.reduce_any(inside_limits, axis=0)  # has to be inside one limits
 
             value = tf.boolean_mask(tensor=value, mask=inside_any_limit)
-            value = tf.transpose(value)
+            # value = tf.transpose(value)
 
         return value
 
@@ -182,9 +184,9 @@ class Data(SessionHolderMixin, ZfitData, BaseDimensional, BaseObject):
         values = self.get_iteration()
         # TODO(Mayou36): add conversion to right dimension? (n_obs, n_events)? # check if 1-D?
         if len(values.shape.as_list()) == 0:
-            values = tf.expand_dims(values, 0)
+            values = tf.expand_dims(values, -1)
         if len(values.shape.as_list()) == 1:
-            values = tf.expand_dims(values, 0)
+            values = tf.expand_dims(values, -1)
         perm_indices = self.space.axes if self.space.axes != tuple(range(values.shape[0])) else False
 
         # permutate = perm_indices is not None
@@ -196,9 +198,9 @@ class Data(SessionHolderMixin, ZfitData, BaseDimensional, BaseObject):
             perm_indices = self.space.get_axes(obs=obs)
             # values = list(values[self.obs.index(o)] for o in obs if o in self.obs)
         if perm_indices:
-            values = tf.unstack(values)
+            values = ztf.unstack_x(values)
             values = list(values[i] for i in perm_indices)
-            values = tf.stack(values)
+            values = ztf.stack_x(values)
 
         # cut data to right range
 
@@ -349,15 +351,13 @@ class LightDataset:
 
 if __name__ == '__main__':
 
-    from skhep_testdata import data_path
+    # from skhep_testdata import data_path
 
-    # path_root = "/data/uni/b2k1ee/classification_new/2012/"
-    # big_root = 'Bu2KpipiEE-MC-12125000-2012-MagAll-StrippingBu2LLK.root'
-    # small_root = 'small.root'
+    path_root = "/data/uni/b2k1ee/classification_new/2012/"
+    small_root = 'small.root'
     #
-    # # path_root += big_root
-    # path_root += small_root
-    path_root = data_path("uproot-Zmumu.root")
+    path_root += small_root
+    # path_root = data_path("uproot-Zmumu.root")
 
     branches = [b'pt1', b'pt2']  # b needed currently -> uproot
 

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -187,7 +187,7 @@ class Data(SessionHolderMixin, ZfitData, BaseDimensional, BaseObject):
             values = tf.expand_dims(values, -1)
         if len(values.shape.as_list()) == 1:
             values = tf.expand_dims(values, -1)
-        perm_indices = self.space.axes if self.space.axes != tuple(range(values.shape[0])) else False
+        perm_indices = self.space.axes if self.space.axes != tuple(range(values.shape[1])) else False
 
         # permutate = perm_indices is not None
         if obs:

--- a/zfit/core/integration.py
+++ b/zfit/core/integration.py
@@ -351,7 +351,7 @@ class Integral(object):  # TODO analytic integral
 if __name__ == '__main__':
     def my_fn1(x):
         if isinstance(x, tf.Tensor):
-            x = tf.unstack(x)
+            x = ztf.unstack_x(x)
         w, x, y, z, l = x
         # return x ** 2 + 0.1 * y ** 2 + 0.01 * z ** 2 + 0.001 * w ** 2 + 0.0001 * l ** 2
         return w + x

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -13,7 +13,8 @@ from ..settings import ztypes
 @no_multiple_limits
 def accept_reject_sample(prob: typing.Callable, n: int, limits: Space,
                          sampler: typing.Callable = tf.random_uniform,
-                         dtype=ztypes.float, prob_max: typing.Union[None, int] = None) -> tf.Tensor:
+                         dtype=ztypes.float, prob_max: typing.Union[None, int] = None,
+                         efficiency_estimation: float = 1.5) -> tf.Tensor:
     """Accept reject sample from a probability distribution.
 
     Args:
@@ -27,6 +28,7 @@ def accept_reject_sample(prob: typing.Callable, n: int, limits: Space,
         prob_max (Union[None, int]): The maximum of the model function for the given limits. If None
             is given, it will be automatically, safely estimated (by a 10% increase in computation time
             (constant weak scaling)).
+        efficiency_estimation (float): estimation of the initial sampling efficiency.
 
     Returns:
         tf.Tensor:
@@ -39,42 +41,39 @@ def accept_reject_sample(prob: typing.Callable, n: int, limits: Space,
     n = tf.to_int64(n)
 
     def enough_produced(n, sample, n_total_drawn, eff):
-        return tf.greater(n, tf.shape(sample, out_type=tf.int64)[1])
+        return tf.greater(n, tf.shape(sample, out_type=tf.int64)[0])
 
-    def sample_body(n, sample, n_total_drawn=0, eff=1.5):
+    def sample_body(n, sample, n_total_drawn=0, eff=1.0):
         if sample is None:
             n_to_produce = n
         else:
-            n_to_produce = n - tf.shape(sample, out_type=tf.int64)[1]
+            n_to_produce = n - tf.shape(sample, out_type=tf.int64)[0]
         n_to_produce = tf.to_int64(ztf.to_real(n_to_produce) / eff * 1.01) + 100  # just to make sure
         # TODO: adjustable efficiency cap for memory efficiency (prevent too many samples at once produced)
         n_to_produce = tf.minimum(n_to_produce, tf.to_int64(5e5))  # introduce a cap to force serial
         n_total_drawn += n_to_produce
         n_total_drawn = tf.to_int64(n_total_drawn)
 
-        sample_drawn = sampler(shape=(n_dims + 1, n_to_produce),  # + 1 dim for the function value
+        sample_drawn = sampler(shape=(n_to_produce, n_dims + 1),  # + 1 dim for the function value
                                dtype=ztypes.float)
-        # HACK n dims?
 
-        rnd_sample = tf.transpose(sample_drawn[:-1, :]) * (upper - lower) + lower
-        rnd_sample = tf.transpose(rnd_sample)
-        # HACK END
+        rnd_sample = sample_drawn[:, :-1] * (upper - lower) + lower  # -1: all except func value
 
         probabilities = prob(rnd_sample)
-        if prob_max is None:
+        if prob_max is None:  # TODO(performance): estimate prob_max, after enough estimations -> fix it?
             prob_max_inferred = tf.reduce_max(probabilities)
         else:
             prob_max_inferred = prob_max
-        random_thresholds = sample_drawn[-1, :] * prob_max_inferred
+        random_thresholds = sample_drawn[:, -1] * prob_max_inferred
         take_or_not = probabilities > random_thresholds
         # rnd_sample = tf.expand_dims(rnd_sample, dim=0) if len(rnd_sample.shape) == 1 else rnd_sample
         take_or_not = take_or_not[0] if len(take_or_not.shape) == 2 else take_or_not
-        filtered_sample = tf.boolean_mask(rnd_sample, mask=take_or_not, axis=1)
+        filtered_sample = tf.boolean_mask(rnd_sample, mask=take_or_not, axis=0)
 
         if sample is None:
             sample = filtered_sample
         else:
-            sample = tf.concat([sample, filtered_sample], axis=1)
+            sample = tf.concat([sample, filtered_sample], axis=0)
 
         # efficiency (estimate) of how many samples we get
         eff = ztf.to_real(tf.shape(sample, out_type=tf.int64)[1]) / ztf.to_real(n_total_drawn)
@@ -82,11 +81,12 @@ def accept_reject_sample(prob: typing.Callable, n: int, limits: Space,
 
     sample = tf.while_loop(cond=enough_produced, body=sample_body,  # paraopt
                            loop_vars=sample_body(n=n, sample=None,  # run first once for initialization
-                                                 n_total_drawn=0, eff=1.),
+                                                 n_total_drawn=0, eff=efficiency_estimation),
                            swap_memory=True,
                            parallel_iterations=4,
                            back_prop=False)[1]  # backprop not needed here
-    return sample[:, :n]  # cutting away to many produced
+    new_sample = sample[:n, :]  # cutting away to many produced
+    return new_sample
 
 
 if __name__ == '__main__':

--- a/zfit/minimizers/minimizer_tfp.py
+++ b/zfit/minimizers/minimizer_tfp.py
@@ -35,7 +35,7 @@ class BFGSMinimizer(BaseMinimizer):
 
                 with tf.control_dependencies([values, printed]):
                     updated_values = []
-                    for param, val in zip(params, tf.unstack(values)):
+                    for param, val in zip(params, ztf.unstack_x(values)):
                         updated_values.append(tf.assign(param, value=val))
                     with tf.control_dependencies(updated_values):
                         func_graph = func()

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -62,6 +62,7 @@ class Exponential(BasePDF):
 
     def _unnormalized_pdf(self, x):
         lambda_ = self.parameters['lambda']
+        x = ztf.unstack_x(x)
         return tf.exp(lambda_ * x)
 
 

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -43,8 +43,9 @@ class WrapDistribution(BasePDF):  # TODO: extend functionality of wrapper, like 
         n_dims = (n_dims or [1])[0]  # n_obs is a list
         return n_dims
 
-    def _unnormalized_pdf(self, x: "zfit.core.data.Data", norm_range=False):
-        return self.distribution.prob(value=x.value(), name="unnormalized_pdf")  # TODO name
+    def _unnormalized_pdf(self, x: "zfit.data.Data", norm_range=False):
+        value = ztf.unstack_x(x.value())
+        return self.distribution.prob(value=value, name="unnormalized_pdf")  # TODO name
 
     # TODO: register integral
     @supports()

--- a/zfit/models/physics.py
+++ b/zfit/models/physics.py
@@ -214,7 +214,7 @@ class CrystalBallPDF(BasePDF):
         sigma = self.parameters['sigma']
         alpha = self.parameters['alpha']
         n = self.parameters['n']
-        x = x.value()
+        x = ztf.unstack_x(x.value())
         return crystalball_func(x=x, mu=mu, sigma=sigma, alpha=alpha, n=n)
 
 

--- a/zfit/old_ztf.py
+++ b/zfit/old_ztf.py
@@ -74,7 +74,7 @@ def nth_pow(x, n, name=None):
 
 
 def unstack_x(value: Any, num: Any = None, axis: int = 0, name: str = "unstack_x"):
-    return tf.unstack(value=value, num=num, axis=axis, name=name)
+    return ztf.unstack_x(value=value, num=num, axis=axis, name=name)
 
 
 # same as in TensorFlow, wrapped

--- a/zfit/ztf/__init__.py
+++ b/zfit/ztf/__init__.py
@@ -26,5 +26,5 @@
 
 # same as in TensorFlow, wrapped
 
-from .zextension import to_complex, to_real, constant, inf, pi, abs_square, nth_pow, unstack_x
+from .zextension import to_complex, to_real, constant, inf, pi, abs_square, nth_pow, unstack_x, stack_x
 from .wrapping_tf import log, exp, random_normal, random_uniform, convert_to_tensor, reduce_sum, reduce_prod, square

--- a/zfit/ztf/zextension.py
+++ b/zfit/ztf/zextension.py
@@ -50,8 +50,12 @@ def nth_pow(x, n, name=None):
 
 
 def unstack_x(value: Any, num: Any = None, axis: int = -1, name: str = "unstack_x"):
-
-    return tf.unstack(value=value, num=num, axis=axis, name=name)
+    if isinstance(value, list):
+        return value
+    unstacked_x = tf.unstack(value=value, num=num, axis=axis, name=name)
+    if len(unstacked_x) == 1:
+        unstacked_x = unstacked_x[0]
+    return unstacked_x
 
 
 def stack_x(values, axis: int = -1, name: str = "stack_x"):

--- a/zfit/ztf/zextension.py
+++ b/zfit/ztf/zextension.py
@@ -49,15 +49,16 @@ def nth_pow(x, n, name=None):
     return power
 
 
-def unstack_x(value: Any, num: Any = None, axis: int = 0, name: str = "unstack_x"):
+def unstack_x(value: Any, num: Any = None, axis: int = -1, name: str = "unstack_x"):
+
     return tf.unstack(value=value, num=num, axis=axis, name=name)
+
+
+def stack_x(values, axis: int = -1, name: str = "stack_x"):
+    return tf.stack(values=values, axis=axis, name=name)
 
 
 # random sampling
-
-
-def unstack_x(value: Any, num: Any = None, axis: int = 0, name: str = "unstack_x"):
-    return tf.unstack(value=value, num=num, axis=axis, name=name)
 
 
 def convert_to_tensor(value, dtype=None, name=None, preferred_dtype=None):


### PR DESCRIPTION
Before, we had a shape of (n_obs, n_samples)
now we switch to (n_samples, n_obs)

this means that value[5] return the 6th "event" and is more consistent with numpy behavior

Furthermore, the return value of `pdf` (and func currently) has shape (n_events) (and not (n_events, 1) as before. Rational: pdf return is always 1d -> expect it to be 1d)