### PR TITLE
WIP: Behavior of floating param given to `minimize`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Major Features and Improvements
 
 Breaking changes
 ------------------
+- `minimize(params=...)` now filters correctly non-floating parameters.
 
 Depreceations
 -------------
@@ -18,6 +19,7 @@ Depreceations
 
 Bug fixes and small changes
 ---------------------------
+- `minimize(params=...)` automatically extracts independent parameters.
 
 Experimental
 ------------

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -60,6 +60,20 @@ obs1_split = (zfit.Space(obs='obs1', limits=(-2.4, 1.3))
               + zfit.Space(obs='obs1', limits=(1.3, 2.1))
               + zfit.Space(obs='obs1', limits=(2.1, 9.1)))
 
+def test_floating_flag():
+    obs = zfit.Space("x", limits=(-2, 3))
+    mu = zfit.Parameter("mu", 1.2, -4, 6)
+    sigma = zfit.Parameter("sigma", 1.3, 0.1, 10)
+    sigma.floating = False
+    gauss = zfit.pdf.Gauss(mu=mu, sigma=sigma, obs=obs)
+    normal_np = np.random.normal(loc=2., scale=3., size=10000)
+    data = zfit.Data.from_numpy(obs=obs, array=normal_np)
+    nll = zfit.loss.UnbinnedNLL(model=gauss, data=data)
+    minimizer = zfit.minimize.Minuit()
+    result = minimizer.minimize(nll, params=[mu, sigma])
+    assert list(result.params.keys()) == [mu]
+    assert sigma not in result.params
+
 
 # @pytest.mark.run(order=4)
 @pytest.mark.parametrize("chunksize", [3000, 100000])

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 
 import pytest
 import tensorflow as tf
+import numpy as np
 
 import zfit.minimizers.baseminimizer as zmin
 import zfit.minimizers.optimizers_tf

--- a/zfit/minimizers/baseminimizer.py
+++ b/zfit/minimizers/baseminimizer.py
@@ -7,6 +7,11 @@ Definition of minimizers, wrappers etc.
 import abc
 import collections
 import copy
+import warnings
+from abc import abstractmethod
+from collections import OrderedDict
+from contextlib import ExitStack
+import copy
 from abc import abstractmethod
 from collections import OrderedDict
 from typing import List, Union, Iterable, Mapping
@@ -147,9 +152,9 @@ class BaseMinimizer(ZfitMinimizer):
         if isinstance(params, (str, ZfitParameter)) or (not hasattr(params, "__len__") and params is not None):
             params = [params, ]
         if params is None or isinstance(params[0], str):
-            params = loss.get_cache_deps(only_floating=only_floating)
+            params = loss.get_params(only_floating=only_floating)
             params = list(params)
-        elif only_floating:
+        if only_floating:
             params = self._filter_floating_params(params)
         if not params:
             raise RuntimeError("No parameter for minimization given/found. Cannot minimize.")
@@ -157,18 +162,19 @@ class BaseMinimizer(ZfitMinimizer):
 
     @staticmethod
     def _filter_floating_params(params):
-        params = [param for param in params if param.floating]
-        return params
+        non_floating = [param for param in params if not param.floating]
+        if non_floating:  # legacy warning
+            warnings.warn(f"CHANGED BEHAVIOR! Non-floating parameters {non_floating} will not be used in the "
+                          f"minimization.")
+        return [param for param in params if param.floating]
 
     @staticmethod
     def _extract_load_method(params):
-        params_load = [param.load for param in params]
-        return params_load
+        return [param.load for param in params]
 
     @staticmethod
     def _extract_param_names(params):
-        names = [param.name for param in params]
-        return names
+        return [param.name for param in params]
 
     def _check_gradients(self, params, gradients):
         non_dependents = [param for param, grad in zip(params, gradients) if grad is None]

--- a/zfit/minimizers/baseminimizer.py
+++ b/zfit/minimizers/baseminimizer.py
@@ -146,10 +146,11 @@ class BaseMinimizer(ZfitMinimizer):
     def _check_input_params(self, loss: ZfitLoss, params, only_floating=True):
         if isinstance(params, (str, ZfitParameter)) or (not hasattr(params, "__len__") and params is not None):
             params = [params, ]
-            params = self._filter_floating_params(params)
         if params is None or isinstance(params[0], str):
             params = loss.get_cache_deps(only_floating=only_floating)
             params = list(params)
+        elif only_floating:
+            params = self._filter_floating_params(params)
         if not params:
             raise RuntimeError("No parameter for minimization given/found. Cannot minimize.")
         return params


### PR DESCRIPTION
What should be the behavior of a parameter, not floating, that is _explicitly_ given to `minimizer.minimize(..., params=[..., non_floating_param,...])?

This changes that if a parameter is not floating it won't be used even if explicitly given. Can though fail, better raise an error?

UPDATE: The behavioral way to go seems to be that:
 - any parameter (object) given will be used in the fit, whether it is independent or not (in the latter case, the independent params will be extracted and used in the fit). Furthermore, any _explicit_ given parameter will, if possible, be given to the minimizer as well and printed as a "fixed" parameter. This includes independent and non-floating parameters as well as dependent parameters. Open: should non-floating independent parameter that are dependencies of a dependent parameter also be printed? (the floating ones will surely).
## Tests added
  - test to check the behavior.
  
## Checklist

 - [x] change approved
 - [x] implementation finished
 - [x] correct namespace imported
 - [x] tests added
 - [x] CHANGELOG updated

