### PR TITLE
Fix test_get_dependents_ordered() and rename to test_get_dependents_is_deterministic()

### DIFF
--- a/tests/test_dependents.py
+++ b/tests/test_dependents.py
@@ -6,8 +6,8 @@ import zfit
 from zfit.core.testing import setup_function, teardown_function, tester
 
 
-def test_get_dependents_ordered():
-    params = [zfit.Parameter(f'param{i}', i) for i in range(4)]
+def test_get_dependents_is_deterministic():
+    parameters = [zfit.Parameter(f'param{i}', i) for i in range(4)]
     obs = zfit.Space('obs1', (-3, 2))
 
     def create_pdf(params):
@@ -19,15 +19,6 @@ def test_get_dependents_ordered():
         sum_pdf = zfit.pdf.SumPDF([gauss1, gauss2, gauss3, gauss4], fracs=[0.1, 0.3, 0.4])
         return sum_pdf
 
-    is_different = 0
-    shuffled_param_list = params, params[::-1]
-    # if error below, the test is at flaw
-    params[0] == params[1]
-    assert ((list(shuffled_param_list[0]) != list(set(shuffled_param_list[0]))) or
-            (list(shuffled_param_list[1]) != list(set(shuffled_param_list[1]))))  # check that set is different
-    for params_shuffled in shuffled_param_list:
-        pdf = create_pdf(params_shuffled)
-        deps = pdf.get_dependents()
-        is_different += list(deps) != list(set(deps))
-
-    assert is_different > 0, "set and OrderedSet return the same order, cannot be."
+    for params in (parameters, reversed(parameters)):
+        pdf = create_pdf(params)
+        assert pdf.get_dependents() == pdf.get_dependents(), "get_dependents() not deterministic"


### PR DESCRIPTION
The pytest test_get_dependents_ordered() tested that the
outcome of list(OrderedDict) != list(set(OrderedDict)).
This is not a guaranteed behavior of the python set() and
list() functions, although it often will be the case.
The actual intention of the test function was to test
whether pdf.get_dependents() would return the same
OrderedDict on each subsequent call, i.e. whether the
function is deterministic. The test function has
been rewritten to reflect that intent.

Fixes #


## Proposed Changes

  -
  -
  -

## Tests added

  -
  -
  -
  
## Checklist

 - [ ] change approved
 - [ ] implementation finished
 - [ ] correct namespace imported
 - [ ] tests added
 - [ ] CHANGELOG updated

