### PR TITLE
Fix exponential pdf

### DIFF
--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -126,7 +126,7 @@ def test_analytic_sampling():
     class SampleGauss(TestGaussian):
         pass
 
-    SampleGauss.register_analytic_integral(func=lambda limits, params: 2 * limits.upper[0][0],
+    SampleGauss.register_analytic_integral(func=lambda limits, params, model: 2 * limits.upper[0][0],
                                            limits=Space.from_axes(limits=(-float("inf"), ANY_UPPER),
                                                                   axes=(0,)))  # DUMMY!
     SampleGauss.register_inverse_analytic_integral(func=lambda x, params: x + 1000.)

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -131,7 +131,7 @@ def func3_2deps(x):
     return a ** 2 + b ** 2
 
 
-def func3_2deps_fully_integrated(limits, params=None):
+def func3_2deps_fully_integrated(limits, params=None, model=None):
     lower, upper = limits.limits
     with suppress(TypeError):
         lower, upper = lower[0], upper[0]
@@ -284,7 +284,7 @@ def test_analytic_integral_selection():
         def _unnormalized_pdf(self, x, norm_range=False):
             return x ** 2
 
-    int1 = lambda x: 1
+    int1 = lambda x: 1  # on purpose wrong signature but irrelevant (not called, only test bookkeeping)
     int2 = lambda x: 2
     int22 = lambda x: 22
     int3 = lambda x: 3

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -183,7 +183,7 @@ def normalization_testing(pdf, normalization_value=1.):
         probs = pdf.pdf(samples)
         result = zfit.run(probs)
         result = np.average(result) * (high - low)
-        assert normalization_value == pytest.approx(result, rel=0.07)
+        assert pytest.approx(result, rel=0.07) == normalization_value
 
 
 def test_extended_gauss():

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -166,7 +166,7 @@ def test_exp():
     sample_np = zfit.run(sample)
     assert not any(np.isnan(sample_np))
     probs1 = exp1.pdf(x=np.random.normal(size=842), norm_range=(-5, 5))
-    probs2 = exp1.pdf(x=np.linspace(-5, 5, num=11), norm_range=(-5, 5))
+    probs2 = exp1.pdf(x=np.linspace(-5300, 5700, num=11), norm_range=(-5, 5))
     probs1_np, probs2_np = zfit.run([probs1, probs2])
     assert not any(np.isnan(probs1_np))
     assert not any(np.isnan(probs2_np))

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -174,8 +174,6 @@ def test_exp():
 
 
 def normalization_testing(pdf, normalization_value=1.):
-    # init = tf.global_variables_initializer()
-    # zfit.run(init)
     with pdf.set_norm_range(Space(obs=obs1, limits=(low, high))):
         samples = tf.cast(np.random.uniform(low=low, high=high, size=(40000, pdf.n_obs)),
                           dtype=tf.float64)

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -162,8 +162,14 @@ def test_exp():
     lambda_true = 3.1
     lambda_ = zfit.Parameter('lambda1', lambda_true)
     exp1 = zfit.pdf.Exponential(lambda_=lambda_, obs='obs1')
-    exp1.sample(n=10, limits=(-10, 10))
-    exp1.pdf(x=np.random.normal(size=100), norm_range=(-5, 5))
+    sample = exp1.sample(n=1000, limits=(-10, 10))
+    sample_np = zfit.run(sample)
+    assert not any(np.isnan(sample_np))
+    probs1 = exp1.pdf(x=np.random.normal(size=842), norm_range=(-5, 5))
+    probs2 = exp1.pdf(x=np.linspace(-5, 5, num=11), norm_range=(-5, 5))
+    probs1_np, probs2_np = zfit.run([probs1, probs2])
+    assert not any(np.isnan(probs1_np))
+    assert not any(np.isnan(probs2_np))
     normalization_testing(exp1, 1)
 
 

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -435,7 +435,7 @@ class BaseModel(BaseNumeric, BaseDimensional, ZfitModel):
 
     def _fallback_analytic_integrate(self, limits, norm_range):
         return self._analytic_integral.integrate(x=None, limits=limits, axes=limits.axes,
-                                                 norm_range=norm_range, params=self.params)
+                                                 norm_range=norm_range, model=self, params=self.params)
 
     @_BaseModel_register_check_support(True)
     def _numeric_integrate(self, limits, norm_range):
@@ -657,7 +657,7 @@ class BaseModel(BaseNumeric, BaseDimensional, ZfitModel):
 
     def _fallback_partial_analytic_integrate(self, x, limits, norm_range):
         return self._analytic_integral.integrate(x=x, limits=limits, axes=limits.axes,
-                                                 norm_range=norm_range, params=self.params)
+                                                 norm_range=norm_range, model=self, params=self.params)
 
     @_BaseModel_register_check_support(True)
     def _partial_numeric_integrate(self, x, limits, norm_range):

--- a/zfit/core/integration.py
+++ b/zfit/core/integration.py
@@ -12,7 +12,7 @@ from typing import Callable, Optional, Union, Type, Tuple, List
 import zfit
 from zfit import ztf
 from zfit.core.dimension import BaseDimensional
-from zfit.core.interfaces import ZfitData, ZfitSpace
+from zfit.core.interfaces import ZfitData, ZfitSpace, ZfitModel
 from zfit.util.container import convert_to_container
 from zfit.util.temporary import TemporarilySet
 from ..util import ztyping
@@ -439,7 +439,7 @@ class AnalyticIntegral:
         # database-like access
 
     def integrate(self, x: Optional[ztyping.XType], limits: ztyping.LimitsType, axes: ztyping.AxesTypeInput = None,
-                  norm_range: ztyping.LimitsType = None, params: dict = None) -> ztyping.XType:
+                  norm_range: ztyping.LimitsType = None, model: ZfitModel = None, params: dict = None) -> ztyping.XType:
         """Integrate analytically over the axes if available.
 
 
@@ -471,9 +471,9 @@ class AnalyticIntegral:
                 "Integral is available for axes {}, but not for limits {}".format(axes, limits))
 
         if x is None:
-            integral = integral_fn(limits=limits, norm_range=norm_range, params=params)
+            integral = integral_fn(limits=limits, norm_range=norm_range, params=params, model=model)
         else:
-            integral = integral_fn(x=x, limits=limits, norm_range=norm_range, params=params)
+            integral = integral_fn(x=x, limits=limits, norm_range=norm_range, params=params, model=model)
         return integral
 
 

--- a/zfit/core/limits.py
+++ b/zfit/core/limits.py
@@ -1091,3 +1091,9 @@ def convert_to_obs_str(obs):
     obs = convert_to_container(value=obs, container=tuple)
     obs = tuple(ob.obs if isinstance(obs, Space) else obs for ob in obs)
     return obs
+
+
+def shift_space(space: Space, shift):
+    shift = convert_to_container(shift)
+    if not len(shift) == space.n_obs:
+        raise ValueError("`Shift` has to have the same number of observables as `space`.")

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -10,6 +10,7 @@ import numpy as np
 import tensorflow as tf
 
 from zfit import ztf
+from zfit.util.exception import DueToLazynessNotImplementedError
 from ..settings import ztypes
 from ..util import ztyping
 from ..core.limits import Space, ANY_LOWER, ANY_UPPER
@@ -65,6 +66,27 @@ class Exponential(BasePDF):
         lambda_ = self.params['lambda']
         x = ztf.unstack_x(x)
         return tf.exp(lambda_ * x)
+
+    def _log_pdf(self, x, norm_range: Space):
+        lambda_ = self.params['lambda']
+        x = ztf.unstack_x(x)
+        func = x * lambda_
+        if norm_range.n_limits > 1:
+            raise DueToLazynessNotImplementedError(
+                "Not implemented, it's more of a hack. I Should implement log_pdf and "
+                "norm probarly")
+        (lower,), (upper,) = norm_range.limits
+        lower = lower[0]
+        upper = upper[0]
+
+        assert False, "WIP, fix log integral"
+
+        def raw_integral(x):
+            return 0.5 * x ** 2 * lambda_
+
+        integral = raw_integral(upper) - raw_integral(lower)
+        pdf = func - integral
+        return pdf
 
 
 def _exp_integral_from_any_to_any(limits, params):

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -149,14 +149,7 @@ class Exponential(BasePDF):
     #     lower = lower[0]
     #     upper = upper[0]
     #
-    #     assert False, "WIP, fix log integral"
-    #
-    #     def raw_integral(x):
-    #         return 0.5 * x ** 2 * lambda_
-    #
-    #     integral = raw_integral(upper) - raw_integral(lower)
-    #     pdf = func - integral
-    #     return pdf
+    #     assert False, "WIP, add log integral"
 
 
 def _exp_integral_from_any_to_any(limits, params, model):

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -11,6 +11,7 @@ import tensorflow as tf
 
 from zfit import ztf
 from zfit.util.exception import DueToLazynessNotImplementedError
+from zfit.util.temporary import TemporarilySet
 from ..settings import ztypes
 from ..util import ztyping
 from ..core.limits import Space, ANY_LOWER, ANY_UPPER
@@ -61,11 +62,71 @@ class Exponential(BasePDF):
         """
         params = {'lambda': lambda_}
         super().__init__(obs, name=name, params=params, **kwargs)
+        self._numerics_data_shift = None
 
     def _unnormalized_pdf(self, x):
         lambda_ = self.params['lambda']
         x = ztf.unstack_x(x)
-        return tf.exp(lambda_ * x)
+        return tf.exp(lambda_ * (x - self._numerics_data_shift))
+
+    def _set_numerics_data_shift(self, limits):
+        lower, upper = limits.limits
+        lower_val = min([lim[0] for lim in lower])
+        upper_val = max([lim[0] for lim in upper])
+
+        value = upper_val - lower_val
+
+        def setter(value):
+            self._numerics_data_shift = value
+
+        def getter():
+            return self._numerics_data_shift
+
+        return TemporarilySet(value=value, getter=getter, setter=setter)
+
+    def _single_hook_integrate(self, limits, norm_range, name='_hook_integrate'):
+        with self._set_numerics_data_shift(limits=norm_range):
+            return super()._single_hook_integrate(limits, norm_range, name)
+
+    def _single_hook_analytic_integrate(self, limits, norm_range, name="_hook_analytic_integrate"):
+        with self._set_numerics_data_shift(limits=norm_range):
+            return super()._single_hook_analytic_integrate(limits, norm_range, name)
+
+    def _single_hook_numeric_integrate(self, limits, norm_range, name='_hook_numeric_integrate'):
+        with self._set_numerics_data_shift(limits=norm_range):
+            return super()._single_hook_numeric_integrate(limits, norm_range, name)
+
+    def _single_hook_partial_integrate(self, x, limits, norm_range, name='_hook_partial_integrate'):
+        with self._set_numerics_data_shift(limits=norm_range):
+            return super()._single_hook_partial_integrate(x, limits, norm_range, name)
+
+    def _single_hook_partial_analytic_integrate(self, x, limits, norm_range, name='_hook_partial_analytic_integrate'):
+        with self._set_numerics_data_shift(limits=norm_range):
+            return super()._single_hook_partial_analytic_integrate(x, limits, norm_range, name)
+
+    def _single_hook_partial_numeric_integrate(self, x, limits, norm_range, name='_hook_partial_numeric_integrate'):
+        with self._set_numerics_data_shift(limits=norm_range):
+            return super()._single_hook_partial_numeric_integrate(x, limits, norm_range, name)
+
+    def _single_hook_normalization(self, limits, name):
+        with self._set_numerics_data_shift(limits=limits):
+            return super()._single_hook_normalization(limits, name)
+
+    def _single_hook_unnormalized_pdf(self, x, component_norm_range, name):
+        with self._set_numerics_data_shift(limits=component_norm_range):
+            return super()._single_hook_unnormalized_pdf(x, component_norm_range, name)
+
+    def _single_hook_pdf(self, x, norm_range, name):
+        with self._set_numerics_data_shift(limits=norm_range):
+            return super()._single_hook_pdf(x, norm_range, name)
+
+    def _single_hook_log_pdf(self, x, norm_range, name):
+        with self._set_numerics_data_shift(limits=norm_range):
+            return super()._single_hook_log_pdf(x, norm_range, name)
+
+    def _single_hook_sample(self, n, limits, name):
+        with self._set_numerics_data_shift(limits=limits):
+            return super()._single_hook_sample(n, limits, name)
 
     # def _log_pdf(self, x, norm_range: Space):
     #     lambda_ = self.params['lambda']

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -36,7 +36,7 @@ class CustomGaussOLD(BasePDF):
         return gauss
 
 
-def _gauss_integral_from_inf_to_inf(limits, params):
+def _gauss_integral_from_inf_to_inf(limits, params, model):
     return tf.sqrt(2 * ztf.pi) * params['sigma']
 
 

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -67,26 +67,26 @@ class Exponential(BasePDF):
         x = ztf.unstack_x(x)
         return tf.exp(lambda_ * x)
 
-    def _log_pdf(self, x, norm_range: Space):
-        lambda_ = self.params['lambda']
-        x = ztf.unstack_x(x)
-        func = x * lambda_
-        if norm_range.n_limits > 1:
-            raise DueToLazynessNotImplementedError(
-                "Not implemented, it's more of a hack. I Should implement log_pdf and "
-                "norm probarly")
-        (lower,), (upper,) = norm_range.limits
-        lower = lower[0]
-        upper = upper[0]
-
-        assert False, "WIP, fix log integral"
-
-        def raw_integral(x):
-            return 0.5 * x ** 2 * lambda_
-
-        integral = raw_integral(upper) - raw_integral(lower)
-        pdf = func - integral
-        return pdf
+    # def _log_pdf(self, x, norm_range: Space):
+    #     lambda_ = self.params['lambda']
+    #     x = ztf.unstack_x(x)
+    #     func = x * lambda_
+    #     if norm_range.n_limits > 1:
+    #         raise DueToLazynessNotImplementedError(
+    #             "Not implemented, it's more of a hack. I Should implement log_pdf and "
+    #             "norm probarly")
+    #     (lower,), (upper,) = norm_range.limits
+    #     lower = lower[0]
+    #     upper = upper[0]
+    #
+    #     assert False, "WIP, fix log integral"
+    #
+    #     def raw_integral(x):
+    #         return 0.5 * x ** 2 * lambda_
+    #
+    #     integral = raw_integral(upper) - raw_integral(lower)
+    #     pdf = func - integral
+    #     return pdf
 
 
 def _exp_integral_from_any_to_any(limits, params):

--- a/zfit/models/physics.py
+++ b/zfit/models/physics.py
@@ -87,7 +87,7 @@ def crystalball_func(x, mu, sigma, alpha, n):
 #     return result
 
 # created with the help of TensorFlow autograph used on python code converted from ShapeCB of RooFit
-def crystalball_integral(limits, params):
+def crystalball_integral(limits, params, model):
     mu = params['mu']
     sigma = params['sigma']
     alpha = params['alpha']


### PR DESCRIPTION
Introducing a shift in exp, leaving the pdf untouched and shifting x to around 0 for numerical stability (exp overflows otherwise)

Also changed analytic integral function API from
`func(limits, params)` 
to
`func(limits, params, model)` 
-> some code may breaks