### PR TITLE
Add new constraint classes

### DIFF
--- a/docs/loss.rst
+++ b/docs/loss.rst
@@ -28,7 +28,7 @@ Constraints (or, in general, penalty terms) can be added to the loss function ei
 These constraints are specified as a list of penalty terms, which can be any object inheriting from :py:class:`~zfit.core.constraint.BaseConstraint` that is simply added to the calculation of the loss.
 
 Useful implementations of penalties can be found in the :py:mod:`zfit.constraint` module.
-For example, if we wanted to add adding a gaussian constraint on the ``mu`` parameter of the previous model, we would write:
+For example, if we wanted to add a gaussian constraint on the ``mu`` parameter of the previous model, we would write:
 
 .. code-block:: pycon
 

--- a/docs/loss.rst
+++ b/docs/loss.rst
@@ -4,14 +4,14 @@
 Loss
 ====
 
-A *loss function* can be defined as a measurement of the discrepancy between the observed data and the predicted data by the fitted function. 
-To some extent it can be visualised as a metric of the goodness of a given prediction as you change the settings of your algorithm. 
-For example, in a general linear model the loss function is essentially the sum of squared deviations from the fitted line or plane. 
+A *loss function* can be defined as a measurement of the discrepancy between the observed data and the predicted data by the fitted function.
+To some extent it can be visualised as a metric of the goodness of a given prediction as you change the settings of your algorithm.
+For example, in a general linear model the loss function is essentially the sum of squared deviations from the fitted line or plane.
 A more useful application in the context of High Energy Physics (HEP) is the Maximum Likelihood Estimator (MLE).
-The MLE is a specific type of probability model estimation, where the loss function is the negative log-likelihood (NLL). 
+The MLE is a specific type of probability model estimation, where the loss function is the negative log-likelihood (NLL).
 
-In zfit, loss functions inherit from the :py:class:`~zfit.core.loss.BaseLoss` class and they follow a common interface, in which the model, 
-the dataset and the fit range (which internally sets ``norm_range`` in the PDF and makes sure data only within that range are used) **must** be given, and 
+In zfit, loss functions inherit from the :py:class:`~zfit.core.loss.BaseLoss` class and they follow a common interface, in which the model,
+the dataset and the fit range (which internally sets ``norm_range`` in the PDF and makes sure data only within that range are used) **must** be given, and
 where parameter constraints in form of a dictionary `{param: constraint}` **may** be given.
 As an example, we can create an unbinned negative log-likelihood loss (:py:class:`~zfit.core.loss.UnbinnedNLL`) from the model described in the :ref:`Basic model section <basic-model>` and the data from the :ref:`Data section <data-section>`:
 
@@ -25,19 +25,19 @@ Adding constraints
 ------------------
 
 Constraints (or, in general, penalty terms) can be added to the loss function either by using the ``constraints`` keyword when creating the loss object or by using the :py:func:`~zfit.core.loss.BaseLoss.add_constraints` method.
-These constraints are specified as a list of penalty terms, which can be any ``tf.Tensor`` object that is simply added to the calculation of the loss.
+These constraints are specified as a list of penalty terms, which can be any object inheriting from :py:class:`~zfit.core.constraint.BaseConstraint` that is simply added to the calculation of the loss.
 
 Useful implementations of penalties can be found in the :py:mod:`zfit.constraint` module.
-For example, if we wanted to add adding a gaussian constraint on the ``mu`` parameter of the previous model, we would write: 
+For example, if we wanted to add adding a gaussian constraint on the ``mu`` parameter of the previous model, we would write:
 
 .. code-block:: pycon
 
     >>> my_loss = zfit.loss.UnbinnedNLL(model_cb,
     >>>                                 data,
     >>>                                 fit_range=(-10, 10),
-    >>>                                 constraints=zfit.constraint.nll_gaussian(params=mu,
-    >>>                                                                          mu=5279.,
-    >>>                                                                          sigma=10.))
+    >>>                                 constraints=zfit.constraint.GaussianConstraint(params=mu,
+    >>>                                                                                mu=5279.,
+    >>>                                                                                sigma=10.))
 
 
 Simultaneous fits
@@ -45,11 +45,11 @@ Simultaneous fits
 
 There are currently two loss functions implementations in the ``zfit`` library, the :py:class:`~zfit.core.loss.UnbinnedNLL` and :py:class:`~zfit.core.loss.ExtendedUnbinnedNLL` classes, which cover non-extended and extended negative log-likelihoods.
 
-A very common use case likelihood fits in HEP is the possibility to examine simultaneously different datasets (that can be independent or somehow correlated). 
+A very common use case likelihood fits in HEP is the possibility to examine simultaneously different datasets (that can be independent or somehow correlated).
 To build loss functions for simultaneous fits, the addition operator can be used (the particular combination that is performed depends on the type of loss function):
 
 .. code-block:: pycon
- 
+
    >>> models = [model1, model2]
    >>> datasets = [data1, data2]
    >>> my_loss1 = zfit.loss.UnbinnedNLL(models[0], datasets[0], fit_range=(-10, 10))
@@ -59,7 +59,6 @@ To build loss functions for simultaneous fits, the addition operator can be used
 The same result can be achieved by passing a list of PDFs on instantiation, along with the same number of datasets and fit ranges:
 
 .. code-block:: pycon
- 
+
    >>> # Adding a list of models, data and observable ranges
    >>> my_loss_sim = zfit.loss.UnbinnedNLL(model=[models], data=[datasets], fit_range=[obsRange])
-

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -289,15 +289,28 @@ using the following argument. Reusing the example above
 .. code:: pycon
 
     >>> sigma.set_value(np.random.normal())
-    >>> sampler.resample(param_values={sigma: 5)
+    >>> sampler.resample(param_values={sigma1: 5})
 
-The sample (and therefore also the sample the `nll` depends on) is now sampled with `sigma` set to 5.
+The sample (and therefore also the sample the `nll` depends on) is now sampled with `sigma1` set to 5.
 
+If some parameters are constrained from external measurements, usually Gaussian constraints, then sampling of
+those parameters might be needed to obtain an unbiased sample from the model. Example:
 
+.. code:: pycon
 
+    >>> # same model depending on mu1, sigma1, mu2, sigma2
 
+    >>> constraint = zfit.constraint.GaussianConstraint(params=[sigma1, sigma2], mu=[1.0, 0.5], sigma=[0.1, 0.05])
 
+    >>> sampler = model.create_sampler(n=1000, fixed_params=[mu1, mu2])
+    >>> nll = zfit.loss.UnbinnedNLL(model=model, data=sampler, constraints=constraint)
 
+    >>> n_samples = 1000
+    >>> constr_values = constraint.sample(n=n_toys)
 
-
-
+    >>> for i in range(n_samples):
+    >>>     sigma1_i = constr_values[sigma1][i]
+    >>>     sigma2_i = constr_values[sigma2][i]
+    >>>     sampler.resample(param_values={sigma1: sigma1_i, sigma2: sigma2_i})
+    >>>     # do something with nll
+    >>>     minimizer.minimize(nll)  # minimize

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -6,7 +6,7 @@ import zfit
 from zfit import ztf
 from zfit.core.testing import setup_function, teardown_function, tester
 from zfit.util.exception import ShapeIncompatibleError
-from zfit.constraint import SimpleConstraint, GaussianConstraint
+from zfit.core.constraint import BaseConstraint, SimpleConstraint, GaussianConstraint
 from zfit.util.container import convert_to_container
 
 
@@ -23,7 +23,13 @@ def nll_gaussian(params, mu, sigma):
     return constraint
 
 
-def test_shape_errors():
+def test_base_constraint():
+    constr = BaseConstraint()
+    with pytest.raises(NotImplementedError):
+        constr.value()
+
+
+def test_gaussian_constraint_shape_errors():
     param1 = zfit.Parameter("Param1", 5)
     param2 = zfit.Parameter("Param2", 6)
 
@@ -37,7 +43,7 @@ def test_shape_errors():
         GaussianConstraint(param1, mu=[4, 2], sigma=[2, 3])
 
 
-def test_gaussian_constraint_value():
+def test_gaussian_constraint():
     param1 = zfit.Parameter("Param1", 5)
     param2 = zfit.Parameter("Param2", 6)
     params = [param1, param2]
@@ -48,6 +54,8 @@ def test_gaussian_constraint_value():
     constr = GaussianConstraint(params=params, mu=mu, sigma=sigma)
     constr_np = zfit.run(constr.value())
     assert constr_np == pytest.approx(3.989638)
+
+    assert constr.get_dependents() == set(params)
 
 
 def test_GaussianConstraint_sampling():
@@ -79,3 +87,5 @@ def test_simple_constraint():
 
     constr_np = zfit.run(constr.value())
     assert constr_np == pytest.approx(2.02)
+
+    assert constr.get_dependents() == set(params)

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -8,6 +8,8 @@ from zfit.core.testing import setup_function, teardown_function, tester
 from zfit.util.exception import ShapeIncompatibleError
 from zfit.core.constraint import BaseConstraint, SimpleConstraint, GaussianConstraint
 from zfit.util.container import convert_to_container
+import tensorflow_probability as tfp
+poisson = tfp.distributions.poisson
 
 
 def nll_gaussian(params, mu, sigma):

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -60,8 +60,8 @@ def test_GaussianConstraint_sampling():
 
     sample = zfit.run(constr.sample(15000))
 
-    assert np.mean(sample[param1]) == pytest.approx(5, rel=0.01)
-    assert np.std(sample[param1]) == pytest.approx(1, rel=0.01)
+    assert np.mean(sample[param1]) == pytest.approx(mu[0], rel=0.01)
+    assert np.std(sample[param1]) == pytest.approx(sigma[0], rel=0.01)
 
 
 def test_simple_constraint():

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -8,8 +8,6 @@ from zfit.core.testing import setup_function, teardown_function, tester
 from zfit.util.exception import ShapeIncompatibleError
 from zfit.core.constraint import BaseConstraint, SimpleConstraint, GaussianConstraint
 from zfit.util.container import convert_to_container
-import tensorflow_probability as tfp
-poisson = tfp.distributions.poisson
 
 
 def nll_gaussian(params, mu, sigma):

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -10,7 +10,7 @@ from zfit.core.constraint import BaseConstraint, SimpleConstraint, GaussianConst
 from zfit.util.container import convert_to_container
 
 
-def nll_gaussian(params, mu, sigma):
+def true_nll_gaussian(params, mu, sigma):
     params = convert_to_container(params, container=tuple)
     mu = convert_to_container(mu, container=tuple)
     sigma = convert_to_container(sigma, container=tuple)
@@ -82,7 +82,7 @@ def test_simple_constraint():
     sigma = [1., 0.5]
 
     def func():
-        return nll_gaussian(params=params, mu=mu, sigma=sigma)
+        return true_nll_gaussian(params=params, mu=mu, sigma=sigma)
     constr = SimpleConstraint(func=func)
 
     constr_np = zfit.run(constr.value())

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -66,7 +66,7 @@ def test_GaussianConstraint_sampling():
     sigma = [1]
     constr = GaussianConstraint(params=params, mu=mu, sigma=sigma)
 
-    sample = zfit.run(constr.sample(15000))
+    sample = constr.sample(15000)
 
     assert np.mean(sample[param1]) == pytest.approx(mu[0], rel=0.01)
     assert np.std(sample[param1]) == pytest.approx(sigma[0], rel=0.01)

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -58,7 +58,8 @@ def test_gaussian_constraint():
     assert constr.get_dependents() == set(params)
 
 
-def test_GaussianConstraint_sampling():
+@pytest.mark.flaky(3)
+def test_gaussian_constraint_sampling():
     param1 = zfit.Parameter("Param1", 5)
     params = [param1]
 

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -15,7 +15,6 @@ import zfit.settings
 from zfit.core.loss import _unbinned_nll_tf, UnbinnedNLL
 from zfit.util.exception import IntentionNotUnambiguousError
 from zfit.core.testing import setup_function, teardown_function, tester
-from zfit.core.constraint import BaseConstraint, SimpleConstraint
 
 mu_true = 1.2
 sigma_true = 4.1

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -15,6 +15,7 @@ import zfit.settings
 from zfit.core.loss import _unbinned_nll_tf, UnbinnedNLL
 from zfit.util.exception import IntentionNotUnambiguousError
 from zfit.core.testing import setup_function, teardown_function, tester
+from zfit.core.constraint import BaseConstraint, SimpleConstraint
 
 mu_true = 1.2
 sigma_true = 4.1
@@ -167,6 +168,7 @@ def test_add():
     constraint1 = zfit.constraint.nll_gaussian(params=param1, mu=1, sigma=0.5)
     constraint2 = zfit.constraint.nll_gaussian(params=param1, mu=2, sigma=0.25)
     merged_contraints = [constraint1, constraint2]
+    # merged_contraints = [SimpleConstraint(lambda: constraint1), SimpleConstraint(lambda: constraint2)]
 
     nll1 = UnbinnedNLL(model=pdfs[0], data=datas[0], fit_range=ranges[0], constraints=constraint1)
     nll2 = UnbinnedNLL(model=pdfs[1], data=datas[1], fit_range=ranges[1], constraints=constraint2)
@@ -185,7 +187,8 @@ def test_add():
 
     assert simult_nll.fit_range == ranges
 
-    assert simult_nll.constraints == merged_contraints
+    funcs = [c._simple_func() for c in simult_nll.constraints]
+    assert funcs == merged_contraints
 
 
 @pytest.mark.parametrize("chunksize", [10000000, 1000])

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -168,7 +168,6 @@ def test_add():
     constraint1 = zfit.constraint.nll_gaussian(params=param1, mu=1, sigma=0.5)
     constraint2 = zfit.constraint.nll_gaussian(params=param1, mu=2, sigma=0.25)
     merged_contraints = [constraint1, constraint2]
-    # merged_contraints = [SimpleConstraint(lambda: constraint1), SimpleConstraint(lambda: constraint2)]
 
     nll1 = UnbinnedNLL(model=pdfs[0], data=datas[0], fit_range=ranges[0], constraints=constraint1)
     nll2 = UnbinnedNLL(model=pdfs[1], data=datas[1], fit_range=ranges[1], constraints=constraint2)
@@ -187,8 +186,10 @@ def test_add():
 
     assert simult_nll.fit_range == ranges
 
-    funcs = [c._simple_func() for c in simult_nll.constraints]
-    assert funcs == merged_contraints
+    def eval_constraint(constraints):
+        return zfit.run(ztf.reduce_sum([c.value() for c in constraints]))
+
+    assert eval_constraint(simult_nll.constraints) == eval_constraint(merged_contraints)
 
 
 @pytest.mark.parametrize("chunksize", [10000000, 1000])

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -15,9 +15,9 @@ def nll_gaussian(params: ztyping.ParamTypeInput, mu: ztyping.NumericalScalarType
         params (list(zfit.Parameter)): The parameters to constraint
         mu (numerical, list(numerical)): The central value of the constraint
         sigma (numerical, list(numerical) or array/tensor): The standard deviations or covariance
-            matrix of the constraint. Can either be a single value or
+            matrix of the constraint. Can either be a single value, a list of values, an array or a tensor
     Returns:
-        `tf.Tensor`: the nll of the constraint
+        `GaussianConstraint`: the constraint object
     Raises:
         ShapeIncompatibleError: if params, mu and sigma don't have the same size
     """

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -3,11 +3,13 @@
 from .util.exception import ShapeIncompatibleError
 from .util import ztyping
 from .util.container import convert_to_container
+from .core.constraint import SimpleConstraint, GaussianConstraint
 from zfit import ztf
 import tensorflow as tf
 import numpy as np
+import warnings
 
-__all__ = ["nll_gaussian"]
+__all__ = ["nll_gaussian", "SimpleConstraint", "GaussianConstraint"]
 
 
 def nll_gaussian(params: ztyping.ParamTypeInput, mu: ztyping.NumericalScalarType,
@@ -24,6 +26,8 @@ def nll_gaussian(params: ztyping.ParamTypeInput, mu: ztyping.NumericalScalarType
     Raises:
         ShapeIncompatibleError: if params, mu and sigma don't have the same size
     """
+
+    warnings.warn("Please use `GaussianConstraint instead", DeprecationWarning)
 
     params = convert_to_container(params, tuple)
     mu = convert_to_container(mu, container=tuple, non_containers=[np.ndarray])
@@ -54,7 +58,7 @@ def nll_gaussian(params: ztyping.ParamTypeInput, mu: ztyping.NumericalScalarType
     constraint = tf.tensordot(tf.linalg.inv(covariance), x, 1)
     constraint = 0.5 * tf.tensordot(xt, constraint, 1)
 
-    return constraint
+    return SimpleConstraint(lambda: constraint)
 
 # def nll_pdf(constraints: dict):
 #     if not constraints:

--- a/zfit/core/constraint.py
+++ b/zfit/core/constraint.py
@@ -98,7 +98,7 @@ class DistributionConstraint(BaseConstraint):
         super().__init__(params=params, name=name, dtype=dtype, **kwargs)
 
         self._distribution = distribution
-        self.dist_params = dist_params
+        self.dist_params = dist_params if dist_params is not None else {}
         self.dist_kwargs = dist_kwargs
         self._tparams = ztf.convert_to_tensor(self.get_params())
 
@@ -129,6 +129,7 @@ class DistributionConstraint(BaseConstraint):
         return {p: sample[:, i] for i, p in enumerate(self.get_params())}
 
     def _sample(self, n):
+        # TODO cache: add proper caching
         return zfit.run(self.distribution.sample(n))
 
 

--- a/zfit/core/constraint.py
+++ b/zfit/core/constraint.py
@@ -98,8 +98,8 @@ class DistributionConstraint(BaseConstraint):
         super().__init__(params=params, name=name, dtype=dtype, **kwargs)
 
         self._distribution = distribution
-        self.dist_params = dist_params if dist_params is not None else {}
-        self.dist_kwargs = dist_kwargs
+        self.dist_params = dist_params
+        self.dist_kwargs = dist_kwargs if dist_kwargs is not None else {}
         self._tparams = ztf.convert_to_tensor(self.get_params())
 
     @property

--- a/zfit/core/constraint.py
+++ b/zfit/core/constraint.py
@@ -19,12 +19,11 @@ tfd = tfp.distributions
 
 
 class BaseConstraint(BaseNumeric):
-    """ Base class for constraints."""
 
     def __init__(self, params: Union[Dict[str, ZfitParameter]] = None,
                  name: str = "BaseConstraint", dtype=ztypes.float,
                  **kwargs):
-        """The base model to inherit from and overwrite `_unnormalized_pdf`.
+        """Base class for constraints.
 
         Args:
             dtype (DType): the dtype of the constraint

--- a/zfit/core/constraint.py
+++ b/zfit/core/constraint.py
@@ -2,19 +2,19 @@ import abc
 
 from typing import Dict, Union, Callable, Optional
 
-from .core.baseobject import BaseNumeric
-from .core.interfaces import ZfitParameter
-from .util import ztyping
-from .util.graph import get_dependents_auto
-from .util.container import convert_to_container
-from .util.exception import ShapeIncompatibleError
+from .baseobject import BaseNumeric
+from .interfaces import ZfitParameter
+from ..util import ztyping
+from ..util.graph import get_dependents_auto
+from ..util.container import convert_to_container
+from ..util.exception import ShapeIncompatibleError
 from ..settings import ztypes
 from zfit import ztf
 
 import tensorflow as tf
 import numpy as np
-import tensorflow_probability.distributions as tfd
-mvnfc = tfd.MultivariateNormalFullCovariance
+import tensorflow_probability as tfp
+mvnfc = tfp.distributions.MultivariateNormalFullCovariance
 
 
 class BaseConstraint(BaseNumeric):
@@ -57,7 +57,9 @@ class SimpleConstraint(BaseConstraint):
         self._simple_func = func
         self._simple_func_dependents = convert_to_container(params, container=set)
         if params is None:
-            params = convert_to_container(self.get_dependents(), container=list)
+            params = self.get_dependents()
+
+        params = convert_to_container(params, container=list)
         params = {p.name: p for p in params}
 
         super().__init__(name="SimpleConstraint", params=params)

--- a/zfit/core/constraint.py
+++ b/zfit/core/constraint.py
@@ -39,11 +39,11 @@ class BaseConstraint(BaseNumeric):
         except NotImplementedError:
             raise NotImplementedError("_eval not properly defined!")
 
-    def sample(self):
-        return self._sample
+    def sample(self, n=1):
+        return self._sample(n=n)
 
     @abc.abstractmethod
-    def _sample(self):
+    def _sample(self, n):
         raise NotImplementedError()
 
     def _get_dependents(self) -> ztyping.DependentsType:
@@ -111,6 +111,6 @@ class GaussianConstraint(BaseConstraint):
         value = -self._dist.log_prob(self._tparams)
         return value
 
-    def _sample(self):
-        sample = self._dist.sample()
-        return {p: sample[i] for i, p in enumerate(self.get_params())}
+    def _sample(self, n):
+        sample = self._dist.sample(n)
+        return {p: sample[:, i] for i, p in enumerate(self.get_params())}

--- a/zfit/core/constraint.py
+++ b/zfit/core/constraint.py
@@ -32,7 +32,6 @@ class BaseConstraint(BaseNumeric):
             params (Dict(str, :py:class:`~zfit.Parameter`)): A dictionary with the internal name of the
                 parameter and the parameters itself the constrains depends on
         """
-
         super().__init__(name=name, dtype=dtype, params=params, **kwargs)
 
     def value(self):
@@ -59,7 +58,6 @@ class SimpleConstraint(BaseConstraint):
             dependents: The dependents (independent `zfit.Parameter`) of the loss. If not given, the
                 dependents are figured out automatically.
         """
-
         self._simple_func = func
         self._simple_func_dependents = convert_to_container(params, container=set)
         if params is None:
@@ -94,7 +92,6 @@ class DistributionConstraint(BaseConstraint):
                 used to constraint the parameters
 
         """
-
         super().__init__(params=params, name=name, dtype=dtype, **kwargs)
 
         self._distribution = distribution
@@ -119,10 +116,10 @@ class DistributionConstraint(BaseConstraint):
     def sample(self, n: ztyping.nSamplingTypeIn = 1) -> Dict:
         """Sample `n` points from the probability density function for the constrained parameters.
 
-            Args:
-                n (int, tf.Tensor): The number of samples to be generated.
-            Returns:
-                Dict(Parameter: n_samples)
+        Args:
+            n (int, tf.Tensor): The number of samples to be generated.
+        Returns:
+            Dict(Parameter: n_samples)
 
         """
         sample = self._sample(n=n)
@@ -148,7 +145,6 @@ class GaussianConstraint(DistributionConstraint):
         Raises:
             ShapeIncompatibleError: if params, mu and sigma don't have the same size
         """
-
         mu = convert_to_container(mu, tuple, non_containers=[np.ndarray])
         params = convert_to_container(params, tuple)
 

--- a/zfit/core/constraint.py
+++ b/zfit/core/constraint.py
@@ -1,0 +1,114 @@
+import abc
+
+from typing import Dict, Union, Callable, Optional
+
+from .core.baseobject import BaseNumeric
+from .core.interfaces import ZfitParameter
+from .util import ztyping
+from .util.graph import get_dependents_auto
+from .util.container import convert_to_container
+from .util.exception import ShapeIncompatibleError
+from ..settings import ztypes
+from zfit import ztf
+
+import tensorflow as tf
+import numpy as np
+import tensorflow_probability.distributions as tfd
+mvnfc = tfd.MultivariateNormalFullCovariance
+
+
+class BaseConstraint(BaseNumeric):
+
+    def __init__(self, params: Union[Dict[str, ZfitParameter], None] = None,
+                 name: str = "BaseModel", dtype=ztypes.float,
+                 **kwargs):
+
+        super().__init__(name=name, dtype=dtype, params=params, **kwargs)
+
+    @abc.abstractmethod
+    def _eval(self):
+        raise NotImplementedError
+
+    def value(self):
+        return self._value()
+
+    def _value(self):
+        try:
+            return self._eval()
+
+        except NotImplementedError:
+            raise NotImplementedError("_eval not properly defined!")
+
+    def sample(self):
+        return self._sample
+
+    @abc.abstractmethod
+    def _sample(self):
+        raise NotImplementedError()
+
+    def _get_dependents(self) -> ztyping.DependentsType:
+        return self._extract_dependents(self.get_params())
+
+
+class SimpleConstraint(BaseConstraint):
+
+    def __init__(self, func: Callable, params: Optional[ztyping.ParametersType] = None):
+
+        self._simple_func = func
+        self._simple_func_dependents = convert_to_container(params, container=set)
+        if params is None:
+            params = convert_to_container(self.get_dependents(), container=list)
+        params = {p.name: p for p in params}
+
+        super().__init__(name="SimpleConstraint", params=params)
+
+    def _get_dependents(self):
+        dependents = self._simple_func_dependents
+        if dependents is None:
+            independent_params = tf.get_collection("zfit_independent")
+            dependents = get_dependents_auto(tensor=self.value(), candidates=independent_params)
+            self._simple_func_dependents = dependents
+        return dependents
+
+    def _eval(self):
+        return self._simple_func()
+
+
+class GaussianConstraint(BaseConstraint):
+
+    def __init__(self, params: ztyping.ParamTypeInput, mu: ztyping.NumericalScalarType,
+                 sigma: ztyping.NumericalScalarType):
+
+        params = convert_to_container(params, tuple)
+        mu = convert_to_container(mu, container=tuple, non_containers=[np.ndarray])
+        super().__init__(name="GaussianConstraint", params={p.name: p for p in params})
+
+        params = ztf.convert_to_tensor(params)
+        mu = ztf.convert_to_tensor(mu)
+        sigma = ztf.convert_to_tensor(sigma)
+
+        if sigma.shape.ndims > 1:
+            covariance = sigma
+        elif sigma.shape.ndims == 1:
+            covariance = tf.diag(ztf.pow(sigma, 2.))
+        else:
+            sigma = tf.reshape(sigma, [1])
+            covariance = tf.diag(ztf.pow(sigma, 2.))
+
+        if not params.shape[0] == mu.shape[0] == covariance.shape[0] == covariance.shape[1]:
+            raise ShapeIncompatibleError(f"params, mu and sigma have to have the same length. Currently"
+                                         f"param: {params.shape[0]}, mu: {mu.shape[0]}, "
+                                         f"covariance (from sigma): {covariance.shape[0:2]}")
+
+        self._covariance = covariance
+        self._mu = mu
+        self._tparams = params
+        self._dist = mvnfc(loc=mu, covariance_matrix=covariance, validate_args=True)
+
+    def _eval(self):
+        value = -self._dist.log_prob(self._tparams)
+        return value
+
+    def _sample(self):
+        sample = self._dist.sample()
+        return {p: sample[i] for i, p in enumerate(self.get_params())}

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -66,8 +66,7 @@ def _constraint_check_convert(constraints):
         if isinstance(constr, BaseConstraint):
             checked_constraints.append(constr)
         else:
-            simple_constr = SimpleConstraint(func=lambda: constr)
-            checked_constraints.append(simple_constr)
+            checked_constraints.append(SimpleConstraint(func=lambda: constr))
     return checked_constraints
 
 

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -16,6 +16,7 @@ from ..models.functions import SimpleFunc
 from ..util.container import convert_to_container, is_container
 from ..util.exception import IntentionNotUnambiguousError, NotExtendedPDFError
 from zfit.settings import ztypes
+from .constraint import BaseConstraint, SimpleConstraint
 
 
 def _unbinned_nll_tf(model: ztyping.PDFInputType, data: ztyping.DataInputType, fit_range: ZfitSpace):
@@ -59,6 +60,19 @@ def _nll_constraints_tf(constraints):
     return constraints_neg_log_prob
 
 
+def _constraint_check(constraints):
+    _constraints = []
+    for c in constraints:
+        print(c, isinstance(c, BaseConstraint))
+        if isinstance(c, BaseConstraint):
+            _constraints.append(c)
+        else:
+            c_ = SimpleConstraint(func=lambda: c)
+            _constraints.append(c_)
+        print(_constraints)
+    return _constraints
+
+
 class BaseLoss(BaseDependentsMixin, ZfitLoss, Cachable, BaseObject):
 
     def __init__(self, model, data, fit_range: ztyping.LimitsTypeInput = None, constraints: List[tf.Tensor] = None):
@@ -84,7 +98,7 @@ class BaseLoss(BaseDependentsMixin, ZfitLoss, Cachable, BaseObject):
         self._fit_range = fit_range
         if constraints is None:
             constraints = []
-        self._constraints = convert_to_container(constraints, list)
+        self._constraints = _constraint_check(convert_to_container(constraints, list))
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -150,7 +164,7 @@ class BaseLoss(BaseDependentsMixin, ZfitLoss, Cachable, BaseObject):
         return self._add_constraints(constraints)
 
     def _add_constraints(self, constraints):
-        constraints = convert_to_container(constraints, container=list)
+        constraints = _constraint_check(convert_to_container(constraints, container=list))
         self._constraints.extend(constraints)
         return constraints
 
@@ -254,12 +268,13 @@ class UnbinnedNLL(CachedLoss):
     def _loss_func(self, model, data, fit_range, constraints):
         nll = _unbinned_nll_tf(model=model, data=data, fit_range=fit_range)
         if constraints:
-            constraints = ztf.reduce_sum(constraints)
+            constraints = ztf.reduce_sum([c.value() for c in constraints])
             nll += constraints
         return nll
 
     def _cache_add_constraints(self, constraints):
         if self._cache.get('loss') is not None:
+            constraints = [c.value() for c in constraints]
             self._cache['loss'] += ztf.reduce_sum(constraints)
 
     @property

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -60,17 +60,15 @@ def _nll_constraints_tf(constraints):
     return constraints_neg_log_prob
 
 
-def _constraint_check(constraints):
-    _constraints = []
-    for c in constraints:
-        print(c, isinstance(c, BaseConstraint))
-        if isinstance(c, BaseConstraint):
-            _constraints.append(c)
+def _constraint_check_convert(constraints):
+    checked_constraints = []
+    for constr in constraints:
+        if isinstance(constr, BaseConstraint):
+            checked_constraints.append(constr)
         else:
-            c_ = SimpleConstraint(func=lambda: c)
-            _constraints.append(c_)
-        print(_constraints)
-    return _constraints
+            simple_constr = SimpleConstraint(func=lambda: constr)
+            checked_constraints.append(simple_constr)
+    return checked_constraints
 
 
 class BaseLoss(BaseDependentsMixin, ZfitLoss, Cachable, BaseObject):
@@ -98,7 +96,7 @@ class BaseLoss(BaseDependentsMixin, ZfitLoss, Cachable, BaseObject):
         self._fit_range = fit_range
         if constraints is None:
             constraints = []
-        self._constraints = _constraint_check(convert_to_container(constraints, list))
+        self._constraints = _constraint_check_convert(convert_to_container(constraints, list))
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -164,7 +162,7 @@ class BaseLoss(BaseDependentsMixin, ZfitLoss, Cachable, BaseObject):
         return self._add_constraints(constraints)
 
     def _add_constraints(self, constraints):
-        constraints = _constraint_check(convert_to_container(constraints, container=list))
+        constraints = _constraint_check_convert(convert_to_container(constraints, container=list))
         self._constraints.extend(constraints)
         return constraints
 


### PR DESCRIPTION
Creation of constraints object

## Proposed Changes

  - Creation of `BaseConstraint` depending only on `BaseNumeric`
  - Creation of `SimpleConstraint` that can take tensor
  - Creation of `DistributionConstraint` that can tfp pdfs, samples of constrained parameters possible
  - Creation of `GaussianConstraint` depending on `DistributionConstraint` 

## Tests added

Modification of tests in `test_loss.py` and `test_constraint`.
