### PR TITLE
Simpler limits

### DIFF
--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -161,6 +161,8 @@ def test_dimensions():
     space = Space(obs=['obs1', 'obs2'], limits=(((1, 2),), ((2, 3),)))
     assert space.n_obs == 2
     assert space.n_limits == 1
+    with pytest.raises(RuntimeError):
+        space.limit1d
 
     space = Space(obs='obs1', limits=(((1,), (2,)), ((2,), (3,))))
     assert space.n_obs == 1
@@ -187,14 +189,23 @@ def test_dimensions():
     space = Space.from_axes(axes=(1,), limits=(((1,), (2,)), ((2,), (3,))))
     assert space.n_obs == 1
     assert space.n_limits == 2
+    with pytest.raises(RuntimeError):
+        space.limit1d
 
     space = Space.from_axes(axes=(1, 2), limits=(((1, 5), (2, 4)), ((2, 3), (3, 2))))
     assert space.n_obs == 2
     assert space.n_limits == 2
+    with pytest.raises(RuntimeError):
+        space.limit1d
 
-    space = Space.from_axes(axes=(1,), limits=(((1,),), ((2,),)))
+    lower1 = 1
+    upper1 = 2
+    space = Space.from_axes(axes=(1,), limits=(((lower1,),), ((upper1,),)))
     assert space.n_obs == 1
     assert space.n_limits == 1
+    lower, upper = space.limit1d
+    assert lower == lower1
+    assert upper == upper1
 
     space = Space.from_axes(axes=(1, 2, 4, 5),
                             limits=(((1, 5, 2, 4), (1, 5, 2, 4)), ((2, 3, 3, 2), (1, 5, 2, 4))))

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -183,6 +183,7 @@ def test_dimensions():
     assert space.n_limits == 2
     with pytest.raises(RuntimeError):
         space.limit2d
+        space.limits1d
 
     space = Space(obs='obs1', limits=(((1,),), ((2,),)))
     assert space.n_obs == 1
@@ -198,9 +199,11 @@ def test_dimensions():
     assert space.n_obs == 4
     assert space.n_limits == 2
 
-    space = Space.from_axes(axes=(1,), limits=(((1,), (2,)), ((2,), (3,))))
+    lower1, lower2, upper1, upper2 = 1, 2, 2, 3
+    space = Space.from_axes(axes=(1,), limits=(((lower1,), (lower2,)), ((upper1,), (upper2,))))
     assert space.n_obs == 1
     assert space.n_limits == 2
+    low1, low2, up1, up2 = space.limits1d
     with pytest.raises(RuntimeError):
         space.limit1d
 

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -158,19 +158,31 @@ def test_exception():
 
 
 def test_dimensions():
-    space = Space(obs=['obs1', 'obs2'], limits=(((1, 2),), ((2, 3),)))
+    lower1, lower2 = 1, 2
+    upper1, upper2 = 2, 3
+    space = Space(obs=['obs1', 'obs2'], limits=(((lower1, lower2),), ((upper1, upper2),)))
     assert space.n_obs == 2
     assert space.n_limits == 1
+    low1, low2, up1, up2 = space.limit2d
+    assert low1 == lower1
+    assert low2 == lower2
+    assert up1 == upper1
+    assert up2 == upper2
+
     with pytest.raises(RuntimeError):
         space.limit1d
 
     space = Space(obs='obs1', limits=(((1,), (2,)), ((2,), (3,))))
     assert space.n_obs == 1
     assert space.n_limits == 2
+    with pytest.raises(RuntimeError):
+        space.limit2d
 
     space = Space(obs=['obs1', 'obs2'], limits=(((1, 5), (2, 4)), ((2, 3), (3, 2))))
     assert space.n_obs == 2
     assert space.n_limits == 2
+    with pytest.raises(RuntimeError):
+        space.limit2d
 
     space = Space(obs='obs1', limits=(((1,),), ((2,),)))
     assert space.n_obs == 1

--- a/zfit/core/limits.py
+++ b/zfit/core/limits.py
@@ -332,6 +332,21 @@ class Space(ZfitSpace, BaseObject):
         return self._limits
 
     @property
+    def limit1d(self):
+        if self.n_obs > 1:
+            raise RuntimeError("Cannot call `limit1d, as `Space` has more then one observables: {}".format(self.n_obs))
+        if self.n_limits > 1:
+            raise RuntimeError("Cannot call `limit1d, as `Space` has several limits: {}".format(self.n_limits))
+
+        limits = self.limits
+        if limits in (None, False):
+            limit = limits
+        else:
+            (lower,), (upper,) = limits
+            limit = lower[0], upper[0]
+        return limit
+
+    @property
     def lower(self) -> ztyping.LowerTypeReturn:
         """Return the lower limits.
 
@@ -1091,9 +1106,3 @@ def convert_to_obs_str(obs):
     obs = convert_to_container(value=obs, container=tuple)
     obs = tuple(ob.obs if isinstance(obs, Space) else obs for ob in obs)
     return obs
-
-
-def shift_space(space: Space, shift):
-    shift = convert_to_container(shift)
-    if not len(shift) == space.n_obs:
-        raise ValueError("`Shift` has to have the same number of observables as `space`.")

--- a/zfit/core/limits.py
+++ b/zfit/core/limits.py
@@ -334,7 +334,7 @@ class Space(ZfitSpace, BaseObject):
     @property
     def limit1d(self):
         if self.n_obs > 1:
-            raise RuntimeError("Cannot call `limit1d, as `Space` has more then one observables: {}".format(self.n_obs))
+            raise RuntimeError("Cannot call `limit1d, as `Space` has more than one observables: {}".format(self.n_obs))
         if self.n_limits > 1:
             raise RuntimeError("Cannot call `limit1d, as `Space` has several limits: {}".format(self.n_limits))
 
@@ -349,9 +349,9 @@ class Space(ZfitSpace, BaseObject):
     @property
     def limit2d(self):
         if self.n_obs != 2:
-            raise RuntimeError("Cannot call `limit1d, as `Space` has more then one observables: {}".format(self.n_obs))
+            raise RuntimeError("Cannot call `limit2d, as `Space` has not two observables: {}".format(self.n_obs))
         if self.n_limits > 1:
-            raise RuntimeError("Cannot call `limit1d, as `Space` has several limits: {}".format(self.n_limits))
+            raise RuntimeError("Cannot call `limit2d, as `Space` has several limits: {}".format(self.n_limits))
 
         limits = self.limits
         if limits in (None, False):
@@ -359,6 +359,26 @@ class Space(ZfitSpace, BaseObject):
         else:
             (lower,), (upper,) = limits
             limit = *lower, *upper
+        return limit
+
+    @property
+    def limits1d(self):
+        if self.n_obs > 1:
+            raise RuntimeError("Cannot call `limits1d, as `Space` has more than one observable: {}".format(self.n_obs))
+        # if self.n_limits > 1:
+        #     raise RuntimeError("Cannot call `limit1d, as `Space` has several limits: {}".format(self.n_limits))
+
+        limits = self.limits
+        if limits in (None, False):
+            limit = limits
+        else:
+            new_lower, new_upper = [], []
+            for lower, upper in self.iter_limits(as_tuple=True):
+                new_lower.append(lower[0])
+                new_upper.append(upper[0])
+            new_lower = tuple(new_lower)
+            new_upper = tuple(new_upper)
+            limit = *new_lower, *new_upper
         return limit
 
     @property

--- a/zfit/core/limits.py
+++ b/zfit/core/limits.py
@@ -347,6 +347,21 @@ class Space(ZfitSpace, BaseObject):
         return limit
 
     @property
+    def limit2d(self):
+        if self.n_obs != 2:
+            raise RuntimeError("Cannot call `limit1d, as `Space` has more then one observables: {}".format(self.n_obs))
+        if self.n_limits > 1:
+            raise RuntimeError("Cannot call `limit1d, as `Space` has several limits: {}".format(self.n_limits))
+
+        limits = self.limits
+        if limits in (None, False):
+            limit = limits
+        else:
+            (lower,), (upper,) = limits
+            limit = *lower, *upper
+        return limit
+
+    @property
     def lower(self) -> ztyping.LowerTypeReturn:
         """Return the lower limits.
 

--- a/zfit/core/limits.py
+++ b/zfit/core/limits.py
@@ -332,7 +332,15 @@ class Space(ZfitSpace, BaseObject):
         return self._limits
 
     @property
-    def limit1d(self):
+    def limit1d(self) -> Tuple[float, float]:
+        """Simplified limits getter for 1 obs, 1 limit only: return the tuple(lower, upper).
+
+        Returns:
+            tuple(float, float): so `lower, upper = space.limit1d` for a simple, 1 obs limit.
+
+        Raises:
+            RuntimeError: if the conditions (n_obs or n_limits) are not satisfied.
+        """
         if self.n_obs > 1:
             raise RuntimeError("Cannot call `limit1d, as `Space` has more than one observables: {}".format(self.n_obs))
         if self.n_limits > 1:
@@ -347,7 +355,16 @@ class Space(ZfitSpace, BaseObject):
         return limit
 
     @property
-    def limit2d(self):
+    def limit2d(self) -> Tuple[float, float, float, float]:
+        """Simplified `.limits` for exactly 2 obs, 1 limit: return the tuple(low_obs1, low_obs2, up_obs1, up_obs2).
+
+        Returns:
+            tuple(float, float, float, float): so `low_x, low_y, up_x, up_y = space.limit2d` for a single, 2 obs limit.
+                low_x is the lower limit in x, up_x is the upper limit in x etc.
+
+        Raises:
+            RuntimeError: if the conditions (n_obs or n_limits) are not satisfied.
+        """
         if self.n_obs != 2:
             raise RuntimeError("Cannot call `limit2d, as `Space` has not two observables: {}".format(self.n_obs))
         if self.n_limits > 1:
@@ -362,7 +379,16 @@ class Space(ZfitSpace, BaseObject):
         return limit
 
     @property
-    def limits1d(self):
+    def limits1d(self) -> Tuple[float]:
+        """Simplified `.limits` for exactly 1 obs, n limits: return the tuple(low_1, ..., low_n, up_1, ..., up_n).
+
+        Returns:
+            tuple(float, float, ...): so `low_1, low_2, up_1, up_2 = space.limits1d` for several, 1 obs limits.
+                low_1 to up_1 is the first interval, low_2 to up_2 is the second interval etc.
+
+        Raises:
+            RuntimeError: if the conditions (n_obs or n_limits) are not satisfied.
+        """
         if self.n_obs > 1:
             raise RuntimeError("Cannot call `limits1d, as `Space` has more than one observable: {}".format(self.n_obs))
         # if self.n_limits > 1:


### PR DESCRIPTION
currently `limit1d` to return (lower, upper) for simple scalars
what other shortcut would be helpful, 1d with two limits? @apuignav 