### PR TITLE
Sampling with fixed limits

### DIFF
--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -191,13 +191,25 @@ def test_importance_sampling():
 def test_sampling_fixed_eventlimits():
     import tensorflow as tf
 
+    n_samples = 5000
+
     obs1 = "obs1"
-    lower = tf.convert_to_tensor(tuple(range(-10, 11, 4)))
-    upper = tf.convert_to_tensor(tuple(range(-9, 12, 4)))
+    zfit.settings.set_verbosity(6)
+    lower1, upper1 = -10, -9
+    lower2, upper2 = 0, 1
+    lower3, upper3 = 10, 11
+    lower = tf.convert_to_tensor(tuple([lower1] * n_samples + [lower2] * n_samples + [lower3] * n_samples))
+    upper = tf.convert_to_tensor(tuple([upper1] * n_samples + [upper2] * n_samples + [upper3] * n_samples))
     lower = ((lower,),)
     upper = ((upper,),)
     limits = zfit.core.sample.EventSpace(obs=obs1, limits=(lower, upper))
     gauss1 = zfit.pdf.Gauss(mu=0.3, sigma=4, obs=zfit.Space(obs=obs1, limits=(-7, 8)))
 
-    sample = gauss1.sample(n=5, limits=limits)
-    zfit.run(sample)
+    sample = gauss1.sample(n=3 * n_samples, limits=limits)
+    sample_np = zfit.run(sample)
+    assert all(lower1 <= sample_np[:n_samples])
+    assert all(sample_np[:n_samples] <= upper1)
+    assert all(lower2 <= sample_np[n_samples:n_samples * 2])
+    assert all(sample_np[n_samples:n_samples * 2] <= upper2)
+    assert all(lower3 <= sample_np[n_samples * 2:n_samples * 3])
+    assert all(sample_np[n_samples * 2:n_samples * 3] <= upper3)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -156,22 +156,22 @@ def test_importance_sampling():
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self.n_to_produce = tf.Variable(initial_value=-42, dtype=tf.int64, use_resource=True,
-                                            trainable=False, validate_shape=False)
-            self.sess.run(self.n_to_produce.initializer)
+            # self.n_to_produce = tf.Variable(initial_value=-42, dtype=tf.int64, use_resource=True,
+            #                                 trainable=False, validate_shape=False)
+            # self.sess.run(self.n_to_produce.initializer)
             # self.dtype = dtype
             # self.limits = limits
 
         def __call__(self, n_to_produce, limits, dtype):
-            n_to_produce = tf.cast(n_to_produce, dtype=tf.int64)
-            assign_op = self.n_to_produce.assign(n_to_produce)
-            with tf.control_dependencies([assign_op]):
-                gaussian_sample = gauss_sampler._create_sampler_tensor(n=assign_op, limits=limits,
-                                                                       fixed_params=False, name='asdf')[2]
-                weights = gauss_sampler.pdf(gaussian_sample)
-                weights_max = tf.reduce_max(weights) * 0.7
-                thresholds = tf.random_uniform(shape=(self.n_to_produce,), dtype=dtype)
-            return gaussian_sample, thresholds, weights, weights_max, self.n_to_produce
+            n_to_produce = tf.cast(n_to_produce, dtype=tf.int32)
+            # assign_op = self.n_to_produce.assign(n_to_produce)
+            # with tf.control_dependencies([assign_op]):
+            gaussian_sample = gauss_sampler._create_sampler_tensor(n=n_to_produce, limits=limits,
+                                                                   fixed_params=False, name='asdf')[2]
+            weights = gauss_sampler.pdf(gaussian_sample)
+            weights_max = tf.reduce_max(weights) * 0.7
+            thresholds = tf.random_uniform(shape=(n_to_produce,), dtype=dtype)
+            return gaussian_sample, thresholds, weights, weights_max, n_to_produce
 
     sample = accept_reject_sample(prob=gauss_pdf.unnormalized_pdf, n=30000, limits=obs_pdf)
     gauss_pdf._sample_and_weights = GaussianSampleAndWeights

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -186,3 +186,16 @@ def test_importance_sampling():
     assert mean2 == pytest.approx(mu_pdf, rel=0.02)
     assert std == pytest.approx(sigma_pdf, rel=0.02)
     assert std2 == pytest.approx(sigma_pdf, rel=0.02)
+
+
+def test_sampling_fixed_eventlimits():
+    import tensorflow as tf
+
+    obs1 = "obs1"
+    lower = tf.convert_to_tensor(tuple(range(-10, 11, step=4)))
+    upper = tf.convert_to_tensor(tuple(range(-9, 12, step=4)))
+    limits = zfit.core.sample.EventSpace(obs=obs1, limits=(lower, upper))
+    gauss1 = zfit.pdf.Gauss(mu=0.3, sigma=4, obs=zfit.Space(obs1=obs1, limits=(-7, 8)))
+
+    sample = gauss1.sample(n=5, limits=limits)
+    zfit.run(sample)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -218,3 +218,6 @@ def test_sampling_fixed_eventlimits():
     assert all(sample_np[n_samples1:n_samples2] <= upper2)
     assert all(lower3 <= sample_np[n_samples2:n_samples3])
     assert all(sample_np[n_samples2:n_samples3] <= upper3)
+    with pytest.raises(ValueError,
+                       match="are incompatible"):  # cannot use the exact message, () are regex syntax... bug in pytest
+        _ = gauss1.sample(n=n_samples_tot + 1, limits=limits)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -192,10 +192,12 @@ def test_sampling_fixed_eventlimits():
     import tensorflow as tf
 
     obs1 = "obs1"
-    lower = tf.convert_to_tensor(tuple(range(-10, 11, step=4)))
-    upper = tf.convert_to_tensor(tuple(range(-9, 12, step=4)))
+    lower = tf.convert_to_tensor(tuple(range(-10, 11, 4)))
+    upper = tf.convert_to_tensor(tuple(range(-9, 12, 4)))
+    lower = ((lower,),)
+    upper = ((upper,),)
     limits = zfit.core.sample.EventSpace(obs=obs1, limits=(lower, upper))
-    gauss1 = zfit.pdf.Gauss(mu=0.3, sigma=4, obs=zfit.Space(obs1=obs1, limits=(-7, 8)))
+    gauss1 = zfit.pdf.Gauss(mu=0.3, sigma=4, obs=zfit.Space(obs=obs1, limits=(-7, 8)))
 
     sample = gauss1.sample(n=5, limits=limits)
     zfit.run(sample)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import tensorflow as tf
 
 import zfit
 from zfit import ztf
@@ -140,7 +141,6 @@ def test_sampling_floating(gauss_factory):
 @pytest.mark.flaky(3)  # statistical
 def test_importance_sampling():
     zfit.run.create_session(reset_graph=True)
-    import tensorflow as tf
 
     mu_sampler = 5.
     sigma_sampler = 4.
@@ -189,13 +189,12 @@ def test_importance_sampling():
 
 
 def test_sampling_fixed_eventlimits():
-    import tensorflow as tf
+    zfit.run.create_session(reset_graph=True)
 
     n_samples1 = 500
     n_samples2 = 400  # just to make sure
     n_samples3 = 356  # just to make sure
     n_samples_tot = n_samples1 + n_samples2 + n_samples3
-
 
     obs1 = "obs1"
     zfit.settings.set_verbosity(6)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -191,25 +191,30 @@ def test_importance_sampling():
 def test_sampling_fixed_eventlimits():
     import tensorflow as tf
 
-    n_samples = 5000
+    n_samples1 = 500
+    n_samples2 = 400  # just to make sure
+    n_samples3 = 356  # just to make sure
+    n_samples_tot = n_samples1 + n_samples2 + n_samples3
+
 
     obs1 = "obs1"
     zfit.settings.set_verbosity(6)
     lower1, upper1 = -10, -9
     lower2, upper2 = 0, 1
     lower3, upper3 = 10, 11
-    lower = tf.convert_to_tensor(tuple([lower1] * n_samples + [lower2] * n_samples + [lower3] * n_samples))
-    upper = tf.convert_to_tensor(tuple([upper1] * n_samples + [upper2] * n_samples + [upper3] * n_samples))
+    lower = tf.convert_to_tensor(tuple([lower1] * n_samples1 + [lower2] * n_samples2 + [lower3] * n_samples3))
+    upper = tf.convert_to_tensor(tuple([upper1] * n_samples1 + [upper2] * n_samples2 + [upper3] * n_samples3))
     lower = ((lower,),)
     upper = ((upper,),)
     limits = zfit.core.sample.EventSpace(obs=obs1, limits=(lower, upper))
     gauss1 = zfit.pdf.Gauss(mu=0.3, sigma=4, obs=zfit.Space(obs=obs1, limits=(-7, 8)))
 
-    sample = gauss1.sample(n=3 * n_samples, limits=limits)
+    sample = gauss1.sample(n=n_samples_tot, limits=limits)
     sample_np = zfit.run(sample)
-    assert all(lower1 <= sample_np[:n_samples])
-    assert all(sample_np[:n_samples] <= upper1)
-    assert all(lower2 <= sample_np[n_samples:n_samples * 2])
-    assert all(sample_np[n_samples:n_samples * 2] <= upper2)
-    assert all(lower3 <= sample_np[n_samples * 2:n_samples * 3])
-    assert all(sample_np[n_samples * 2:n_samples * 3] <= upper3)
+    assert sample_np.shape[0] == n_samples_tot
+    assert all(lower1 <= sample_np[:n_samples1])
+    assert all(sample_np[:n_samples1] <= upper1)
+    assert all(lower2 <= sample_np[n_samples1:n_samples2])
+    assert all(sample_np[n_samples1:n_samples2] <= upper2)
+    assert all(lower3 <= sample_np[n_samples2:n_samples3])
+    assert all(sample_np[n_samples2:n_samples3] <= upper3)

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -869,7 +869,7 @@ class BaseModel(BaseNumeric, Cachable, BaseDimensional, ZfitModel):
                 raise tf.errors.InvalidArgumentError("limits are False/None, have to be specified")
         limits = self._check_input_limits(limits=limits, caller_name=name, none_is_error=True)
         sample = self._single_hook_sample(n=n, limits=limits, name=name)
-        sample_data = SampleData.from_sample(sample=sample, obs=self.space)
+        sample_data = SampleData.from_sample(sample=sample, obs=self.space.obs)
 
         return sample_data
 

--- a/zfit/core/limits.py
+++ b/zfit/core/limits.py
@@ -782,8 +782,9 @@ class Space(ZfitSpace, BaseObject):
         Returns:
             :py:class:`~zfit.Space`:
         """
-        with self._set_obs_axes(obs_axes=obs_axes, ordered=ordered, allow_subset=allow_subset):
-            return copy.deepcopy(self)
+        new_space = Space(obs=self.obs, limits=self.limits)
+        new_space._set_obs_axes(obs_axes=obs_axes, ordered=ordered, allow_subset=allow_subset)
+        return new_space
 
     def with_autofill_axes(self, overwrite: bool = False) -> "zfit.Space":
         """Return a :py:class:`~zfit.Space` with filled axes corresponding to range(len(n_obs)).

--- a/zfit/core/limits.py
+++ b/zfit/core/limits.py
@@ -169,7 +169,7 @@ class Space(ZfitSpace, BaseObject):
                   limits: Optional[ztyping.LimitsTypeInput] = None,
                   name: str = None) -> "zfit.Space":
         if obs is None:
-            new_space = Space.from_axes(axes=axes, limits=limits, name=name)
+            new_space = cls.from_axes(axes=axes, limits=limits, name=name)
         else:
             new_space = Space(obs=obs, limits=limits, name=name)
             new_space._axes = axes
@@ -782,7 +782,7 @@ class Space(ZfitSpace, BaseObject):
         Returns:
             :py:class:`~zfit.Space`:
         """
-        new_space = Space(obs=self.obs, limits=self.limits)
+        new_space = type(self)(obs=self.obs, limits=self.limits)
         new_space._set_obs_axes(obs_axes=obs_axes, ordered=ordered, allow_subset=allow_subset)
         return new_space
 
@@ -885,7 +885,7 @@ class Space(ZfitSpace, BaseObject):
             sub_upper = tuple(tuple(lim[i] for i in sub_index) for lim in upper)
             sub_limits = sub_lower, sub_upper
 
-        new_space = Space._from_any(obs=sub_obs, axes=sub_axes, limits=sub_limits, name=name)
+        new_space = type(self)._from_any(obs=sub_obs, axes=sub_axes, limits=sub_limits, name=name)
 
         return new_space
 
@@ -913,7 +913,7 @@ class Space(ZfitSpace, BaseObject):
         if set(overwrite_kwargs) - set(kwargs):
             raise KeyError("Not usable keys in `overwrite_kwargs`: {}".format(set(overwrite_kwargs) - set(kwargs)))
 
-        new_space = Space._from_any(**kwargs)
+        new_space = type(self)._from_any(**kwargs)
         return new_space
 
     def __le__(self, other):

--- a/zfit/core/limits.py
+++ b/zfit/core/limits.py
@@ -782,7 +782,7 @@ class Space(ZfitSpace, BaseObject):
         Returns:
             :py:class:`~zfit.Space`:
         """
-        new_space = type(self)(obs=self.obs, limits=self.limits)
+        new_space = type(self)._from_any(obs=self.obs, axes=self.axes, limits=self.limits)
         new_space._set_obs_axes(obs_axes=obs_axes, ordered=ordered, allow_subset=allow_subset)
         return new_space
 

--- a/zfit/core/limits.py
+++ b/zfit/core/limits.py
@@ -171,7 +171,7 @@ class Space(ZfitSpace, BaseObject):
         if obs is None:
             new_space = cls.from_axes(axes=axes, limits=limits, name=name)
         else:
-            new_space = Space(obs=obs, limits=limits, name=name)
+            new_space = cls(obs=obs, limits=limits, name=name)
             new_space._axes = axes
 
         return new_space
@@ -547,7 +547,7 @@ class Space(ZfitSpace, BaseObject):
                     limit = lower, upper
                 else:
                     limit = lower
-                space = Space._from_any(obs=self.obs, axes=self.axes, limits=limit)
+                space = type(self)._from_any(obs=self.obs, axes=self.axes, limits=limit)
                 space_objects.append(space)
             return tuple(space_objects)
 

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -236,7 +236,7 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
 
         n_accepted = tf.shape(filtered_sample)[0]
         n_produced_new = n_produced + n_accepted
-        if dynamic_array_shape:
+        if not dynamic_array_shape:
             indices = tf.boolean_mask(draw_indices, mask=take_or_not)
             is_sampled = tf.logical_or(is_sampled, tf.SparseTensor(indices=tf.expand_dims(indices, axis=1),
                                                                    values=tf.broadcast_to(input=(True,), shape=(n,)),

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -259,10 +259,11 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
                                                                         dense_shape=(tf.cast(n, dtype=tf.int64),)),
                                                         default_value=False)
             is_sampled = tf.logical_or(is_sampled, current_sampled)
+            indices = indices[:, 0]
         else:
             indices = tf.range(n_produced, n_produced_new)
 
-        sample_new = sample.scatter(indices=tf.cast(indices[:, 0], dtype=tf.int32), value=filtered_sample)
+        sample_new = sample.scatter(indices=tf.cast(indices, dtype=tf.int32), value=filtered_sample)
 
         # efficiency (estimate) of how many samples we get
         eff = ztf.to_real(n_produced_new) / ztf.to_real(n_total_drawn)

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -65,7 +65,7 @@ class EventSpace(Space):
 
     @property
     def limits(self) -> ztyping.LimitsTypeReturn:
-        limits = super().limits()
+        limits = super().limits
         limits_tensor = self._limits_tensor
         if limits_tensor is not None:
             lower, upper = limits
@@ -78,7 +78,9 @@ class EventSpace(Space):
                         new_bound = (lim() for lim in bound)
                     new_bounds[i].append(new_bound)
                 new_bounds[i] = tuple(new_bounds[i])
-        return tuple(new_bounds)
+            limits = tuple(new_bounds)
+
+        return limits
 
     def create_limits(self, n):
         if self._factory is not None:

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -147,9 +147,10 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
     # multiple limits and therefore need to randomly remove events, otherwise we are biased because the
     # drawn samples are ordered in the different
     dynamic_array_shape = True
-    # for fixed limits in EventSpace we need to know which indices have been succesfully sampled. Therefore this
+
+    # for fixed limits in EventSpace we need to know which indices have been successfully sampled. Therefore this
     # can be None (if not needed) or a boolean tensor with the size `n`
-    is_sampled = None
+    is_sampled = tf.constant("EMPTY")
     inital_n_produced = tf.constant(0, dtype=tf.int32)
     initial_n_drawn = tf.constant(0, dtype=tf.int32)
 
@@ -223,12 +224,13 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
         sample_new = sample.scatter(indices=indices, value=filtered_sample)
 
         # efficiency (estimate) of how many samples we get
-        eff = ztf.to_real(tf.shape(sample, out_type=tf.int32)[0]) / ztf.to_real(n_total_drawn)
+        eff = ztf.to_real(n_produced_new) / ztf.to_real(n_total_drawn)
         return n, sample_new, n_produced_new, n_total_drawn, eff, is_sampled
 
     # TODO(Mayou36): refactor, remove initial call
     #    loop_vars = sample_body(n=n, sample=None,  # run first once for initialization
     #                            n_total_drawn=0, eff=efficiency_estimation)
+    efficiency_estimation = ztf.to_real(efficiency_estimation)
     loop_vars = (n, sample, inital_n_produced, initial_n_drawn, efficiency_estimation, is_sampled)
     sample_array = tf.while_loop(cond=not_enough_produced, body=sample_body,  # paraopt
                                  loop_vars=loop_vars,


### PR DESCRIPTION
Finally, there we go :)

If fixed limits are used with an event space, sampling from a PDF (currently n has to be specified still, although it is in principle redundant, but if it does not match, it raises an error) means repeating the accept reject until a candidate for each limit is found.

