### PR TITLE
More general nll_gaussian constraint

### DIFF
--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -1,0 +1,20 @@
+#  Copyright (c) 2019 zfit
+import pytest
+
+import zfit
+from zfit.core.testing import setup_function, teardown_function, tester
+from zfit.util.exception import ShapeIncompatibleError
+
+
+def test_shape_errors():
+    param1 = zfit.Parameter("Param1", 5)
+    param2 = zfit.Parameter("Param2", 5)
+
+    with pytest.raises(ShapeIncompatibleError):
+        zfit.constraint.nll_gaussian([param1, param2], mu=[4, 2, 3], sigma=5)
+    with pytest.raises(ShapeIncompatibleError):
+        zfit.constraint.nll_gaussian([param1, param2], mu=[4, 2], sigma=5)
+    with pytest.raises(ShapeIncompatibleError):
+        zfit.constraint.nll_gaussian([param1, param2], mu=2, sigma=[1, 4])
+    with pytest.raises(ShapeIncompatibleError):
+        zfit.constraint.nll_gaussian(param1, mu=[4, 2], sigma=[2, 3])

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -1,14 +1,16 @@
 #  Copyright (c) 2019 zfit
 import pytest
+import numpy as np
 
 import zfit
+from zfit import ztf
 from zfit.core.testing import setup_function, teardown_function, tester
 from zfit.util.exception import ShapeIncompatibleError
 
 
 def test_shape_errors():
     param1 = zfit.Parameter("Param1", 5)
-    param2 = zfit.Parameter("Param2", 5)
+    param2 = zfit.Parameter("Param2", 6)
 
     with pytest.raises(ShapeIncompatibleError):
         zfit.constraint.nll_gaussian([param1, param2], mu=[4, 2, 3], sigma=5)
@@ -18,3 +20,16 @@ def test_shape_errors():
         zfit.constraint.nll_gaussian([param1, param2], mu=2, sigma=[1, 4])
     with pytest.raises(ShapeIncompatibleError):
         zfit.constraint.nll_gaussian(param1, mu=[4, 2], sigma=[2, 3])
+
+
+def test_nll_gaussian_values():
+    param1 = zfit.Parameter("Param1", 5)
+    param2 = zfit.Parameter("Param2", 6)
+    params = [param1, param2]
+
+    mu = [3., 6.1]
+    sigma = np.array([[1, 0.3],
+                      [0.8, 0.5]])
+    constr = zfit.constraint.nll_gaussian(params=params, mu=mu, sigma=sigma)
+    constr_np = zfit.run(constr)
+    assert constr_np == pytest.approx(4.28846)

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -111,8 +111,8 @@ def test_unbinned_simultaneous_nll():
 
 
 @pytest.mark.flaky(3)
-@pytest.mark.parametrize('weights', (None, None, np.random.normal(loc=1., scale=0.2, size=test_values_np.shape[0]), None, None))
-@pytest.mark.parametrize('sigma', (constr, covariance, constr, constr_tf, covariance))
+@pytest.mark.parametrize('weights', (None, np.random.normal(loc=1., scale=0.2, size=test_values_np.shape[0])))
+@pytest.mark.parametrize('sigma', (constr, covariance, constr_tf))
 def test_unbinned_nll(weights, sigma):
     gaussian1, mu1, sigma1 = create_gauss1()
     gaussian2, mu2, sigma2 = create_gauss2()

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -53,7 +53,7 @@ mu_constr = [1.6, 0.2]  # mu, sigma
 sigma_constr = [3.8, 0.2]
 constr = lambda: [mu_constr[1], sigma_constr[1]]
 constr_tf = lambda: ztf.convert_to_tensor(constr())
-covariance = lambda: np.array([[mu_constr[1]**0.5, -0.05], [-0.05, sigma_constr[1]**0.5]])
+covariance = lambda: np.array([[mu_constr[1] ** 0.5, -0.05], [-0.05, sigma_constr[1] ** 0.5]])
 covariance_tf = lambda: ztf.convert_to_tensor(covariance())
 
 
@@ -193,8 +193,8 @@ def test_gradients(chunksize):
     zfit.run.chunking.active = True
     zfit.run._chunksize = chunksize
 
-    param1 = Parameter("param111", 1.)
-    param2 = Parameter("param222", 2.)
+    param1 = Parameter("param1", 1.)
+    param2 = Parameter("param2", 2.)
 
     gauss1 = Gauss(param1, 4, obs=obs1)
     gauss1.set_norm_range((-5, 5))

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -52,6 +52,8 @@ obs1 = 'obs1'
 mu_constr = [1.6, 0.2]  # mu, sigma
 sigma_constr = [3.8, 0.2]
 
+covariance = np.array([[mu_constr[1]**0.5, 0.2], [0.2, sigma_constr[1]**0.5]])
+
 
 def create_gauss1():
     mu, sigma = create_params1()
@@ -107,8 +109,9 @@ def test_unbinned_simultaneous_nll():
 
 
 @pytest.mark.flaky(3)
-@pytest.mark.parametrize('weights', [None, np.random.normal(loc=1., scale=0.2, size=test_values_np.shape[0])])
-def test_unbinned_nll(weights):
+@pytest.mark.parametrize('weights, sigma', [(None, [mu_constr[1], sigma_constr[1]]), (None, covariance),
+                         (np.random.normal(loc=1., scale=0.2, size=test_values_np.shape[0]), [mu_constr[1], sigma_constr[1]])])
+def test_unbinned_nll(weights, sigma):
     gaussian1, mu1, sigma1 = create_gauss1()
     gaussian2, mu2, sigma2 = create_gauss2()
 
@@ -125,7 +128,7 @@ def test_unbinned_nll(weights):
 
     constraints = zfit.constraint.nll_gaussian(params=[mu2, sigma2],
                                                mu=[mu_constr[0], sigma_constr[0]],
-                                               sigma=[mu_constr[1], sigma_constr[1]])
+                                               sigma=sigma)
     nll_object = UnbinnedNLL(model=gaussian2, data=test_values, fit_range=(-np.infty, np.infty),
                              constraints=constraints)
 

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -109,7 +109,8 @@ def test_unbinned_simultaneous_nll():
 
 @pytest.mark.flaky(3)
 @pytest.mark.parametrize('weights, sigma', [(None, [mu_constr[1], sigma_constr[1]]), (None, covariance),
-                         (np.random.normal(loc=1., scale=0.2, size=test_values_np.shape[0]), [mu_constr[1], sigma_constr[1]])])
+                         (np.random.normal(loc=1., scale=0.2, size=test_values_np.shape[0]),
+                         [mu_constr[1], sigma_constr[1]])])
 def test_unbinned_nll(weights, sigma):
     gaussian1, mu1, sigma1 = create_gauss1()
     gaussian2, mu2, sigma2 = create_gauss2()

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -51,8 +51,7 @@ obs1 = 'obs1'
 
 mu_constr = [1.6, 0.2]  # mu, sigma
 sigma_constr = [3.8, 0.2]
-
-covariance = np.array([[mu_constr[1]**0.5, 0.2], [0.2, sigma_constr[1]**0.5]])
+covariance = np.array([[mu_constr[1]**0.5, -0.05], [-0.05, sigma_constr[1]**0.5]])
 
 
 def create_gauss1():

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -12,7 +12,8 @@ def nll_gaussian(params, mu, sigma):
     Args:
         params (list(zfit.Parameter)): The parameters to constraint
         mu (float, list(float) or numpy array): The central value of the constraint
-        sigma (float, list(float) or numpy array): The standard deviations of correlations matrix of the constraint
+        sigma (float, list(float) or numpy array): The standard deviations of correlations matrix of the 
+        constraint
     Returns:
         graph: the nll of the constraint
     Raises:
@@ -28,9 +29,9 @@ def nll_gaussian(params, mu, sigma):
     isnumber = isinstance(sigma, (float, int))
 
     if iscontainer or is1darray:
-        covariance = np.diag(sigma)
+        covariance = np.diag(np.power(sigma, 2.))
     elif isnumber:
-        covariance = np.diag([sigma])
+        covariance = np.diag([sigma**2])
 
     covariance = ztf.convert_to_tensor(covariance)
 

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -12,7 +12,7 @@ def nll_gaussian(params, mu, sigma):
     Args:
         params (list(zfit.Parameter)): The parameters to constraint
         mu (float, list(float) or numpy array): The central value of the constraint
-        sigma (float, list(float) or numpy array): The standard deviations of correlations matrix of the 
+        sigma (float, list(float) or numpy array): The standard deviations or covariance matrix of the 
         constraint
     Returns:
         graph: the nll of the constraint

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -5,6 +5,7 @@ from .util import ztyping
 from .util.container import convert_to_container
 from zfit import ztf
 import tensorflow as tf
+import numpy as np
 
 __all__ = ["nll_gaussian"]
 
@@ -15,17 +16,17 @@ def nll_gaussian(params: ztyping.ParamTypeInput, mu: ztyping.NumericalScalarType
 
     Args:
         params (list(zfit.Parameter)): The parameters to constraint
-        mu (float, list(float) or numpy array): The central value of the constraint
-        sigma (float, list(float), numpy array or a tensor): The standard deviations or covariance
-        matrix of the constraint
+        mu (numerical, list(numerical)): The central value of the constraint
+        sigma (numerical, list(numerical) or array/tensor): The standard deviations or covariance
+            matrix of the constraint. Can either be a single value or
     Returns:
-        graph: the nll of the constraint
+        `tf.Tensor`: the nll of the constraint
     Raises:
         ShapeIncompatibleError: if params, mu and sigma don't have the same size
     """
 
     params = convert_to_container(params, tuple)
-    mu = convert_to_container(mu, tuple)
+    mu = convert_to_container(mu, container=tuple, non_containers=[np.ndarray])
 
     params = ztf.convert_to_tensor(params)
     mu = ztf.convert_to_tensor(mu)
@@ -34,9 +35,9 @@ def nll_gaussian(params: ztyping.ParamTypeInput, mu: ztyping.NumericalScalarType
     def covfunc(s):
         return tf.diag(ztf.pow(s, 2.))
 
-    if len(sigma.shape) > 1:
+    if sigma.shape.ndims > 1:
         covariance = sigma
-    elif len(sigma.shape) == 1:
+    elif sigma.shape.ndims == 1:
         covariance = covfunc(sigma)
     else:
         sigma = tf.reshape(sigma, [1])

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -5,7 +5,8 @@ import tensorflow as tf
 
 __all__ = ["nll_gaussian"]
 
-#def nll_gaussian(params, mu, sigma):
+
+# def nll_gaussian(params, mu, sigma):
 #    params = convert_to_container(params, container=tuple)
 #    mu = convert_to_container(mu, container=tuple)
 #    sigma = convert_to_container(sigma, container=tuple)
@@ -18,10 +19,11 @@ __all__ = ["nll_gaussian"]
 #        constraint += ztf.reduce_sum(ztf.square(param - mean) / (2. * ztf.square(sig)))
 #
 #    return constraint
-    
+
+
 def nll_gaussian(params, mu, sigma):
     """Return negative log likelihood graph for gaussian constraints on a list of parameters.
-    
+
     Args:
         params (list(zfit.Parameter)): The parameters to constraint
         mu (float, list(float) or numpy array): The central value of the constraint
@@ -31,33 +33,33 @@ def nll_gaussian(params, mu, sigma):
     Raises:
         ValueError: if params, mu and sigma don't have the same size
     """
-    
+
     params = convert_to_container(params, tuple)
     mu = convert_to_container(mu, tuple)
-    
+
     iscontainer = isinstance(sigma, (list, tuple))
     isarray = isinstance(sigma, (np.ndarray))
     is1darray = isarray and sigma.ndim == 1
-    isnumber = lambda x: isinstance(x, (float, int))
-    
+    isnumber = isinstance(sigma, (float, int))
+
     if iscontainer or is1darray:
         covariance = np.diag(sigma)
-    elif isnumber(sigma):
+    elif isnumber:
         covariance = np.diag([sigma])
-        
+
     covariance = ztf.convert_to_tensor(covariance)
-                
+
     if not len(params) == len(mu) == covariance.shape[0] == covariance.shape[1]:
         raise ValueError("params, mu and sigma have to have the same length.")
-        
+
     params = ztf.convert_to_tensor(params)
     mu = ztf.convert_to_tensor(mu)
-        
-    X = (params - mu)
-    Xt = tf.transpose(X)
 
-    constraint = tf.tensordot(tf.linalg.inv(covariance), X, 1)
-    constraint = 0.5 * tf.tensordot(Xt, constraint, 1)
+    x = (params - mu)
+    xt = tf.transpose(x)
+
+    constraint = tf.tensordot(tf.linalg.inv(covariance), x, 1)
+    constraint = 0.5 * tf.tensordot(xt, constraint, 1)
 
     return constraint
 

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -32,6 +32,8 @@ def nll_gaussian(params, mu, sigma):
         covariance = np.diag(np.power(sigma, 2.))
     elif isnumber:
         covariance = np.diag([sigma**2])
+    else:
+        covariance = sigma
 
     covariance = ztf.convert_to_tensor(covariance)
 

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -1,7 +1,5 @@
-import zfit
 from zfit import ztf
 from .util.container import convert_to_container
-import numpy as np
 import tensorflow as tf
 
 __all__ = ["nll_gaussian"]
@@ -13,8 +11,8 @@ def nll_gaussian(params, mu, sigma):
     Args:
         params (list(zfit.Parameter)): The parameters to constraint
         mu (float, list(float) or numpy array): The central value of the constraint
-        sigma (float, list(float), numpy array or a tensor): The standard deviations or covariance matrix of the 
-        constraint
+        sigma (float, list(float), numpy array or a tensor): The standard deviations or covariance
+        matrix of the constraint
     Returns:
         graph: the nll of the constraint
     Raises:
@@ -24,17 +22,18 @@ def nll_gaussian(params, mu, sigma):
     params = convert_to_container(params, tuple)
     mu = convert_to_container(mu, tuple)
     sigma = ztf.convert_to_tensor(sigma)
-    
-    covfunc = lambda s: tf.diag(ztf.pow(s, 2.))
-    
-    if len(sigma.shape) == 0:
-        sigma = tf.reshape(sigma, [1])
-        covariance = covfunc(sigma)
+
+    def covfunc(s):
+        return tf.diag(ztf.pow(s, 2.))
+
+    if len(sigma.shape) > 1:
+        covariance = sigma
     elif len(sigma.shape) == 1:
         covariance = covfunc(sigma)
     else:
-        covariance = sigma
-    
+        sigma = tf.reshape(sigma, [1])
+        covariance = covfunc(sigma)
+
     if not len(params) == len(mu) == covariance.shape[0] == covariance.shape[1]:
         raise ValueError("params, mu and sigma have to have the same length.")
 

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -42,7 +42,7 @@ def nll_gaussian(params, mu, sigma):
 
     x = (params - mu)
     xt = tf.transpose(x)
-    
+
     constraint = tf.tensordot(tf.linalg.inv(covariance), x, 1)
     constraint = 0.5 * tf.tensordot(xt, constraint, 1)
 

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -6,21 +6,6 @@ import tensorflow as tf
 __all__ = ["nll_gaussian"]
 
 
-# def nll_gaussian(params, mu, sigma):
-#    params = convert_to_container(params, container=tuple)
-#    mu = convert_to_container(mu, container=tuple)
-#    sigma = convert_to_container(sigma, container=tuple)
-#    constraint = ztf.constant(0.)
-#    if not len(params) == len(mu) == len(sigma):
-#        raise ValueError("params, mu and sigma have to have the same length.")
-#    for param, mean, sig in zip(params, mu, sigma):
-#        mean = ztf.convert_to_tensor(mean)
-#        sig = ztf.convert_to_tensor(sig)
-#        constraint += ztf.reduce_sum(ztf.square(param - mean) / (2. * ztf.square(sig)))
-#
-#    return constraint
-
-
 def nll_gaussian(params, mu, sigma):
     """Return negative log likelihood graph for gaussian constraints on a list of parameters.
 

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -1,19 +1,63 @@
 from zfit import ztf
 from .util.container import convert_to_container
+import numpy as np
+import tensorflow as tf
 
 __all__ = ["nll_gaussian"]
 
+#def nll_gaussian(params, mu, sigma):
+#    params = convert_to_container(params, container=tuple)
+#    mu = convert_to_container(mu, container=tuple)
+#    sigma = convert_to_container(sigma, container=tuple)
+#    constraint = ztf.constant(0.)
+#    if not len(params) == len(mu) == len(sigma):
+#        raise ValueError("params, mu and sigma have to have the same length.")
+#    for param, mean, sig in zip(params, mu, sigma):
+#        mean = ztf.convert_to_tensor(mean)
+#        sig = ztf.convert_to_tensor(sig)
+#        constraint += ztf.reduce_sum(ztf.square(param - mean) / (2. * ztf.square(sig)))
+#
+#    return constraint
+    
 def nll_gaussian(params, mu, sigma):
-    params = convert_to_container(params, container=tuple)
-    mu = convert_to_container(mu, container=tuple)
-    sigma = convert_to_container(sigma, container=tuple)
-    constraint = ztf.constant(0.)
-    if not len(params) == len(mu) == len(sigma):
+    """Return negative log likelihood graph for gaussian constraints on a list of parameters.
+    
+    Args:
+        params (list(zfit.Parameter)): The parameters to constraint
+        mu (float, list(float) or numpy array): The central value of the constraint
+        sigma (float, list(float) or numpy array): The standard deviations of correlations matrix of the constraint
+    Returns:
+        graph: the nll of the constraint
+    Raises:
+        ValueError: if params, mu and sigma don't have the same size
+    """
+    
+    params = convert_to_container(params, tuple)
+    mu = convert_to_container(mu, tuple)
+    
+    iscontainer = isinstance(sigma, (list, tuple))
+    isarray = isinstance(sigma, (np.ndarray))
+    is1darray = isarray and sigma.ndim == 1
+    isnumber = lambda x: isinstance(x, (float, int))
+    
+    if iscontainer or is1darray:
+        covariance = np.diag(sigma)
+    elif isnumber(sigma):
+        covariance = np.diag([sigma])
+        
+    covariance = ztf.convert_to_tensor(covariance)
+                
+    if not len(params) == len(mu) == covariance.shape[0] == covariance.shape[1]:
         raise ValueError("params, mu and sigma have to have the same length.")
-    for param, mean, sig in zip(params, mu, sigma):
-        mean = ztf.convert_to_tensor(mean)
-        sig = ztf.convert_to_tensor(sig)
-        constraint += ztf.reduce_sum(ztf.square(param - mean) / (2. * ztf.square(sig)))
+        
+    params = ztf.convert_to_tensor(params)
+    mu = ztf.convert_to_tensor(mu)
+        
+    X = (params - mu)
+    Xt = tf.transpose(X)
+
+    constraint = tf.tensordot(tf.linalg.inv(covariance), X, 1)
+    constraint = 0.5 * tf.tensordot(Xt, constraint, 1)
 
     return constraint
 

--- a/zfit/ztf/__init__.py
+++ b/zfit/ztf/__init__.py
@@ -40,5 +40,5 @@ Some function are already wrapped, others are not. Best practice is to use `ztf`
 from .zextension import (to_complex, to_real, constant, inf, pi, abs_square, nth_pow, unstack_x, stack_x, safe_where,
                          run_no_nan, )
 from .wrapping_tf import (log, exp, random_normal, random_uniform, convert_to_tensor, reduce_sum, reduce_prod, square,
-                          sqrt, complex, check_numerics)
+                          sqrt, complex, check_numerics, pow)
 from . import random

--- a/zfit/ztf/wrapping_tf.py
+++ b/zfit/ztf/wrapping_tf.py
@@ -42,7 +42,7 @@ def square(x, name=None):
 def sqrt(x, name=None):
     return _auto_upcast(tf.sqrt(x, name=name))
     
-    
+
 def pow(x, y, name=None):
     return _auto_upcast(tf.pow(x, y, name=name))
 

--- a/zfit/ztf/wrapping_tf.py
+++ b/zfit/ztf/wrapping_tf.py
@@ -41,6 +41,10 @@ def square(x, name=None):
 
 def sqrt(x, name=None):
     return _auto_upcast(tf.sqrt(x, name=name))
+    
+    
+def pow(x, y, name=None):
+    return _auto_upcast(tf.pow(x, y, name=name))
 
 
 def complex(real, imag, name=None):

--- a/zfit/ztf/wrapping_tf.py
+++ b/zfit/ztf/wrapping_tf.py
@@ -41,7 +41,7 @@ def square(x, name=None):
 
 def sqrt(x, name=None):
     return _auto_upcast(tf.sqrt(x, name=name))
-    
+
 
 def pow(x, y, name=None):
     return _auto_upcast(tf.pow(x, y, name=name))


### PR DESCRIPTION
nll_gaussian can now take as input for the `sigma` argument either a list of standard deviations or a covariance matrix.

## Tests added

None, already implemented tests are working.
