### PR TITLE
Fix hesse_np and add covariance for any minimizer

### DIFF
--- a/tests/test_fitresult.py
+++ b/tests/test_fitresult.py
@@ -80,12 +80,14 @@ def test_fmin(minimizer_class_and_kwargs):
 
 @pytest.mark.parametrize("minimizer_class_and_kwargs", minimizers)
 def test_covariance(minimizer_class_and_kwargs):
+        
     results = create_fitresult(minimizer_class_and_kwargs=minimizer_class_and_kwargs)
     result = results['result']
     hesse = result.hesse()
     a = results['a_param']
     b = results['b_param']
     c = results['c_param']
+    
 
     cov_mat_3 = result.covariance(params=[a, b, c])
     cov_mat_2 = result.covariance(params=[c, b])
@@ -101,3 +103,7 @@ def test_covariance(minimizer_class_and_kwargs):
     assert pytest.approx(hesse[c]['error'], rel=0.01) == np.sqrt(cov_dict[(c, c)])
     assert pytest.approx(hesse[c]['error'], rel=0.01) == np.sqrt(cov_mat_3[2, 2])
     assert pytest.approx(hesse[c]['error'], rel=0.01) == np.sqrt(cov_mat_2[0, 0])
+
+    cov_mat_3_np = result.covariance(params=[a, b, c], method="hesse_np")
+    
+    assert np.allclose(cov_mat_3, cov_mat_3_np, rtol=0.05)

--- a/tests/test_fitresult.py
+++ b/tests/test_fitresult.py
@@ -78,6 +78,7 @@ def test_fmin(minimizer_class_and_kwargs):
     assert pytest.approx(results['cur_val']) == result.fmin
 
 
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize("minimizer_class_and_kwargs", minimizers)
 def test_covariance(minimizer_class_and_kwargs):
         

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -101,11 +101,16 @@ def minimize_func(minimizer_class_and_kwargs):
             assert custom_errors[param]['myval'] == 42
 
         # Test Hesse
+
         for method in ['minuit_hesse', 'hesse_np']:
             b_hesses = result.hesse(params=b_param, method=method)
             assert tuple(b_hesses.keys()) == (b_param,)
             errors = result.hesse()
             b_hesse = b_hesses[b_param]
+            print("\n LOOK HERE ", method,":")
+            print(minimizer_class_and_kwargs)
+            print("default hesse: ", errors)
+            print("b_hesse: ", b_hesse, "\n")
             assert abs(b_hesse['error']) == pytest.approx(0.0965, abs=0.15)
             assert abs(errors[b_param]['error']) == pytest.approx(0.0965, abs=0.15)
             assert abs(errors[c_param]['error']) == pytest.approx(0.1, abs=0.15)

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -100,18 +100,15 @@ def minimize_func(minimizer_class_and_kwargs):
         for param, errors2 in result.params.items():
             assert custom_errors[param]['myval'] == 42
 
-        # Test Hesse
+        # Test Hesse        
 
         for method in ['minuit_hesse', 'hesse_np']:
             b_hesses = result.hesse(params=b_param, method=method)
             assert tuple(b_hesses.keys()) == (b_param,)
             errors = result.hesse()
             b_hesse = b_hesses[b_param]
-            print("\n LOOK HERE ", method,":")
-            print(minimizer_class_and_kwargs)
-            print("default hesse: ", errors)
-            print("b_hesse: ", b_hesse, "\n")
             assert abs(b_hesse['error']) == pytest.approx(0.0965, abs=0.15)
+            assert abs(b_hesse['error']) == pytest.approx(abs(errors[b_param]['error']), rel=0.1)
             assert abs(errors[b_param]['error']) == pytest.approx(0.0965, abs=0.15)
             assert abs(errors[c_param]['error']) == pytest.approx(0.1, abs=0.15)
 

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -49,9 +49,9 @@ def _hesse_np(result: "FitResult", params, sigma=1.0):
     # if not isinstance(minimizer, Minuit):
     #     raise TypeError("Cannot perform hesse error calculation 'minuit' with a different minimizer then"
     #                     "`Minuit`.")
-    result_hesse = 2 * np.linalg.inv(result.loss.value_gradients_hessian(params)[2])
+    covariance = np.linalg.inv(result.loss.value_gradients_hessian(params)[2])
 
-    hesse = OrderedDict((param, {'error': result_hesse[i, i]}) for i, param in enumerate(params))
+    hesse = OrderedDict((param, {'error': covariance[i, i]**0.5}) for i, param in enumerate(params))
     return hesse
 
 
@@ -66,6 +66,43 @@ def _minos_minuit(result, params, sigma=1.0):
               for p in params][-1]  # returns every var
     result = OrderedDict((p, result[p.name]) for p in params)
     return result
+    
+    
+def _covariance_minuit(result, params, as_dict=False):
+    fitresult = result
+    minimizer = fitresult.minimizer
+
+    from zfit.minimizers.minimizer_minuit import Minuit
+    if not isinstance(minimizer, Minuit):
+        raise TypeError("Cannot compute the covariance matrix with 'covariance_minuit' with a different minimizer then"
+                        "`Minuit`.")
+
+    covariance_dict = result.minimizer._minuit_minimizer.covariance
+    
+    cov = {}
+    for p1 in params:
+      for p2 in params:
+        key = (p1, p2)
+        cov[key] = covariance_dict[tuple(k.name for k in key)]
+    covariance_dict = cov
+
+    if as_dict:
+        return covariance_dict
+    else:
+        return dict_to_matrix(params, covariance_dict)
+        
+def _covariance_np(result, params, as_dict=False):
+    
+    # check if no weights in data
+    if any([data.weights is not None for data in result.loss.data]):
+        raise WeightsNotImplementedError("Weights are not supported with hesse numpy.")
+
+    covariance = np.linalg.inv(result.loss.value_gradients_hessian(params)[2])
+
+    if as_dict:
+        return matrix_to_dict(covariance)
+    else:
+        return covariance
 
 
 class FitResult(ZfitResult):
@@ -73,6 +110,8 @@ class FitResult(ZfitResult):
     _hesse_methods = {'minuit_hesse': _hesse_minuit, 'hesse_np': _hesse_np}
     _default_error = 'minuit_minos'
     _error_methods = {"minuit_minos": _minos_minuit}
+    _default_covariance = 'covariance_np'
+    _covariance_methods = {'covariance_minuit': _covariance_minuit, 'covariance_np': _covariance_np}
 
     def __init__(self, params: Dict[ZfitParameter, float], edm: float, fmin: float, status: int, converged: bool,
                  info: dict, loss: ZfitLoss, minimizer: "ZfitMinimizer"):
@@ -267,7 +306,7 @@ class FitResult(ZfitResult):
                 raise KeyError("The following method is not a valid, implemented method: {}".format(method))
         return method(result=self, params=params, sigma=sigma)
 
-    def covariance(self, params: ParamsTypeOpt = None, as_dict: bool = False):
+    def covariance(self, params: ParamsTypeOpt = None, method: Union[str, Callable] = None, as_dict: bool = False):
         """Calculate the covariance matrix for `params`.
 
             Args:
@@ -279,25 +318,27 @@ class FitResult(ZfitResult):
                 2D `numpy.array` of shape (N, N);
                 `dict`(param1, param2) -> covariance if `as_dict == True`.
         """
+        
+        if method is None:
+            # LEGACY START
+            method = self._default_hesse
+            from zfit.minimizers.minimizer_minuit import Minuit
+            if isinstance(self.minimizer, Minuit):
+                method = 'covariance_minuit'
+            # LEGACY END
+        
         params = self._input_check_params(params)
-
-        try:
-            covariance_dict = self.minimizer._minuit_minimizer.covariance
-        except AttributeError:
-            raise WorkInProgressError("Currently, only covariance from minuit is available. "
-                                      "Use `Minuit` or open an issue on GitHub.")
-
-        cov = {}
-        for p1 in params:
-            for p2 in params:
-                key = (p1, p2)
-                cov[key] = covariance_dict[tuple(k.name for k in key)]
-        covariance_dict = cov
-
-        if as_dict:
-            return covariance_dict
-        else:
-            return dict_to_matrix(params, covariance_dict)
+        return self._covariance(params=params, method=method, as_dict=as_dict)
+          
+    def _covariance(self, params, method, as_dict):
+      if not callable(method):
+          try:
+              method = self._covariance_methods[method]
+          except KeyError:
+              raise KeyError("The following method is not a valid, implemented method: {}".format(method))
+      return method(result=self, params=params, as_dict=as_dict)
+            
+        
 
 
 def dict_to_matrix(params, matrix_dict):
@@ -314,6 +355,23 @@ def dict_to_matrix(params, matrix_dict):
                 matrix[j, i] = matrix_dict[key]
 
     return matrix
+    
+    
+def matrix_to_dict(params, matrix):
+    nparams = len(params)
+    matrix_dict = {}
+    
+    for i in range(nparams):
+        pi = params[i]
+        for j in range(i, nparams):
+            pj = params[j]
+            key = (pi, pj)
+            matrix_dict[key] = matrix[i, j]
+            if i != j:
+                matrix_dict[key] = matrix[j, i]
+
+    return matrix_dict
+    
 
 # def set_error_method(self, method):
 #     if isinstance(method, str):

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -266,14 +266,14 @@ class FitResult(ZfitResult):
                 raise KeyError("The following method is not a valid, implemented method: {}".format(method))
         return method(result=self, params=params, sigma=sigma)
 
-    def covariance(self, params: ParamsTypeOpt = None, method: str = None, as_dict: bool = False):
+    def covariance(self, params: ParamsTypeOpt = None, method: Union[str, Callable] = None, as_dict: bool = False):
         """Calculate the covariance matrix for `params`.
 
             Args:
                 params (list(:py:class:`~zfit.Parameter`)): The parameters to calculate
                     the covariance matrix. If `params` is `None`, use all *floating* parameters.
-                method (str): The method to use to calculate the covariance matrix. Valid choices are
-                    {'minuit_hesse', 'hesse_np'}.
+                method (str or Callbel): The method to use to calculate the covariance matrix. Valid choices are
+                    {'minuit_hesse', 'hesse_np'} or a Callable.
                 as_dict (bool): Default `False`. If `True` then returns a dictionnary.
 
             Returns:

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -60,39 +60,40 @@ def _minos_minuit(result, params, sigma=1.0):
     minimizer = fitresult.minimizer
     from zfit.minimizers.minimizer_minuit import Minuit
     if not isinstance(minimizer, Minuit):
-        raise TypeError("Cannot perform error calculation 'minos_minuit' with a different minimizer then"
+        raise TypeError("Cannot perform error calculation 'minos_minuit' with a different minimizer than"
                         "`Minuit`.")
     result = [minimizer._minuit_minimizer.minos(var=p.name, sigma=sigma)
               for p in params][-1]  # returns every var
     result = OrderedDict((p, result[p.name]) for p in params)
     return result
-    
-    
+
+
 def _covariance_minuit(result, params, as_dict=False):
     fitresult = result
     minimizer = fitresult.minimizer
 
     from zfit.minimizers.minimizer_minuit import Minuit
     if not isinstance(minimizer, Minuit):
-        raise TypeError("Cannot compute the covariance matrix with 'covariance_minuit' with a different minimizer then"
-                        "`Minuit`.")
+        raise TypeError("Cannot compute the covariance matrix with 'covariance_minuit' with a different"
+                        " minimizer than `Minuit`.")
 
     covariance_dict = result.minimizer._minuit_minimizer.covariance
-    
+
     cov = {}
     for p1 in params:
-      for p2 in params:
-        key = (p1, p2)
-        cov[key] = covariance_dict[tuple(k.name for k in key)]
+        for p2 in params:
+            key = (p1, p2)
+            cov[key] = covariance_dict[tuple(k.name for k in key)]
     covariance_dict = cov
 
     if as_dict:
         return covariance_dict
     else:
         return dict_to_matrix(params, covariance_dict)
-        
+
+
 def _covariance_np(result, params, as_dict=False):
-    
+
     # check if no weights in data
     if any([data.weights is not None for data in result.loss.data]):
         raise WeightsNotImplementedError("Weights are not supported with hesse numpy.")
@@ -306,7 +307,8 @@ class FitResult(ZfitResult):
                 raise KeyError("The following method is not a valid, implemented method: {}".format(method))
         return method(result=self, params=params, sigma=sigma)
 
-    def covariance(self, params: ParamsTypeOpt = None, method: Union[str, Callable] = None, as_dict: bool = False):
+    def covariance(self, params: ParamsTypeOpt = None, method: Union[str, Callable] = None,
+                   as_dict: bool = False):
         """Calculate the covariance matrix for `params`.
 
             Args:
@@ -318,7 +320,7 @@ class FitResult(ZfitResult):
                 2D `numpy.array` of shape (N, N);
                 `dict`(param1, param2) -> covariance if `as_dict == True`.
         """
-        
+
         if method is None:
             # LEGACY START
             method = self._default_hesse
@@ -326,19 +328,17 @@ class FitResult(ZfitResult):
             if isinstance(self.minimizer, Minuit):
                 method = 'covariance_minuit'
             # LEGACY END
-        
+
         params = self._input_check_params(params)
         return self._covariance(params=params, method=method, as_dict=as_dict)
-          
+
     def _covariance(self, params, method, as_dict):
-      if not callable(method):
-          try:
-              method = self._covariance_methods[method]
-          except KeyError:
-              raise KeyError("The following method is not a valid, implemented method: {}".format(method))
-      return method(result=self, params=params, as_dict=as_dict)
-            
-        
+        if not callable(method):
+            try:
+                method = self._covariance_methods[method]
+            except KeyError:
+                raise KeyError("The following method is not a valid, implemented method: {}".format(method))
+        return method(result=self, params=params, as_dict=as_dict)
 
 
 def dict_to_matrix(params, matrix_dict):
@@ -355,12 +355,12 @@ def dict_to_matrix(params, matrix_dict):
                 matrix[j, i] = matrix_dict[key]
 
     return matrix
-    
-    
+
+
 def matrix_to_dict(params, matrix):
     nparams = len(params)
     matrix_dict = {}
-    
+
     for i in range(nparams):
         pi = params[i]
         for j in range(i, nparams):
@@ -371,7 +371,7 @@ def matrix_to_dict(params, matrix):
                 matrix_dict[key] = matrix[j, i]
 
     return matrix_dict
-    
+
 
 # def set_error_method(self, method):
 #     if isinstance(method, str):

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -260,6 +260,7 @@ class FitResult(ZfitResult):
             error_dict = self._hesse(params=uncached_params, method=method, sigma=sigma)
             self._cache_errors(error_name=error_name, errors=error_dict)
 
+        params = self._input_check_params(params)
         all_errors = OrderedDict((p, self.params[p][error_name]) for p in params)
         return all_errors
 

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -34,11 +34,8 @@ def _hesse_minuit(result: "FitResult", params, sigma=1.0):
     result_hesse = minimizer._minuit_minimizer.hesse()
     result_hesse = OrderedDict((res["name"], res) for res in result_hesse)
 
-    result = OrderedDict(
-        (params_name[p_name], {"error": res["error"]})
-        for p_name, res in result_hesse.items()
-        if p_name in params_name
-    )
+    result = OrderedDict((params_name[p_name], {"error": res["error"]})
+                         for p_name, res in result_hesse.items() if p_name in params_name)
     return result
 
 
@@ -57,9 +54,7 @@ def _hesse_np(result: "FitResult", params, sigma=1.0):
     #                     "`Minuit`.")
     covariance = np.linalg.inv(result.loss.value_gradients_hessian(params)[2])
 
-    hesse = OrderedDict(
-        (param, {"error": covariance[i, i] ** 0.5}) for i, param in enumerate(params)
-    )
+    hesse = OrderedDict((param, {"error": covariance[i, i] ** 0.5}) for i, param in enumerate(params))
     return hesse
 
 
@@ -72,11 +67,8 @@ def _minos_minuit(result, params, sigma=1.0):
         raise TypeError("Cannot perform error calculation 'minos_minuit' with a different minimizer than"
                         "`Minuit`.")
 
-    result = [
-        minimizer._minuit_minimizer.minos(var=p.name, sigma=sigma) for p in params
-    ][
-        -1
-    ]  # returns every var
+    result = [minimizer._minuit_minimizer.minos(var=p.name, sigma=sigma) 
+              for p in params][-1]  # returns every var
     result = OrderedDict((p, result[p.name]) for p in params)
     return result
 
@@ -248,9 +240,7 @@ class FitResult(ZfitResult):
             # LEGACY END
         if error_name is None:
             if not isinstance(method, str):
-                raise ValueError(
-                    "Need to specify `error_name` or use a string as `method`"
-                )
+                raise ValueError("Need to specify `error_name` or use a string as `method`")
             error_name = method
 
         all_params = list(self.params.keys())
@@ -304,15 +294,11 @@ class FitResult(ZfitResult):
             method = self._default_error
         if error_name is None:
             if not isinstance(method, str):
-                raise ValueError(
-                    "Need to specify `error_name` or use a string as `method`"
-                )
+                raise ValueError("Need to specify `error_name` or use a string as `method`")
             error_name = method
 
         params = self._input_check_params(params)
-        uncached_params = self._get_uncached_params(
-            params=params, method_name=error_name
-        )
+        uncached_params = self._get_uncached_params(params=params, method_name=error_name)
 
         if uncached_params:
             error_dict = self._error(params=uncached_params, method=method, sigma=sigma)

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -43,18 +43,9 @@ def _hesse_np(result: "FitResult", params, sigma=1.0):
     if sigma != 1.0:
         raise ValueError("sigma other then 1 is not valid for hesse numpy.")
 
-    # check if no weights in data
-    if any([data.weights is not None for data in result.loss.data]):
-        raise WeightsNotImplementedError("Weights are not supported with hesse numpy.")
+    covariance = _covariance_np(result, params)
 
-    # minimizer = fitresult.minimizer
-    # from zfit.minimizers.minimizer_minuit import Minuit
-    # if not isinstance(minimizer, Minuit):
-    #     raise TypeError("Cannot perform hesse error calculation 'minuit' with a different minimizer then"
-    #                     "`Minuit`.")
-    covariance = np.linalg.inv(result.loss.value_gradients_hessian(params)[2])
-
-    hesse = OrderedDict((param, {"error": covariance[i, i] ** 0.5}) for i, param in enumerate(params))
+    hesse = OrderedDict((p, {"error": covariance[(p, p)] ** 0.5}) for p in params)
     return hesse
 
 


### PR DESCRIPTION
## Fixes 

* fixes error from `hesse_np` function
* In the `hesse` method, the hessian matrix is now computed using all the free parameters in the fit, leading to the same results between using `hesse_np` and `minuit_hesse` methods when using the `params` argument
* makes `covariance` available for any minimizers

## Tests added

* One test to check that errors from `hesse_np` and `minuit_hesse` are similar.
  
## Checklist

 - [ ] change approved
 - [ ] implementation finished
 - [ ] correct namespace imported
 - [ ] tests added
 - [ ] CHANGELOG updated

