### PR TITLE
ordered dependents

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ iminuit
 typing
 colorlog
 texttable
+ordered-set

--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -18,7 +18,7 @@ from zfit.models.functor import ProductPDF
 from zfit.models.special import SimplePDF
 import zfit.settings
 from zfit import ztf
-from zfit.core.testing import setup_function, teardown_function, tester
+from zfit.core.testing import setup_function, teardown_function, tester  # needed
 
 # from zfit.ztf import
 from zfit.util import ztyping

--- a/tests/test_dependents.py
+++ b/tests/test_dependents.py
@@ -1,0 +1,9 @@
+#  Copyright (c) 2019 zfit
+import zfit
+import pytest
+
+from zfit.core.testing import setup_function, teardown_function, tester  # needed
+
+
+def test_get_dependents_ordered():
+    pass  # TODO

--- a/tests/test_dependents.py
+++ b/tests/test_dependents.py
@@ -1,4 +1,6 @@
 #  Copyright (c) 2019 zfit
+from ordered_set import OrderedSet
+
 import zfit
 import pytest
 
@@ -6,4 +8,27 @@ from zfit.core.testing import setup_function, teardown_function, tester  # neede
 
 
 def test_get_dependents_ordered():
-    pass  # TODO
+    params = [zfit.Parameter(f'param{i}', i) for i in range(4)]
+    obs = zfit.Space('obs1', (-3, 2))
+
+    def create_pdf(params):
+        param1, param2, param3, param4 = params
+        gauss1 = zfit.pdf.Gauss(param1, param2, obs=obs)
+        gauss2 = zfit.pdf.Gauss(param2, param2, obs=obs)
+        gauss3 = zfit.pdf.Gauss(param2, param4, obs=obs)
+        gauss4 = zfit.pdf.Gauss(param3, param1, obs=obs)
+        sum_pdf = zfit.pdf.SumPDF([gauss1, gauss2, gauss3, gauss4], fracs=[0.1, 0.3, 0.4])
+        return sum_pdf
+
+    is_different = 0
+    shuffled_param_list = params, params[::-1]
+    # if error below, the test is at flaw
+    params[0] == params[1]
+    assert ((list(shuffled_param_list[0]) != list(set(shuffled_param_list[0]))) or
+            (list(shuffled_param_list[1]) != list(set(shuffled_param_list[1]))))  # check that set is different
+    for params_shuffled in shuffled_param_list:
+        pdf = create_pdf(params_shuffled)
+        deps = pdf.get_dependents()
+        is_different += list(deps) != list(set(deps))
+
+    assert is_different > 0, "set and OrderedSet return the same order, cannot be."

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -73,7 +73,7 @@ def test_composed_param():
     param1 = Parameter('param1', 1.)
     param2 = Parameter('param2', 2.)
     param3 = Parameter('param3', 3., floating=False)
-    param4 = Parameter('param4', 4.)
+    param4 = Parameter('param4', 4.)  # needed to make sure it does not only take all params as deps
     a = ztf.log(3. * param1) * tf.square(param2) - param3
     param_a = ComposedParameter('param_as', tensor=a)
     assert isinstance(param_a.get_dependents(only_floating=True), OrderedSet)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import tensorflow as tf
+from ordered_set import OrderedSet
 
 import zfit
 from zfit import Parameter, ztf
@@ -75,7 +76,7 @@ def test_composed_param():
     param4 = Parameter('param4', 4.)
     a = ztf.log(3. * param1) * tf.square(param2) - param3
     param_a = ComposedParameter('param_as', tensor=a)
-    assert isinstance(param_a.get_dependents(only_floating=True), set)
+    assert isinstance(param_a.get_dependents(only_floating=True), OrderedSet)
     assert param_a.get_dependents(only_floating=True) == {param1, param2}
     assert param_a.get_dependents(only_floating=False) == {param1, param2, param3}
     a_unchanged = zfit.run(a)

--- a/zfit/core/baseobject.py
+++ b/zfit/core/baseobject.py
@@ -7,8 +7,7 @@ import itertools
 from typing import List, Set
 
 import tensorflow as tf
-
-
+from ordered_set import OrderedSet
 
 import zfit
 from ..util.cache import Cachable
@@ -94,11 +93,11 @@ class BaseDependentsMixin(ZfitDependentsMixin):
         """
         dependents = self._get_dependents()
         if only_floating:
-            dependents = set(filter(lambda p: p.floating, dependents))
+            dependents = OrderedSet(filter(lambda p: p.floating, dependents))
         return dependents
 
     @staticmethod
-    def _extract_dependents(zfit_objects: List[ZfitObject]) -> Set["zfit.Parameters"]:
+    def _extract_dependents(zfit_objects: List[ZfitObject]) -> ztyping.DependentsType:
         """Calls the :py:meth:`~BaseDependentsMixin.get_dependents` method on every object and returns a combined set.
 
         Args:
@@ -109,7 +108,7 @@ class BaseDependentsMixin(ZfitDependentsMixin):
         """
         zfit_objects = convert_to_container(zfit_objects)
         dependents = (obj.get_dependents(only_floating=False) for obj in zfit_objects)
-        dependents_set = set(itertools.chain.from_iterable(dependents))  # flatten
+        dependents_set = OrderedSet(itertools.chain.from_iterable(dependents))  # flatten
         return dependents_set
 
 

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -7,6 +7,7 @@ import numpy as np
 import tensorflow as tf
 
 # TF backwards compatibility
+from ordered_set import OrderedSet
 from tensorflow.python import ops, array_ops
 
 import zfit
@@ -546,7 +547,7 @@ class ConstantParameter(BaseZParameter):
         return False
 
     def _get_dependents(self) -> ztyping.DependentsType:
-        return set()
+        return OrderedSet()
 
 
 class ComposedParameter(BaseComposedParameter):

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -299,6 +299,12 @@ class ZfitParameterMixin(BaseNumeric):
                 return operations.multiply(other, self)
         return super().__rmul__(other)
 
+    def __eq__(self, other):
+        return id(self) == id(other)
+
+    def __hash__(self):
+        return super().__hash__()
+
 
 # solve metaclass confict
 # class TFBaseVariable(TFBaseVariable, metaclass=MetaBaseParameter):    # TODO(Mayou36): upgrade to tf2

--- a/zfit/util/ztyping.py
+++ b/zfit/util/ztyping.py
@@ -8,6 +8,7 @@ import tensorflow as tf
 
 
 # space
+from ordered_set import OrderedSet
 
 LowerTypeInput = Union[Tuple[Tuple[float, ...]], Tuple[float, ...], float]
 LowerTypeReturn = Union[Tuple[Tuple[float, ...]], None, bool]
@@ -72,7 +73,7 @@ SessionType = Optional[tf.compat.v1.Session]
 BaseObjectType = Union['zfit.core.interfaces.ZfitParameter',
                        'zfit.core.interfaces.ZfitFunction',
                        'zfit.core.interfaces.ZfitPDF']
-DependentsType = Set['zfit.Parameter']
+DependentsType = OrderedSet('zfit.Parameter')
 
 # Caching
 CacherOrCachersType = Union['zfit.core.interfaces.ZfitCachable',


### PR DESCRIPTION
Fixes #166

## Proposed Changes

  - use ordered-set package to preserve the order

## Tests added

  -
  
## Checklist

 - [x] change approved
 - [x] implementation finished
 - [x] correct namespace imported
 - [x] tests added
 - [x] CHANGELOG updated

