### PR TITLE
Tfp dists

### DIFF
--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -80,9 +80,9 @@ def create_mu_sigma_2(nameadd=""):
 
 def create_wrapped_gauss(nameadd=""):
     mu2, sigma2 = create_mu_sigma_2(nameadd)
-    gauss_params = dict(loc=mu2, scale=sigma2, name="tf_gauss1")
+    gauss_params = dict(loc=mu2, scale=sigma2)
     tf_gauss = tf.distributions.Normal
-    return zfit.models.dist_tfp.WrapDistribution(tf_gauss, dist_params=gauss_params, obs=obs1)
+    return zfit.models.dist_tfp.WrapDistribution(tf_gauss, dist_params=gauss_params, obs=obs1, name="tf_gauss1")
 
 
 def create_gauss3(nameadd=""):

--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -80,8 +80,9 @@ def create_mu_sigma_2(nameadd=""):
 
 def create_wrapped_gauss(nameadd=""):
     mu2, sigma2 = create_mu_sigma_2(nameadd)
-    tf_gauss = tf.distributions.Normal(loc=mu2, scale=sigma2, name="tf_gauss1")
-    return zfit.models.dist_tfp.WrapDistribution(tf_gauss, obs=obs1)
+    gauss_params = dict(loc=mu2, scale=sigma2, name="tf_gauss1")
+    tf_gauss = tf.distributions.Normal
+    return zfit.models.dist_tfp.WrapDistribution(tf_gauss, dist_params=gauss_params, obs=obs1)
 
 
 def create_gauss3(nameadd=""):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,9 @@
+#  Copyright (c) 2019 zfit
+
+from zfit.core.testing import setup_function, teardown_function, tester
+
+
+
 from zfit.util.cache import Cachable, invalidates_cache
 
 import numpy as np

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,3 +1,8 @@
+#  Copyright (c) 2019 zfit
+
+from zfit.core.testing import setup_function, teardown_function, tester
+
+
 import copy
 
 import pytest

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -1,3 +1,8 @@
+#  Copyright (c) 2019 zfit
+
+from zfit.core.testing import setup_function, teardown_function, tester
+
+
 import os
 
 import pytest

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,3 +1,8 @@
+#  Copyright (c) 2019 zfit
+
+from zfit.core.testing import setup_function, teardown_function, tester
+
+
 import copy
 
 import pytest

--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -1,3 +1,8 @@
+#  Copyright (c) 2019 zfit
+
+from zfit.core.testing import setup_function, teardown_function, tester
+
+
 import pytest
 import numpy as np
 import tensorflow as tf

--- a/tests/test_functor_pdf.py
+++ b/tests/test_functor_pdf.py
@@ -1,3 +1,8 @@
+#  Copyright (c) 2019 zfit
+
+from zfit.core.testing import setup_function, teardown_function, tester
+
+
 import pytest
 
 import zfit

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,3 +1,8 @@
+#  Copyright (c) 2019 zfit
+
+from zfit.core.testing import setup_function, teardown_function, tester
+
+
 import sys
 
 import zfit

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -1,3 +1,5 @@
+#  Copyright (c) 2019 zfit
+
 from contextlib import suppress
 import math as mt
 
@@ -14,6 +16,8 @@ import zfit.core.math as zmath
 from zfit.core.parameter import Parameter
 from zfit.models.basic import CustomGaussOLD
 from zfit.models.dist_tfp import Gauss
+
+from zfit.core.testing import setup_function, teardown_function, tester
 
 from zfit.core.testing import setup_function, teardown_function, tester
 

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,3 +1,5 @@
+#  Copyright (c) 2019 zfit
+
 import pytest
 import tensorflow as tf
 import numpy as np

--- a/tests/test_simple_subclass.py
+++ b/tests/test_simple_subclass.py
@@ -1,3 +1,8 @@
+#  Copyright (c) 2019 zfit
+
+from zfit.core.testing import setup_function, teardown_function, tester
+
+
 import pytest
 
 import zfit

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -1,3 +1,8 @@
+#  Copyright (c) 2019 zfit
+
+from zfit.core.testing import setup_function, teardown_function, tester
+
+
 from collections import OrderedDict
 import copy
 import random

--- a/tests/test_temporary.py
+++ b/tests/test_temporary.py
@@ -1,3 +1,8 @@
+#  Copyright (c) 2019 zfit
+
+from zfit.core.testing import setup_function, teardown_function, tester
+
+
 from zfit.util.temporary import TemporarilySet
 from zfit.core.testing import setup_function, teardown_function, tester
 

--- a/tests/test_ztf_random.py
+++ b/tests/test_ztf_random.py
@@ -23,8 +23,9 @@ def test_counts_multinomial():
     std = np.std(counts_np, axis=0)
 
     assert (3,) == counts_np[0].shape
-    assert np.sum(counts_np, axis=1) == pytest.approx(total_count, rel=0.05)
-    assert np.array(probs) * total_count == pytest.approx(mean, rel=0.05)
+    assert all(total_count == np.sum(counts_np, axis=1))
+    probs_scaled = np.array(probs) * total_count
+    assert probs_scaled == pytest.approx(mean, rel=0.05)
     assert [9, 14, 16] == pytest.approx(std, rel=0.5)  # flaky
 
     total_count2 = 5000
@@ -32,14 +33,14 @@ def test_counts_multinomial():
     counts_np2 = [zfit.run(counts) for _ in range(3)]
     mean2 = np.mean(counts_np2, axis=0)
 
-    assert pytest.approx(total_count2, rel=0.05) == np.sum(counts_np2, axis=1)
-    assert pytest.approx(mean2, rel=0.05) == np.array(probs) * total_count2
+    assert all(total_count2 == np.sum(counts_np2, axis=1))
+    probs_scaled2 = np.array(probs) * total_count2
+    assert pytest.approx(mean2, rel=0.15) == probs_scaled2
 
     total_count3 = 3000.
-    counts3 = ztf.random.counts_multinomial(total_count=total_count3, logits=np.array(probs) * 30)
+    counts3 = ztf.random.counts_multinomial(total_count=total_count3,
+                                            logits=probs * 30)  # sigmoid: inverse of logits (softmax)
 
     counts_np3 = [zfit.run(counts3) for _ in range(5)]
-    mean3 = np.mean(counts_np3, axis=0)
 
-    assert pytest.approx(total_count3, rel=0.05) == np.sum(counts_np3, axis=1)
-    assert pytest.approx(mean3, rel=0.05) == np.array(probs) * total_count3
+    assert all(total_count3 == np.sum(counts_np3, axis=1))

--- a/tests/test_ztf_random.py
+++ b/tests/test_ztf_random.py
@@ -1,3 +1,4 @@
+
 #  Copyright (c) 2019 zfit
 
 from zfit.core.testing import setup_function, teardown_function

--- a/tests/test_ztf_random.py
+++ b/tests/test_ztf_random.py
@@ -1,0 +1,45 @@
+#  Copyright (c) 2019 zfit
+
+from zfit.core.testing import setup_function, teardown_function
+
+import pytest
+import numpy as np
+import tensorflow as tf
+
+import zfit
+from zfit import ztf
+
+
+@pytest.mark.flaky(2)
+def test_counts_multinomial():
+    probs = [0.1, 0.3, 0.6]
+    total_count = 1000.
+    total_count_var = tf.Variable(total_count, use_resource=True, trainable=False)
+    zfit.run(total_count_var.initializer)
+    counts = ztf.random.counts_multinomial(total_count=total_count_var, probs=probs)
+
+    counts_np = [zfit.run(counts) for _ in range(20)]
+    mean = np.mean(counts_np, axis=0)
+    std = np.std(counts_np, axis=0)
+
+    assert (3,) == counts_np[0].shape
+    assert np.sum(counts_np, axis=1) == pytest.approx(total_count, rel=0.05)
+    assert np.array(probs) * total_count == pytest.approx(mean, rel=0.05)
+    assert [9, 14, 16] == pytest.approx(std, rel=0.5)  # flaky
+
+    total_count2 = 5000
+    total_count_var.load(total_count2, session=zfit.run.sess)
+    counts_np2 = [zfit.run(counts) for _ in range(3)]
+    mean2 = np.mean(counts_np2, axis=0)
+
+    assert pytest.approx(total_count2, rel=0.05) == np.sum(counts_np2, axis=1)
+    assert pytest.approx(mean2, rel=0.05) == np.array(probs) * total_count2
+
+    total_count3 = 3000.
+    counts3 = ztf.random.counts_multinomial(total_count=total_count3, logits=np.array(probs) * 30)
+
+    counts_np3 = [zfit.run(counts3) for _ in range(5)]
+    mean3 = np.mean(counts_np3, axis=0)
+
+    assert pytest.approx(total_count3, rel=0.05) == np.sum(counts_np3, axis=1)
+    assert pytest.approx(mean3, rel=0.05) == np.array(probs) * total_count3

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -140,6 +140,7 @@ class BaseModel(BaseNumeric, Cachable, BaseDimensional, ZfitModel):
             raise BasePDFSubclassingError("Method {} has not been correctly wrapped with @supports "
                                           "OR has been wrapped but it should not be".format(method_name))
 
+    # since subclasses can be funcs of pdfs, we need to now what to sample/integrate from
     @abc.abstractmethod
     def _func_to_integrate(self, x: ztyping.XType) -> tf.Tensor:
         raise NotImplementedError

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -550,7 +550,7 @@ class BasePDF(ZfitPDF, BaseModel):
         from ..models.dist_tfp import WrapDistribution
 
         if type(self) == WrapDistribution:
-            parameters = dict(distribution=self.distribution)
+            parameters = dict(distribution=self._distribution, dist_params=self.dist_params)
         else:
             # HACK END
 

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -558,13 +558,16 @@ class BasePDF(ZfitPDF, BaseModel):
             lambda_ = parameters.pop('lambda', None)
             if lambda_ is not None:
                 parameters['lambda_'] = lambda_
-        from zfit.models.functor import BaseFunctor
+        from zfit.models.functor import BaseFunctor, SumPDF
         if isinstance(self, BaseFunctor):
             parameters = {}
-            fracs = self.fracs
-            if not self.is_extended:
-                fracs = fracs[:-1]
-            parameters.update(pdfs=self.pdfs, fracs=fracs)
+            if isinstance(self, SumPDF):
+                fracs = self.fracs
+                if not self.is_extended:
+                    fracs = fracs[:-1]
+                parameters.update(fracs=fracs)
+            parameters.update(pdfs=self.pdfs)
+
         parameters.update(obs=obs, name=self.name)
         parameters.update(**override_parameters)
         # if hasattr(self, "distribution"):

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -49,6 +49,8 @@ For more advanced methods and ways to register analytic integrals or overwrite c
 also the advanced tutorials in `zfit tutorials <https://github.com/zfit/zfit-tutorials>`_
 """
 
+#  Copyright (c) 2019 zfit
+
 import abc
 from contextlib import suppress
 from typing import Union, Any, Type, Dict
@@ -549,7 +551,7 @@ class BasePDF(ZfitPDF, BaseModel):
         # HACK(Mayou36): remove once copy is proper implemented
         from ..models.dist_tfp import WrapDistribution
 
-        if type(self) == WrapDistribution:
+        if type(self) == WrapDistribution:  # NOT isinstance! Because e.g. Gauss wraps that and takes different args
             parameters = dict(distribution=self._distribution, dist_params=self.dist_params)
         else:
             # HACK END

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -202,7 +202,7 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
         if dynamic_array_shape:
             n_to_produce = tf.to_int32(ztf.to_real(n_to_produce) / eff * 1.01) + 10  # just to make sure
             # TODO: adjustable efficiency cap for memory efficiency (prevent too many samples at once produced)
-            n_to_produce = tf.minimum(n_to_produce, tf.to_int32(5e5))  # introduce a cap to force serial
+            n_to_produce = tf.minimum(n_to_produce, tf.to_int32(5e6))  # introduce a cap to force serial
             new_limits = limits
         else:
             if multiple_limits:

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -3,6 +3,8 @@ Basic PDFs are provided here. Gauss, exponential... that can be used together wi
 build larger models.
 """
 
+#  Copyright (c) 2019 zfit
+
 import math as mt
 from typing import Type, Any
 import warnings
@@ -52,7 +54,7 @@ class Exponential(BasePDF):
         defined as :math:`\\frac{ e^{\\lambda \\cdot x}}{ \\int_{lower}^{upper} e^{\\lambda \\cdot x} dx}`
 
         Args:
-            lambda_ (:py:class:`~zfit.Parameter`): Accessed as "lambda".
+            lambda_ (:py:class:`~zfit.Parameter`): Accessed as parameter "lambda".
             obs (:py:class:`~zfit.Space`): The :py:class:`~zfit.Space` the pdf is defined in.
             name (str): Name of the pdf.
             dtype (DType):

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -35,7 +35,6 @@ class WrapDistribution(BasePDF):  # TODO: extend functionality of wrapper, like 
         self.distribution = distribution
         self.dist_params = dist_params
 
-
     def _unnormalized_pdf(self, x: "zfit.data.Data", norm_range=False):
         value = x.unstack_x()
         dist = self.distribution(**self.dist_params)
@@ -84,6 +83,18 @@ class Uniform(WrapDistribution):
         dist_params = dict(low=low, high=high, name=name + "_tfp")
         distribution = tfp.distributions.Uniform
         super().__init__(distribution=distribution, dist_params=dist_params, obs=obs, params=params, name=name)
+
+
+class TruncatedNormal(WrapDistribution):
+    _N_OBS = 1
+
+    def __init__(self, mu, sigma, low, high, obs, name=None):
+        mu, sigma, low, high = self._check_input_params(mu, sigma, low, high)
+        params = OrderedDict((("mu", mu), ("sigma", sigma), ("low", low), ("high", high)))
+        distribution = tfp.distributions.TruncatedNormal
+        dist_params = dict(loc=mu, scale=sigma, low=low, high=high, name=name + "_tfp")
+        super().__init__(distribution=distribution, dist_params=dist_params,
+                         obs=obs, params=params, name=name)
 
 
 if __name__ == '__main__':

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -94,5 +94,17 @@ class Uniform(WrapDistribution):
         super().__init__(distribution=distribution, dist_params=dist_params, obs=obs, params=params, name=name + "_tfp")
 
 
+class TruncatedNormal(WrapDistribution):
+    _N_OBS = 1
+
+    def __init__(self, mu, sigma, low, high, obs, name=None):
+        mu, sigma, low, high = self._check_input_params(mu, sigma, low, high)
+        params = OrderedDict((("mu", mu), ("sigma", sigma), ("low", low), ("high", high)))
+        distribution = tfp.distributions.TruncatedNormal
+        dist_params = dict(loc=mu, scale=sigma, low=low, high=high, name=name + "_tfp")
+        super().__init__(distribution=distribution, dist_params=dist_params,
+                         obs=obs, params=params, name=name)
+
+
 if __name__ == '__main__':
     exp1 = ExponentialTFP(tau=5., obs=['a'])

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -16,6 +16,7 @@ import tensorflow_probability as tfp
 import tensorflow as tf
 
 from zfit import ztf
+from ..util import ztyping
 from ..settings import ztypes
 from ..core.basepdf import BasePDF
 from ..core.interfaces import ZfitParameter
@@ -64,7 +65,28 @@ class WrapDistribution(BasePDF):  # TODO: extend functionality of wrapper, like 
 class Gauss(WrapDistribution):
     _N_OBS = 1
 
-    def __init__(self, mu, sigma, obs, name="Gauss"):
+    def __init__(self, mu: ztyping.ParamTypeInput, sigma: ztyping.ParamTypeInput, obs: ztyping.ObsTypeInput,
+                 name: str = "Gauss"):
+        """Gaussian or Normal distribution with a mean (mu) and a standartdevation (sigma).
+
+        The gaussian shape is defined as
+
+        .. math::
+            f(x \mid \mu, \\sigma^2) = e^{ -\\frac{(x - \\mu)^{2}}{2\\sigma^2} }
+
+        with the normalization over [-inf, inf] of
+
+        .. math::
+            \\frac{1}{\\sqrt{2\pi\sigma^2} }
+
+        The normalization changes for different normalization ranges
+
+        Args:
+            mu (:py:class:`~zfit.Parameter`): Mean of the gaussian dist
+            sigma (:py:class:`~zfit.Parameter`): Standard deviation or spread of the gaussian
+            obs (:py:class:`~zfit.Space`): Observables and normalization range the pdf is defined in
+            name (str): Name of the pdf
+        """
         mu, sigma = self._check_input_params(mu, sigma)
         params = OrderedDict((('mu', mu), ('sigma', sigma)))
         dist_params = dict(loc=mu, scale=sigma)
@@ -75,7 +97,7 @@ class Gauss(WrapDistribution):
 class ExponentialTFP(WrapDistribution):
     _N_OBS = 1
 
-    def __init__(self, tau, obs, name="Exponential"):
+    def __init__(self, tau: ztyping.ParamTypeInput, obs: ztyping.ObsTypeInput, name: str = "Exponential"):
         (tau,) = self._check_input_params(tau)
         params = OrderedDict((('tau', tau),))
         dist_params = dict(rate=tau)
@@ -86,7 +108,16 @@ class ExponentialTFP(WrapDistribution):
 class Uniform(WrapDistribution):
     _N_OBS = 1
 
-    def __init__(self, low, high, obs, name="Uniform"):
+    def __init__(self, low: ztyping.ParamTypeInput, high: ztyping.ParamTypeInput, obs: ztyping.ObsTypeInput,
+                 name: str = "Uniform"):
+        """Uniform distribution which is constant between `low`, `high` and zero outside.
+
+        Args:
+            low:
+            high:
+            obs:
+            name:
+        """
         low, high = self._check_input_params(low, high)
         params = OrderedDict((("low", low), ("high", high)))
         dist_params = dict(low=low, high=high)
@@ -97,7 +128,8 @@ class Uniform(WrapDistribution):
 class TruncatedNormal(WrapDistribution):
     _N_OBS = 1
 
-    def __init__(self, mu, sigma, low, high, obs, name=None):
+    def __init__(self, mu: ztyping.ParamTypeInput, sigma: ztyping.ParamTypeInput, low: ztyping.ParamTypeInput,
+                 high: ztyping.ParamTypeInput, obs: ztyping.ObsTypeInput, name: str = None):
         mu, sigma, low, high = self._check_input_params(mu, sigma, low, high)
         params = OrderedDict((("mu", mu), ("sigma", sigma), ("low", low), ("high", high)))
         distribution = tfp.distributions.TruncatedNormal

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -5,6 +5,8 @@ different from the zfit models, it is similar enough to be easily wrapped.
 
 Therefore a convenient wrapper as well as a lot of implementations are provided.
 """
+#  Copyright (c) 2019 zfit
+
 from collections import OrderedDict
 
 import numpy as np
@@ -90,18 +92,6 @@ class Uniform(WrapDistribution):
         dist_params = dict(low=low, high=high)
         distribution = tfp.distributions.Uniform
         super().__init__(distribution=distribution, dist_params=dist_params, obs=obs, params=params, name=name + "_tfp")
-
-
-class TruncatedNormal(WrapDistribution):
-    _N_OBS = 1
-
-    def __init__(self, mu, sigma, low, high, obs, name=None):
-        mu, sigma, low, high = self._check_input_params(mu, sigma, low, high)
-        params = OrderedDict((("mu", mu), ("sigma", sigma), ("low", low), ("high", high)))
-        distribution = tfp.distributions.TruncatedNormal
-        dist_params = dict(loc=mu, scale=sigma, low=low, high=high, name=name + "_tfp")
-        super().__init__(distribution=distribution, dist_params=dist_params,
-                         obs=obs, params=params, name=name)
 
 
 if __name__ == '__main__':

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -129,7 +129,7 @@ class TruncatedGauss(WrapDistribution):
     _N_OBS = 1
 
     def __init__(self, mu: ztyping.ParamTypeInput, sigma: ztyping.ParamTypeInput, low: ztyping.ParamTypeInput,
-                 high: ztyping.ParamTypeInput, obs: ztyping.ObsTypeInput, name: str = None):
+                 high: ztyping.ParamTypeInput, obs: ztyping.ObsTypeInput, name: str = "TruncatedGauss"):
         """Gaussian distribution that is 0 outside of `low`, `high`. Equivalent to the product of Gauss and Uniform.
 
         Args:
@@ -143,7 +143,7 @@ class TruncatedGauss(WrapDistribution):
         mu, sigma, low, high = self._check_input_params(mu, sigma, low, high)
         params = OrderedDict((("mu", mu), ("sigma", sigma), ("low", low), ("high", high)))
         distribution = tfp.distributions.TruncatedNormal
-        dist_params = dict(loc=mu, scale=sigma, low=low, high=high, name=name + "_tfp")
+        dist_params = dict(loc=mu, scale=sigma, low=low, high=high)
         super().__init__(distribution=distribution, dist_params=dist_params,
                          obs=obs, params=params, name=name)
 

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -113,10 +113,10 @@ class Uniform(WrapDistribution):
         """Uniform distribution which is constant between `low`, `high` and zero outside.
 
         Args:
-            low:
-            high:
-            obs:
-            name:
+            low (:py:class:`~zfit.Parameter`): Below this value, the pdf is zero.
+            high (:py:class:`~zfit.Parameter`): Above this value, the pdf is zero.
+            obs (:py:class:`~zfit.Space`): Observables and normalization range the pdf is defined in
+            name (str): Name of the pdf
         """
         low, high = self._check_input_params(low, high)
         params = OrderedDict((("low", low), ("high", high)))
@@ -125,11 +125,21 @@ class Uniform(WrapDistribution):
         super().__init__(distribution=distribution, dist_params=dist_params, obs=obs, params=params, name=name + "_tfp")
 
 
-class TruncatedNormal(WrapDistribution):
+class TruncatedGauss(WrapDistribution):
     _N_OBS = 1
 
     def __init__(self, mu: ztyping.ParamTypeInput, sigma: ztyping.ParamTypeInput, low: ztyping.ParamTypeInput,
                  high: ztyping.ParamTypeInput, obs: ztyping.ObsTypeInput, name: str = None):
+        """Gaussian distribution that is 0 outside of `low`, `high`. Equivalent to the product of Gauss and Uniform.
+
+        Args:
+            mu (:py:class:`~zfit.Parameter`): Mean of the gaussian dist
+            sigma (:py:class:`~zfit.Parameter`): Standard deviation or spread of the gaussian
+            low (:py:class:`~zfit.Parameter`): Below this value, the pdf is zero.
+            high (:py:class:`~zfit.Parameter`): Above this value, the pdf is zero.
+            obs (:py:class:`~zfit.Space`): Observables and normalization range the pdf is defined in
+            name (str): Name of the pdf
+        """
         mu, sigma, low, high = self._check_input_params(mu, sigma, low, high)
         params = OrderedDict((("mu", mu), ("sigma", sigma), ("low", low), ("high", high)))
         distribution = tfp.distributions.TruncatedNormal

--- a/zfit/pdf.py
+++ b/zfit/pdf.py
@@ -1,14 +1,16 @@
+#  Copyright (c) 2019 zfit
+
 from .core.basepdf import BasePDF
 from .models.basic import Exponential
 from .models.physics import CrystalBall
-from .models.dist_tfp import Gauss, Uniform, WrapDistribution
+from .models.dist_tfp import Gauss, Uniform, WrapDistribution, TruncatedGauss
 from .models.functor import ProductPDF, SumPDF
 from .models.special import ZPDF, SimplePDF, SimpleFunctorPDF
 
 __all__ = ['BasePDF',
            'Exponential',
            'CrystalBall',
-           'Gauss', 'Uniform', 'WrapDistribution',
+           'Gauss', 'Uniform', 'TruncatedGauss', 'WrapDistribution',
            'ProductPDF', 'SumPDF',
            'ZPDF', 'SimplePDF', 'SimpleFunctorPDF'
            ]

--- a/zfit/ztf/__init__.py
+++ b/zfit/ztf/__init__.py
@@ -7,6 +7,8 @@ Some function are already wrapped, others are not. Best practice is to use `ztf`
 `tf` for the rest.
 """
 
+#  Copyright (c) 2019 zfit
+
 # fill the following in to the namespace for (future) wrapping
 
 # doesn't work below because of autoimport... probably anytime in the Future :)
@@ -39,3 +41,4 @@ from .zextension import (to_complex, to_real, constant, inf, pi, abs_square, nth
                          run_no_nan, )
 from .wrapping_tf import (log, exp, random_normal, random_uniform, convert_to_tensor, reduce_sum, reduce_prod, square,
                           sqrt, complex, check_numerics)
+from . import random

--- a/zfit/ztf/random.py
+++ b/zfit/ztf/random.py
@@ -26,18 +26,21 @@ def counts_multinomial(total_count: Union[int, tf.Tensor], probs: Iterable[Union
     """
     control_deps = []
     if probs is not None:
-        probs = convert_to_container(probs)
-        if len(probs) < 2:
-            raise ValueError("`probs` has to have length 2 at least.")
-        probs = tf.convert_to_tensor(probs)
+        if not isinstance(probs, (tf.Tensor, tf.Variable)):
+            probs = convert_to_container(probs)
+            if len(probs) < 2:
+                raise ValueError("`probs` has to have length 2 at least.")
+            probs = tf.convert_to_tensor(probs)
         probs = tf.cast(probs, tf.float32)
         control_deps.append(probs)
         # probs_logits_shape = tf.shape(probs)
     elif logits is not None:
-        logits = convert_to_container(logits)
-        if len(logits) < 2:
-            raise ValueError("`logits` has to have length 2 at least.")
-        logits = tf.convert_to_tensor(logits, dtype=None)
+
+        if not isinstance(logits, (tf.Tensor, tf.Variable)):
+            logits = convert_to_container(logits)
+            if len(logits) < 2:
+                raise ValueError("`logits` has to have length 2 at least.")
+            logits = tf.convert_to_tensor(logits, dtype=None)
         logits = tf.cast(logits, tf.float32)
         control_deps.append(logits)
         # probs_logits_shape = tf.shape(logits)

--- a/zfit/ztf/random.py
+++ b/zfit/ztf/random.py
@@ -1,0 +1,58 @@
+#  Copyright (c) 2019 zfit
+
+from typing import Union, Iterable, Sized
+
+import tensorflow_probability as tfp
+import tensorflow as tf
+
+from .wrapping_tf import convert_to_tensor
+from ..util.container import convert_to_container
+
+__all__ = ["counts_multinomial"]
+
+
+def counts_multinomial(total_count: Union[int, tf.Tensor], probs: Iterable[Union[float, tf.Tensor]] = None,
+                       logits: Iterable[Union[float, tf.Tensor]] = None, dtype=tf.int32) -> tf.Tensor:
+    """Get the number of counts for different classes with given probs/logits.
+
+    Args:
+        total_count (int): The total number of draws.
+        probs: Length k (number of classes) object where the k-1th entry contains the probability to
+            get a single draw from the class k. Have to be from [0, 1] and sum up to 1.
+        logits: Same as probs but from [-inf, inf] (will be transformet to [0, 1])
+
+    Returns:
+        :py:class.`tf.Tensor`: shape (k,) tensor containing the number of draws.
+    """
+    control_deps = []
+    if probs is not None:
+        probs = convert_to_container(probs)
+        if len(probs) < 2:
+            raise ValueError("`probs` has to have length 2 at least.")
+        probs = tf.convert_to_tensor(probs)
+        probs = tf.cast(probs, tf.float32)
+        control_deps.append(probs)
+        # probs_logits_shape = tf.shape(probs)
+    elif logits is not None:
+        logits = convert_to_container(logits)
+        if len(logits) < 2:
+            raise ValueError("`logits` has to have length 2 at least.")
+        logits = tf.convert_to_tensor(logits, dtype=None)
+        logits = tf.cast(logits, tf.float32)
+        control_deps.append(logits)
+        # probs_logits_shape = tf.shape(logits)
+    else:
+        raise ValueError("Exactly one of `probs` or`logits` have to be specified")
+    if not isinstance(total_count, tf.Variable):
+        total_count = convert_to_tensor(total_count, dtype=None)
+    total_count = tf.cast(total_count, dtype=tf.float32)
+    control_deps.append(total_count)
+    # needed since otherwise shape of sample will be (1, n_probs)
+    # total_count = tf.broadcast_to(total_count, shape=probs_logits_shape)
+
+    with tf.control_dependencies(control_deps):
+        dist = tfp.distributions.Multinomial(total_count=total_count, probs=probs, logits=logits)
+        counts = dist.sample()
+    counts = tf.cast(counts, dtype=dtype)
+    with tf.control_dependencies([counts]):
+        return counts


### PR DESCRIPTION
Changes:
- Move the instantiation of the tfp distributions inside the `unnormalized_pdf`, s.t. the parameters op connecting it with the output happen inside it. Needed for the gradient taping (https://github.com/tensorflow/probability/issues/285) as in normalization on-the-fly

- add the truncatedgauss (simple TFP wrap)
- add docs to Gauss, Uniform
- use setup_function and teardown_function in every unittest module (currently resets tf session and graph)
