### PR TITLE
Rename `Func.value` to `Func.func` without sideeffects

### DIFF
--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -76,7 +76,7 @@ def test_func():
     test_values_tf = ztf.convert_to_tensor(test_values, dtype=zfit.settings.ztypes.float)
 
     gauss_func = gauss_params1.as_func(norm_range=(-5, 5))
-    vals = gauss_func.value(test_values)
+    vals = gauss_func.func(test_values)
     vals = zfit.run(vals)
     assert True  # better assertion?
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -58,9 +58,9 @@ def test_param_func():
     new_func_equivalent = func * param4
 
     zfit.run(tf.global_variables_initializer())
-    result1 = zfit.run(new_func.value(x=rnd_test_values))
-    result1_equivalent = zfit.run(new_func_equivalent.value(x=rnd_test_values))
-    result2 = zfit.run(func.value(x=rnd_test_values) * param4)
+    result1 = zfit.run(new_func.func(x=rnd_test_values))
+    result1_equivalent = zfit.run(new_func_equivalent.func(x=rnd_test_values))
+    result2 = zfit.run(func.func(x=rnd_test_values) * param4)
     np.testing.assert_array_equal(result1, result2)
     np.testing.assert_array_equal(result1_equivalent, result2)
 
@@ -85,9 +85,9 @@ def test_func_func():
     added_func = func1 + func2
     prod_func = func1 * func2
 
-    added_values = added_func.value(rnd_test_values)
+    added_values = added_func.func(rnd_test_values)
     true_added_values = func1_pure(rnd_test_values) + func2_pure(rnd_test_values)
-    prod_values = prod_func.value(rnd_test_values)
+    prod_values = prod_func.func(rnd_test_values)
     true_prod_values = func1_pure(rnd_test_values) * func2_pure(rnd_test_values)
 
     zfit.run(tf.global_variables_initializer())

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -138,7 +138,7 @@ def test_func_sum():
     zfit.run(tf.global_variables_initializer())
     test_values = np.random.uniform(low=-3, high=4, size=10)
     sum_gauss_as_func = sum_gauss.as_func(norm_range=False)
-    vals = sum_gauss_as_func.value(x=test_values)
+    vals = sum_gauss_as_func.func(x=test_values)
     vals = zfit.run(vals)
     # test_sum = sum([g.func(test_values) for g in gauss_dists])
     np.testing.assert_allclose(vals, true_gaussian_sum(test_values), rtol=1e-2)  # MC integral

--- a/tests/test_simple_subclass.py
+++ b/tests/test_simple_subclass.py
@@ -48,7 +48,7 @@ def test_func_simple_subclass():
 
     gauss1 = SimpleGaussFunc(obs='obs1', mu=3, sigma=5)
 
-    value = gauss1.value(np.random.random(size=(10, 1)))
+    value = gauss1.func(np.random.random(size=(10, 1)))
     zfit.run(value)
 
     with pytest.raises(ValueError):

--- a/zfit/core/basefunc.py
+++ b/zfit/core/basefunc.py
@@ -22,10 +22,10 @@ class BaseFunc(BaseModel, ZfitFunc):
         super().__init__(obs=obs, dtype=dtype, name=name, params=params)
 
     def _func_to_integrate(self, x: ztyping.XType):
-        return self.value(x=x)
+        return self.func(x=x)
 
     def _func_to_sample_from(self, x):
-        return self.value(x=x)
+        return self.func(x=x)
 
     # TODO(Mayou36): how to deal with copy properly?
     def copy(self, **override_params):
@@ -41,7 +41,7 @@ class BaseFunc(BaseModel, ZfitFunc):
     def _value(self, x):
         raise NotImplementedError
 
-    def value(self, x: ztyping.XType, name: str = "value") -> ztyping.XType:  # TODO(naming): rename to `func`?
+    def func(self, x: ztyping.XType, name: str = "value") -> ztyping.XType:  # TODO(naming): rename to `func`?
         """The function evaluated at `x`.
 
         Args:

--- a/zfit/core/interfaces.py
+++ b/zfit/core/interfaces.py
@@ -366,7 +366,7 @@ class ZfitModel(ZfitNumeric, ZfitDimensional):
 
 class ZfitFunc(ZfitModel):
     @abc.abstractmethod
-    def value(self, x: ztyping.XType, name: str = "value") -> ztyping.XType:
+    def func(self, x: ztyping.XType, name: str = "value") -> ztyping.XType:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/zfit/core/operations.py
+++ b/zfit/core/operations.py
@@ -92,7 +92,7 @@ def multiply_param_func(param: ZfitParameter, func: ZfitFunc) -> ZfitFunc:
     from ..models.functions import SimpleFunc
 
     def combined_func(x):
-        return param * func.value(x=x)
+        return param * func.func(x=x)
 
     params = {param.name: param}
     params.update(func.params)
@@ -217,5 +217,5 @@ def convert_func_to_pdf(func: Union[ZfitFunc, Callable], obs=None, name=None) ->
     from ..models.special import SimplePDF
 
     name = func.name if name is None else func_name
-    pdf = SimplePDF(func=func.value, obs=func.obs, name=name, **func.params)
+    pdf = SimplePDF(func=func.func, obs=func.obs, name=name, **func.params)
     return pdf

--- a/zfit/models/functions.py
+++ b/zfit/models/functions.py
@@ -58,7 +58,7 @@ class SumFunc(BaseFunctorFunc):
 
     def _value(self, x):
         # sum_funcs = tf.add_n([func.value(x) for func in self.funcs])
-        funcs = [func.value(x) for func in self.funcs]
+        funcs = [func.func(x) for func in self.funcs]
         sum_funcs = tf.accumulate_n(funcs)
         return sum_funcs
 
@@ -68,9 +68,9 @@ class ProdFunc(BaseFunctorFunc):
         super().__init__(funcs=funcs, obs=obs, name=name, **kwargs)
 
     def _value(self, x):
-        value = self.funcs[0].value(x)
+        value = self.funcs[0].func(x)
         for func in self.funcs[1:]:
-            value *= func.value(x)
+            value *= func.func(x)
         return value
 
 


### PR DESCRIPTION
Now without mixup