### PR TITLE
Fix resample method when using param_values argument

### DIFF
--- a/docs/loss.rst
+++ b/docs/loss.rst
@@ -43,21 +43,21 @@ Custom penalties can also be added to the loss function, for instance if you wan
 
 .. code-block:: pycon
 
->>> def custom_constraint(param, max_value):
-        return tf.cond(tf.greater_equal(param, max_value), lambda: 10000., lambda: 0.)
+    >>> def custom_constraint(param, max_value):
+            return tf.cond(tf.greater_equal(param, max_value), lambda: 10000., lambda: 0.)
 
 The custom penalty needs to be callable to be added to the loss function
 
 .. code-block:: pycon
 
->>> my_loss.add_constraints(lambda: custom_constraint(mu, 5400))
+    >>> my_loss.add_constraints(lambda: custom_constraint(mu, 5400))
 
 or equivalently
 
 .. code-block:: pycon
 
->>> simple_constraint = zfit.constraint.SimpleConstraint(lambda: custom_constraint(mu, 5400))
->>> my_loss.add_constraints(simple_constraint)
+    >>> simple_constraint = zfit.constraint.SimpleConstraint(lambda: custom_constraint(mu, 5400))
+    >>> my_loss.add_constraints(simple_constraint)
 
 In this example if the value of ``param`` is larger than ``max_value`` a large value is added the loss function
 driving it away from the minimum.

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -311,6 +311,6 @@ those parameters might be needed to obtain an unbiased sample from the model. Ex
 
     >>> for i in range(n_samples):
     >>>     sampler.resample(param_values={sigma1: constr_values[sigma1][i],
-                                           sigma2: constr_values[sigma2][i]})
+    >>>                                    sigma2: constr_values[sigma2][i]})
     >>>     # do something with nll
     >>>     minimizer.minimize(nll)  # minimize

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -98,6 +98,22 @@ def test_sampling_fixed(gauss_factory):
         assert mu_sampled == pytest.approx(mu_true, rel=0.07)
         assert sigma_sampled == pytest.approx(sigma_true, rel=0.07)
 
+    gauss_full_sample2 = gauss.create_sampler(n=10000, limits=(-10, 10))
+
+    gauss_full_sample2.resample(param_values={mu: mu_true-1.0})
+    sampled_gauss2_full = zfit.run(gauss_full_sample2)
+    mu_sampled = np.mean(sampled_gauss2_full)
+    sigma_sampled = np.std(sampled_gauss2_full)
+    assert mu_sampled == pytest.approx(mu_true-1.0, rel=0.07)
+    assert sigma_sampled == pytest.approx(sigma_true, rel=0.07)
+
+    gauss_full_sample2.resample(param_values={sigma: sigma_true+1.0})
+    sampled_gauss2_full = zfit.run(gauss_full_sample2)
+    mu_sampled = np.mean(sampled_gauss2_full)
+    sigma_sampled = np.std(sampled_gauss2_full)
+    assert mu_sampled == pytest.approx(mu_true, rel=0.07)
+    assert sigma_sampled == pytest.approx(sigma_true+1.0, rel=0.07)
+
 
 @pytest.mark.parametrize('gauss_factory', gaussian_dists)
 def test_sampling_floating(gauss_factory):

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -624,8 +624,14 @@ class Sampler(Data):
         temp_param_values = self.fixed_params.copy()
         if param_values is not None:
             temp_param_values.update(param_values)
+
         with ExitStack() as stack:
-            _ = [stack.enter_context(param.set_value(val)) for param, val in self.fixed_params.items()]
+
+            [stack.enter_context(param.set_value(val)) for param, val in temp_param_values.items()]
+
+            for p in temp_param_values.keys():
+                print(p.name, zfit.run(p))
+
             if not (n and self._initial_resampled):  # we want to load and make sure that it's initialized
                 # means it's handled inside the function
                 # TODO(Mayou36): check logic; what if new_samples loaded? get's overwritten by initializer

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -627,10 +627,7 @@ class Sampler(Data):
 
         with ExitStack() as stack:
 
-            [stack.enter_context(param.set_value(val)) for param, val in temp_param_values.items()]
-
-            for p in temp_param_values.keys():
-                print(p.name, zfit.run(p))
+            _ = [stack.enter_context(param.set_value(val)) for param, val in temp_param_values.items()]
 
             if not (n and self._initial_resampled):  # we want to load and make sure that it's initialized
                 # means it's handled inside the function


### PR DESCRIPTION
Fixes#

- `param_values` was not taken into account before in the function.
- also some fixes for the constraint documentation look 

## Tests added

 add tests using `param_values` argument in `test_sampling.py`
