### PR TITLE
Fix simple typo in docstring

### DIFF
--- a/zfit/models/physics.py
+++ b/zfit/models/physics.py
@@ -197,7 +197,7 @@ class CrystalBall(BasePDF):
         Args:
             mu (`zfit.Parameter`): The mean of the gaussian
             sigma (`zfit.Parameter`): Standard deviation of the gaussian
-            alpha (`zfit.Parameter`): parameter where to swith from a gaussian to the powertail
+            alpha (`zfit.Parameter`): parameter where to switch from a gaussian to the powertail
             n (`zfit.Parameter`): Exponent of the powertail
             obs (:py:class:`~zfit.Space`):
             name (str):


### PR DESCRIPTION
Fixes a simple typo in the Crystal Ball docstring.