### PR TITLE
Restrict python version to be strictly smaller than 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     keywords='TensorFlow, model, fitting, scalable, HEP',
     name='zfit',
-    python_requires=">=3.6",
+    python_requires=">=3.6, <3.8",  # 3.8 not yet supported by Tensorflow 2.
     packages=find_packages(include=['zfit', 'zfit.z',
                                     'zfit.util', 'zfit.core', "zfit.minimizers", 'zfit.models']),
     setup_requires=setup_requirements,


### PR DESCRIPTION
Tensorflow2 does not yet support python38 and the error message
when trying to install with pip and python38 is more helpful if
we restrict it too.

* Example of error message with restriction:
  `zfit requires Python '>=3.6, <3.8' but the running Python is
  3.8.0`
* Without restriction:
  `Could not find a version that satisfies the requirement
  tensorflow>=2`

Fixes #


## Proposed Changes
  - Change `python_requires` string.

## Tests added
None
  
## Checklist

 - [x] change approved
 - [x] implementation finished
 - [x] correct namespace imported (does not apply)
 - [x] tests added (does not apply)
 - [x] CHANGELOG updated (does not apply)

