### PR TITLE
WIP: SumPDF rework, consistent frac behavior

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 Develop
 =======
 
-Complete refactoring of Spaces.
+Complete refactoring of Spaces. New behavior with extended. SumPDF refactoring
 
 
 
@@ -25,6 +25,18 @@ Major Features and Improvements
    Due to the ambiguity of the name `limits`, `area` etc (since they do only reflect the rectangular case)
    method with leading `rect_*` have been added (`rect_limits`, `rect_area` etc.) and are encouraged to be used.
 
+ - Extending a PDF is more straightforward and removes any "magic". The philosophy is: a PDF can be extended
+   or not. But it does not change the fundamental behavior of functions.
+
+ - SumPDF has been refactored and behaves now as follows:
+   - Giving in pdfs (extended or not or mixed) *and* fracs (either length pdfs or one less) will create a
+     non-extended SumPDF using the fracs. The fact that the pdfs are maybe extended is ignored.
+     This will lead to highly consistent behavior.
+     If the number of fracs given equals the number of pdfs, it is up to the user (currently) to take care of
+     the normalization.
+     *Only* if *all* pdfs are extended **and** no fracs are given, the sumpdf will be using the yields as
+     normalized fracs and be extended.
+
 
 Breaking changes
 ------------------
@@ -34,6 +46,8 @@ Breaking changes
 
    To extract limits from multiple limits, `MultiSpace` and `Space` are both iterables, returning
    the containing spaces respectively itself (for the `Space` case).
+ - SumPDF changed in the behavior. Read above in the Major Features and Improvement.
+ - Integrals of extended PDFs are not extended anymore.
 
 
 Bug fixes and small changes

--- a/docs/intro/model.rst
+++ b/docs/intro/model.rst
@@ -82,18 +82,7 @@ Let's consider a second crystal ball with the same mean position and width, but 
     >>> # New crystal Ball function defined in the same observable range
     >>> model_cb2 = zfit.pdf.CrystalBall(obs=obs, mu=mu, sigma=sigma, alpha=a2, n=n2)
 
-We can now combine these two PDFs to create a double Crystal Ball with a single mean and width, either using arithmetic operations
-
-.. code-block:: pycon
-
-    >>> # First needs to define a parameters that represent
-    >>> # the relative fraction between the two PDFs
-    >>> frac = zfit.Parameter("frac", 0.5, 0, 1)
-
-    >>> # Two different ways to combine
-    >>> double_cb = frac * model_cb + model_cb2
-
-Or through the :py:class:`zfit.pdf.SumPDF` class:
+We can now combine these two PDFs to create a double Crystal Ball with a single mean and width through the :py:class:`zfit.pdf.SumPDF` class:
 
 .. code-block:: pycon
 
@@ -154,8 +143,7 @@ An extended PDF can be easily implemented in zfit in two ways:
 
     >>> # Extended PDF using a predefined method
     >>> extended_gauss_method = gauss.create_extended(yieldGauss)
-    >>> # Or simply with a Python syntax of multiplying a PDF with the parameter
-    >>> extended_gauss_python = yieldGauss * gauss
+
 
 
 Custom PDF

--- a/examples/composing_pdf.py
+++ b/examples/composing_pdf.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2019 zfit
+#  Copyright (c) 2020 zfit
 
 import zfit
 
@@ -15,7 +15,4 @@ frac = zfit.Parameter("fraction", 0.5, 0., 1.)
 gauss = zfit.pdf.Gauss(mu=mu, sigma=sigma, obs=obs)
 exponential = zfit.pdf.Exponential(lambd, obs=obs)
 
-# two equivalent ways to create a sum with a fraction
-sum_pdf = frac * gauss + exponential
-# OR
 sum_pdf = zfit.pdf.SumPDF([gauss, exponential], fracs=frac)

--- a/examples/signal_bkg_mass_extended_fit.py
+++ b/examples/signal_bkg_mass_extended_fit.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2019 zfit
+#  Copyright (c) 2020 zfit
 
 import numpy as np
 import zfit
@@ -39,7 +39,7 @@ lambd.set_value(-0.05)
 nll = zfit.loss.ExtendedUnbinnedNLL(model=model, data=data)
 
 # create a minimizer
-minimizer = zfit.minimize.Minuit()
+minimizer = zfit.minimize.Minuit(verbosity=10)
 result = minimizer.minimize(nll)
 print(result.params)
 # do the error calculations, here with minos

--- a/examples/signal_bkg_mass_extended_fit.py
+++ b/examples/signal_bkg_mass_extended_fit.py
@@ -39,8 +39,9 @@ lambd.set_value(-0.05)
 nll = zfit.loss.ExtendedUnbinnedNLL(model=model, data=data)
 
 # create a minimizer
-minimizer = zfit.minimize.Minuit(verbosity=10)
+minimizer = zfit.minimize.Minuit(verbosity=7)
 result = minimizer.minimize(nll)
 print(result.params)
 # do the error calculations, here with minos
+param_errors = result.hesse(method='hesse_np')
 param_errors = result.error()

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ sphinx_bootstrap_theme
 twine>=1.10.0
 setuptools>=30.3.0
 
-pytest>=3.4.2
+pytest>=3.4.2,<5.4  # breaks unittests
 pytest-runner>=2.11.1
 pytest-rerunfailures>=6
 pytest-xdist

--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -19,7 +19,8 @@ from zfit.models.dist_tfp import Gauss
 from zfit.models.special import SimplePDF
 # from zfit.z import
 from zfit.util import ztyping
-from zfit.util.exception import AlreadyExtendedPDFError, BreakingAPIChangeError
+from zfit.util.exception import AlreadyExtendedPDFError, BreakingAPIChangeError, SpaceIncompatibleError, \
+    CoordinatesUnderdefinedError, ObsIncompatibleError
 
 test_values = np.array([3., 11.3, -0.2, -7.82])
 
@@ -27,7 +28,7 @@ mu_true = 1.4
 sigma_true = 1.8
 low, high = -4.3, 1.9
 
-obs1 = 'obs1'
+obs1 = zfit.Space('obs1', (low, high))
 
 
 def create_gauss1(nameadd=""):
@@ -117,6 +118,13 @@ def test_gradient():
     tensor_grad = gauss3.gradients(x=random_vals, params=['mu', 'sigma'], norm_range=(-np.infty, np.infty))
     random_vals_eval = tensor_grad.numpy()
     np.testing.assert_allclose(random_vals_eval, true_gaussian_grad(random_vals), rtol=1e-3)
+
+
+def test_input_space():
+    gauss3 = create_gauss3()
+    space = zfit.Space('nonexisting_obs', (-3, 5))
+    with pytest.raises(ObsIncompatibleError):
+        gauss3.set_norm_range(space)
 
 
 def test_func():

--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -19,6 +19,7 @@ from zfit.models.dist_tfp import Gauss
 from zfit.models.special import SimplePDF
 # from zfit.z import
 from zfit.util import ztyping
+from zfit.util.exception import AlreadyExtendedPDFError, BreakingAPIChangeError
 
 test_values = np.array([3., 11.3, -0.2, -7.82])
 
@@ -260,6 +261,17 @@ def test_copy():
     assert new_gauss == gauss_params1
     assert new_gauss is not gauss_params1
 
+
+def test_set_yield():
+    gauss_params1 = create_gauss1()
+    assert not gauss_params1.is_extended
+    gauss_params1._set_yield(10)
+    assert gauss_params1.is_extended
+    with pytest.raises(AlreadyExtendedPDFError):
+        gauss_params1._set_yield(15)
+
+    with pytest.raises(BreakingAPIChangeError):
+        gauss_params1._set_yield(None)
 
 def test_projection_pdf():
     x = zfit.Space("x", limits=(-1, 1))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,60 +3,64 @@ import pytest
 
 import zfit
 from zfit import z
+import numpy as np
+
 # noinspection PyUnresolvedReferences
 from zfit.core.testing import setup_function, teardown_function, tester
 from zfit.util.cache import Cachable, invalidates_cache
 
 
-# class Test1(Cachable):
-#
-#     def value(self):
-#         value = self._cache.get("value")
-#         if value is None:
-#             self._cache['value'] = np.random.random()
-#         return self._cache['value']
-#
-#     @invalidates_cache
-#     def change_param(self, new_param):
-#         # invalidates cache
-#         return None
-#
-#
-# class MotherTest1(Cachable):
-#
-#     def __init__(self, test1, test2):
-#         super().__init__()
-#         self.add_cache_dependents([test1, test2])
-#         self.test1 = test1
-#         self.test2 = test2
-#
-#     def mother_value(self):
-#         value = self._cache.get("mother_value")
-#         if value is None:
-#             value = self.test1.value() + self.test2.value()
-#         self._cache['mother_value'] = value
-#         return value
-#
-#     @invalidates_cache
-#     def change_param(self):
-#         return None
-#
-#
-# def test_simple_cache():
-#     test1 = Test1()
-#     assert test1.value() == test1.value()
-#     value1 = test1.value()
-#     test1.change_param(24)
-#     assert value1 != test1.value()
-#
-#
-# def test_mother_cache():
-#     test1, test2 = Test1(), Test1()
-#     mother_test = MotherTest1(test1, test2)
-#     assert mother_test.mother_value() == mother_test.mother_value()
-#     mother_value = mother_test.mother_value()
-#     test1.change_param(12)
-#     assert mother_test.mother_value() != mother_value
+class Test1(Cachable):
+
+    def value(self):
+        value = self._cache.get("value")
+        if value is None:
+            self._cache['value'] = np.random.random()
+        return self._cache['value']
+
+    @invalidates_cache
+    def change_param(self, new_param):
+        # invalidates cache
+        return None
+
+
+class MotherTest1(Cachable):
+
+    def __init__(self, test1, test2):
+        super().__init__()
+        self.add_cache_dependents([test1, test2])
+        self.test1 = test1
+        self.test2 = test2
+
+    def mother_value(self):
+        value = self._cache.get("mother_value")
+        if value is None:
+            value = self.test1.value() + self.test2.value()
+        self._cache['mother_value'] = value
+        return value
+
+    @invalidates_cache
+    def change_param(self):
+        return None
+
+
+def test_simple_cache():
+    test1 = Test1()
+    assert test1.value() == test1.value()
+    value1 = test1.value()
+    test1.change_param(24)
+    assert value1 != test1.value()
+
+
+def test_mother_cache():
+    test1, test2 = Test1(), Test1()
+    mother_test = MotherTest1(test1, test2)
+    assert mother_test.mother_value() == mother_test.mother_value()
+    mother_value = mother_test.mother_value()
+    test1.change_param(12)
+    assert mother_test.mother_value() != mother_value
+
+
 #     assert mother_test.mother_value() == mother_test.mother_value()
 
 class GraphCreator1(Cachable):

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -177,3 +177,10 @@ def test_with_obs_or_axes(graph, testclass):
     assert coords_axes2.axes == axes
     with pytest.raises(AxesIncompatibleError):
         coords_obs2 = coords.with_axes(axes=coords_axes, allow_superset=False)
+
+    # check non-overlaping obs
+    with pytest.raises(ObsIncompatibleError):
+        coords_obs2.with_obs(['er', 'te', 'qwer', 'fd', 'asd'])
+
+    with pytest.raises(AxesIncompatibleError):
+        coords_obs2.with_axes(list(range(10, 15)))

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -3,12 +3,12 @@
 import pytest
 
 import zfit
-from zfit.core.dimension import limits_overlap
+from zfit.core.dimension import limits_overlap, obs_subsets
 from zfit.core.space import combine_spaces
 from zfit.core.space import limits_consistent
 # noinspection PyUnresolvedReferences
 from zfit.core.testing import setup_function, teardown_function, tester
-from zfit.util.exception import (LimitsIncompatibleError, SpaceIncompatibleError,
+from zfit.util.exception import (SpaceIncompatibleError,
                                  ObsIncompatibleError, MultipleLimitsNotImplementedError, LimitsNotSpecifiedError)
 
 obs = ['obs' + str(i) for i in range(4)]
@@ -96,7 +96,6 @@ def test_add_spaces():
         add_spaces(space1d_2, space1d_1).limits
 
 
-
 def test_limits_consistent():
     assert limits_consistent(spaces=[space1, space2])
     assert limits_consistent(spaces=[space1, space2, space3])
@@ -116,3 +115,32 @@ def test_limits_overlap():
     assert limits_overlap([space1d_1, space1d_2, space1d_12])
     assert limits_overlap([space1d_1, space2d_2, space1d_12])
     assert not limits_overlap([space1d_1, space2d_2, space1d_12], allow_exact_match=True)
+
+
+def test_obs_subsets():
+    space1 = zfit.Space('obs1')
+    space2 = zfit.Space(['obs1', 'obs2', 'obs4'])
+    space5 = zfit.Space(['obs3'])
+    space6 = zfit.Space('obs6')
+    space4 = zfit.Space(['obs3', 'obs7'])
+    space3 = zfit.Space(['obs4', 'obs5'])
+    spaces = [space1,
+              space2,
+              space5,
+              space6,
+              space4,
+              space3]
+    obs_subset = obs_subsets(spaces)
+
+    obs1comb = frozenset(['obs1', 'obs2', 'obs4', 'obs5'])
+    obs37comb = frozenset(['obs3', 'obs7'])
+    obs6 = frozenset(['obs6'])
+    true_obs = {obs1comb,
+                obs37comb,
+                obs6,
+                }
+
+    assert true_obs == set(obs_subset.keys())
+    assert obs_subset[obs1comb] == [space1, space2, space3]
+    assert obs_subset[obs37comb] == [space5, space4]
+    assert obs_subset[obs6] == [space6]

--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -23,10 +23,10 @@ def test_extract_extended_pdfs():
     yield1 = zfit.Parameter('yield123' + str(np.random.random()), 200.)
 
     # sum1 = 0.3 * gauss1 + gauss2
-    gauss3_ext = 45. * gauss3
-    gauss4_ext = 100. * gauss4
+    gauss3_ext = gauss3.create_extended(45)
+    gauss4_ext = gauss4.create_extended(100)
     sum2_ext_daughters = gauss3_ext + gauss4_ext
-    sum3 = 0.4 * gauss5 + gauss6
+    sum3 = zfit.pdf.SumPDF((gauss5, gauss6), 0.4)
     sum3_ext = sum3.create_extended(yield1)
 
     sum_all = zfit.pdf.SumPDF(pdfs=[sum2_ext_daughters, sum3_ext])

--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -8,7 +8,7 @@ from zfit.core.sample import extract_extended_pdfs, extended_sampling
 # noinspection PyUnresolvedReferences
 from zfit.core.testing import setup_function, teardown_function, tester
 
-obs1 = 'obs1'
+obs1 = zfit.Space('obs1', limits=(-3, 4))
 
 
 @pytest.mark.flaky(reruns=3)  # poissonian sampling

--- a/tests/test_fitresult.py
+++ b/tests/test_fitresult.py
@@ -29,7 +29,7 @@ def create_loss():
     gauss1 = zfit.pdf.Gauss(mu=a_param, sigma=b_param, obs=obs1)
     exp1 = zfit.pdf.Exponential(lambda_=c_param, obs=obs1)
 
-    sum_pdf1 = zfit.pdf.SumPDF((gauss1, exp1), 0.9)
+    sum_pdf1 = zfit.pdf.SumPDF((gauss1, exp1), 0.7)
 
     sampled_data = sum_pdf1.create_sampler(n=15000)
     sampled_data.resample()
@@ -44,8 +44,6 @@ def create_fitresult(minimizer_class_and_kwargs):
 
     true_minimum = loss.value().numpy()
 
-    parameter_tolerance = 0.25  # percent
-    max_distance_to_min = 10.
 
     for param in [a_param, b_param, c_param]:
         param.assign(param.initialized_value())  # reset the value
@@ -78,9 +76,8 @@ def test_fmin(minimizer_class_and_kwargs):
     assert pytest.approx(results['cur_val']) == result.fmin
 
 
-@pytest.mark.flaky(reruns=3)
+# @pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize("minimizer_class_and_kwargs", minimizers)
-@pytest.mark.flaky(2)  # odd graph problem...
 def test_covariance(minimizer_class_and_kwargs):
 
     results = create_fitresult(minimizer_class_and_kwargs=minimizer_class_and_kwargs)
@@ -107,4 +104,4 @@ def test_covariance(minimizer_class_and_kwargs):
 
     cov_mat_3_np = result.covariance(params=[a, b, c], method="hesse_np")
 
-    assert np.allclose(cov_mat_3, cov_mat_3_np, rtol=0.05, atol=0.001)
+    np.testing.assert_allclose(cov_mat_3, cov_mat_3_np, rtol=0.05, atol=0.001)

--- a/tests/test_fitresult.py
+++ b/tests/test_fitresult.py
@@ -29,7 +29,7 @@ def create_loss():
     gauss1 = zfit.pdf.Gauss(mu=a_param, sigma=b_param, obs=obs1)
     exp1 = zfit.pdf.Exponential(lambda_=c_param, obs=obs1)
 
-    sum_pdf1 = 0.9 * gauss1 + exp1
+    sum_pdf1 = zfit.pdf.SumPDF((gauss1, exp1), 0.9)
 
     sampled_data = sum_pdf1.create_sampler(n=15000)
     sampled_data.resample()

--- a/tests/test_fitresult.py
+++ b/tests/test_fitresult.py
@@ -76,7 +76,7 @@ def test_fmin(minimizer_class_and_kwargs):
     assert pytest.approx(results['cur_val']) == result.fmin
 
 
-# @pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize("minimizer_class_and_kwargs", minimizers)
 def test_covariance(minimizer_class_and_kwargs):
 

--- a/tests/test_functor_pdf.py
+++ b/tests/test_functor_pdf.py
@@ -41,10 +41,10 @@ def test_combine_range():
     gauss4 = zfit.pdf.Gauss(1., 4., obs=space4)
     gauss5 = zfit.pdf.Gauss(1., 4., obs=space4)
 
-    sum1 = zfit.pdf.SumPDF(pdfs=[gauss1, gauss4], fracs=0.4)
-    assert sum1.obs == (obs1, obs2)
-    assert sum1.norm_range == space5
+    product = zfit.pdf.ProductPDF(pdfs=[gauss1, gauss4])
+    assert product.obs == (obs1, obs2)
+    assert product.norm_range == space5
 
-    sum1 = zfit.pdf.SumPDF(pdfs=[gauss1, gauss4, gauss5], fracs=[0.4, 0.1])
-    assert sum1.obs == (obs1, obs2)
-    assert sum1.norm_range == space5
+    product = zfit.pdf.ProductPDF(pdfs=[gauss1, gauss4, gauss5])
+    assert product.obs == (obs1, obs2)
+    assert product.norm_range == space5

--- a/tests/test_functor_pdf.py
+++ b/tests/test_functor_pdf.py
@@ -1,8 +1,10 @@
 #  Copyright (c) 2020 zfit
+import pytest
 
 import zfit
 # noinspection PyUnresolvedReferences
 from zfit.core.testing import setup_function, teardown_function, tester
+from zfit.util.exception import NormRangeUnderdefinedError
 
 limits1 = (-4, 3)
 limits2 = (-2, 5)
@@ -23,12 +25,13 @@ def test_norm_range():
     gauss2 = zfit.pdf.Gauss(1., 4., obs=space1)
     gauss3 = zfit.pdf.Gauss(1., 4., obs=space2)
 
-    sum1 = zfit.pdf.SumPDF(pdfs=[gauss1, gauss2], fracs=0.4)
+    sum1 = zfit.pdf.SumPDF(pdfs=[gauss1, gauss2], fracs=0.4, obs=space1)
     assert sum1.obs == (obs1,)
     assert sum1.norm_range == space1
 
-    sum2 = zfit.pdf.SumPDF(pdfs=[gauss1, gauss3], fracs=0.34)
-    assert not sum2.norm_range.limits_are_set
+    with pytest.raises(NormRangeUnderdefinedError):
+        _ = zfit.pdf.SumPDF(pdfs=[gauss1, gauss3], fracs=0.34)
+    sum2 = zfit.pdf.SumPDF(pdfs=[gauss1, gauss3], fracs=0.34, obs=space3)
 
     sum2.set_norm_range(space2)
     with sum2.set_norm_range(space3):

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -135,7 +135,7 @@ def func3_2deps(x):
 
 
 def func3_2deps_fully_integrated(limits, params=None, model=None):
-    lower, upper = limits.limits
+    lower, upper = limits.rect_limits
     with suppress(TypeError):
         lower, upper = lower[0], upper[0]
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,8 +1,10 @@
 #  Copyright (c) 2020 zfit
 import numpy as np
+import pytest
 
 import zfit
 # noinspection PyUnresolvedReferences
+from zfit import z
 from zfit.core.testing import setup_function, teardown_function, tester
 from zfit.z.math import numerical_gradient, autodiff_gradient, numerical_hessian, autodiff_hessian
 
@@ -20,7 +22,8 @@ def test_numerical_gradient():
     np.testing.assert_allclose(num_gradients, tf_gradients)
 
 
-def test_numerical_hessian():
+@pytest.mark.parametrize('graph', [False, True])
+def test_numerical_hessian(graph):
     param1 = zfit.Parameter('param1', 4.)
     param2 = zfit.Parameter('param2', 5.)
     param3 = zfit.Parameter('param3', 2.)
@@ -28,11 +31,17 @@ def test_numerical_hessian():
     def func1():
         return param1 * param2 ** 2 + param3 ** param1
 
+    def create_derivatives(func1, params):
+        num_hessian_diag = numerical_hessian(func1, params=params, hessian='diag')
+        num_hessian = numerical_hessian(func1, params=params)
+        tf_hessian_diag = autodiff_hessian(func1, params=params, hessian='diag')
+        tf_hessian = autodiff_hessian(func1, params=params)
+        return num_hessian, num_hessian_diag, tf_hessian, tf_hessian_diag
+
     params = [param1, param2, param3]
-    num_hessian_diag = numerical_hessian(func1, params=params, hessian='diag')
-    num_hessian = numerical_hessian(func1, params=params)
-    tf_hessian_diag = autodiff_hessian(func1, params=params, hessian='diag')
-    tf_hessian = autodiff_hessian(func1, params=params)
+    if graph:
+        create_derivatives = z.function(create_derivatives)
+    num_hessian, num_hessian_diag, tf_hessian, tf_hessian_diag = create_derivatives(func1, params)
     np.testing.assert_allclose(num_hessian, tf_hessian, rtol=1e-5, atol=1e-10)
     tf_hessian_diag_from_hessian = [tf_hessian[i, i] for i in range(len(params))]
     np.testing.assert_allclose(tf_hessian_diag_from_hessian, tf_hessian_diag, rtol=1e-5, atol=1e-10)

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -62,7 +62,7 @@ obs1_split = (zfit.Space(obs='obs1', limits=(-2.4, 1.3))
 
 
 @pytest.mark.order4
-@pytest.mark.parametrize("chunksize", [10000000, 3000])
+@pytest.mark.parametrize("chunksize", [3000, 100000])
 @pytest.mark.parametrize("num_grad", [False, True])
 @pytest.mark.parametrize("spaces", [obs1, obs1_split])
 @pytest.mark.parametrize("minimizer_class_and_kwargs", minimizers)

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -47,9 +47,9 @@ def create_loss(obs1):
 
 
 minimizers = [  # minimizers, minimizer_kwargs, do error estimation
-    (zfit.minimizers.optimizers_tf.WrapOptimizer, dict(optimizer=tf.keras.optimizers.Adam(learning_rate=0.1)),
-     False),
-    (zfit.minimizers.optimizers_tf.Adam, dict(learning_rate=0.1), False),
+    # (zfit.minimizers.optimizers_tf.WrapOptimizer, dict(optimizer=tf.keras.optimizers.Adam(learning_rate=0.05)),
+    #  False),
+    (zfit.minimizers.optimizers_tf.Adam, dict(learning_rate=0.05), False),
     (zfit.minimize.Minuit, {}, True),
     (BFGS, {}, True),  # check for one not dependent on Minuit
     # (zfit.minimize.Scipy, {}, False),
@@ -152,10 +152,10 @@ def test_minimizers(minimizer_class_and_kwargs, num_grad, chunksize, spaces):
                 assert tuple(b_hesses.keys()) == (sigma_param,)
                 errors = result.hesse()
                 b_hesse = b_hesses[sigma_param]
-                assert abs(b_hesse['error']) == pytest.approx(0.0965, abs=0.15)
+                assert abs(b_hesse['error']) == pytest.approx(0.0965, abs=0.105)
                 assert abs(b_hesse['error']) == pytest.approx(abs(errors[sigma_param]['error']), rel=0.1)
-                assert abs(errors[sigma_param]['error']) == pytest.approx(0.0965, abs=0.15)
-                assert abs(errors[lambda_param]['error']) == pytest.approx(0.1, abs=0.15)
+                assert abs(errors[sigma_param]['error']) == pytest.approx(0.010, abs=0.015)
+                assert abs(errors[lambda_param]['error']) == pytest.approx(0.007, abs=0.015)
 
     else:
         with pytest.raises(TypeError):

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -3,14 +3,12 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
-import zfit
 from zfit import Parameter, z
 # noinspection PyUnresolvedReferences
 from zfit.core.testing import setup_function, teardown_function, tester
 from zfit.models.functions import SimpleFunc
-from zfit.models.functor import SumPDF
 from zfit.models.special import SimplePDF
-from zfit.util.exception import AlreadyExtendedPDFError, ModelIncompatibleError
+from zfit.util.exception import ModelIncompatibleError, BreakingAPIChangeError
 
 rnd_test_values = np.array([1., 0.01, -14.2, 0., 1.5, 152, -0.1, 12])
 
@@ -21,7 +19,6 @@ def test_not_allowed():
     param1 = Parameter('param1', 1.)
     param2 = Parameter('param2', 2.)
     param3 = Parameter('param3', 3., floating=False)
-    param4 = Parameter('param4', 4.)
 
     def func1_pure(self, x):
         return param1 * x
@@ -30,13 +27,18 @@ def test_not_allowed():
         return param2 * x + param3
 
     func1 = SimpleFunc(func=func1_pure, obs=obs1, p1=param1)
-    func2 = SimpleFunc(func=func2_pure, obs=obs1, p2=param2, p3=param3)
 
     pdf1 = SimplePDF(func=lambda self, x: x * param1, obs=obs1)
     pdf2 = SimplePDF(func=lambda self, x: x * param2, obs=obs1)
 
     with pytest.raises(ModelIncompatibleError):
         pdf1 + pdf2
+
+    ext_pdf1 = pdf1.create_extended(param1)
+    with pytest.raises(BreakingAPIChangeError):
+        ext_pdf1 + pdf2
+    with pytest.raises(BreakingAPIChangeError):
+        param2 * pdf1
     with pytest.raises(ValueError):
         param1 + func1
     with pytest.raises(NotImplementedError):
@@ -70,7 +72,6 @@ def test_func_func():
     param1 = Parameter('param1', 1.)
     param2 = Parameter('param2', 2.)
     param3 = Parameter('param3', 3., floating=False)
-    param4 = Parameter('param4', 4.)
 
     def func1_pure(self, x):
         x = z.unstack_x(x)
@@ -97,73 +98,3 @@ def test_func_func():
     true_prod_values = true_prod_values.numpy()
     np.testing.assert_allclose(true_added_values, added_values)
     np.testing.assert_allclose(true_prod_values, prod_values)
-
-
-def test_param_pdf():
-    param1 = Parameter('param1', 12.)
-    param2 = Parameter('param2', 22.)
-    yield1 = Parameter('yield1', 21.)
-    yield2 = Parameter('yield2', 22.)
-    pdf1 = SimplePDF(func=lambda self, x: x * param1, obs=obs1)
-    pdf2 = SimplePDF(func=lambda self, x: x * param2, obs=obs1)
-    assert not pdf1.is_extended
-    extended_pdf = yield1 * pdf1
-    assert extended_pdf.is_extended
-    with pytest.raises(ModelIncompatibleError):
-        _ = pdf2 * yield2
-    with pytest.raises(AlreadyExtendedPDFError):
-        _ = yield2 * extended_pdf
-
-
-def test_implicit_extended():
-    param1 = Parameter('param1', 12.)
-    yield1 = Parameter('yield1', 21.)
-    param2 = Parameter('param2', 13., floating=False)
-    yield2 = Parameter('yield2', 31., floating=False)
-    pdf1 = SimplePDF(func=lambda self, x: x * param1, obs=obs1)
-    pdf2 = SimplePDF(func=lambda self, x: x * param2, obs=obs1)
-    extended_pdf = yield1 * pdf1 + yield2 * pdf2
-    with pytest.raises(ModelIncompatibleError):
-        true_extended_pdf = SumPDF(pdfs=[pdf1, pdf2], obs=obs1)
-    assert isinstance(extended_pdf, SumPDF)
-    assert extended_pdf.is_extended
-
-
-def test_implicit_sumpdf():
-    norm_range = (-5.7, 13.6)
-    param1 = Parameter('param13s', 1.1)
-    frac1 = 0.11
-    frac1_param = Parameter('frac13s', frac1)
-    frac2 = 0.56
-    frac2_param = Parameter('frac23s', frac2)
-    frac3 = 1 - frac1 - frac2  # -frac1_param -frac2_param
-
-    param2 = Parameter('param23s', 1.5, floating=False)
-    param3 = Parameter('param33s', 0.4, floating=False)
-    pdf1 = SimplePDF(func=lambda self, x: x * param1 ** 2, obs=obs1)
-    pdf2 = SimplePDF(func=lambda self, x: x * param2, obs=obs1)
-    pdf3 = SimplePDF(func=lambda self, x: x * 2 + param3, obs=obs1)
-
-    # sugar 1
-    # sum_pdf = frac1_param * pdf1 + frac2_param * pdf2 + pdf3  # TODO(Mayou36): deps, correct copy
-    sum_pdf = zfit.pdf.SumPDF(pdfs=[pdf1, pdf2, pdf3], fracs=[frac1_param, frac2_param])
-
-    true_values = pdf1.pdf(rnd_test_values, norm_range=norm_range)
-    true_values *= frac1_param
-    true_values += pdf2.pdf(rnd_test_values, norm_range=norm_range) * frac2_param
-    true_values += pdf3.pdf(rnd_test_values, norm_range=norm_range) * z.constant(frac3)
-
-    assert isinstance(sum_pdf, SumPDF)
-    assert not sum_pdf.is_extended
-
-    assert sum(sum_pdf._maybe_extended_fracs).numpy() == 1.
-    true_values = true_values.numpy()
-    test_values = sum_pdf.pdf(rnd_test_values, norm_range=norm_range).numpy()
-    np.testing.assert_allclose(true_values, test_values, rtol=5e-2)  # it's MC normalized
-
-    # sugar 2
-    sum_pdf2_part1 = frac1 * pdf1 + frac2 * pdf3
-    # sum_pdf2 = sum_pdf2_part1 + pdf2  # TODO(Mayou36): deps copy
-
-    # test_values2 = sum_pdf2.pdf(rnd_test_values, norm_range=norm_range)  # TODO(Mayou36): deps copy
-    # np.testing.assert_allclose(true_values, test_values2, rtol=1e-2)  # it's MC normalized  # TODO(Mayou36): deps copy

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -31,7 +31,7 @@ def test_not_allowed():
     pdf1 = SimplePDF(func=lambda self, x: x * param1, obs=obs1)
     pdf2 = SimplePDF(func=lambda self, x: x * param2, obs=obs1)
 
-    with pytest.raises(ModelIncompatibleError):
+    with pytest.raises(BreakingAPIChangeError):
         pdf1 + pdf2
 
     ext_pdf1 = pdf1.create_extended(param1)

--- a/tests/test_pdf_sumpdf.py
+++ b/tests/test_pdf_sumpdf.py
@@ -64,7 +64,7 @@ def test_frac_behavior(yields):
         if isinstance(fracs, list) and len(fracs) == 3:
             assert sumpdf2.params['frac_2'] == frac3
 
-
+@pytest.mark.flaky(2)  # ks test
 def test_sampling():
     class SimpleSampleSumPDF(zfit.pdf.SumPDF):
 

--- a/tests/test_pdf_sumpdf.py
+++ b/tests/test_pdf_sumpdf.py
@@ -1,13 +1,63 @@
 #  Copyright (c) 2020 zfit
-import numpy as np
 import pytest
 
 import zfit
-from zfit import Parameter
 # noinspection PyUnresolvedReferences
 from zfit.core.testing import setup_function, teardown_function, tester
-from zfit.models.dist_tfp import Gauss
+
+
+def create_gaussians(yields):
+    obs = zfit.Space('obs1', (-2, 5))
+
+    gauss1 = zfit.pdf.Gauss(mu=2, sigma=4, obs=obs)
+    gauss2 = zfit.pdf.Gauss(mu=3, sigma=5, obs=obs)
+    gauss3 = zfit.pdf.Gauss(mu=1, sigma=6, obs=obs)
+    gausses = gauss1, gauss2, gauss3
+
+    if yields:
+        if len(yields) == 2:
+            yields = yields + [None]
+        gausses = [gauss.create_extended(yiel) if yiel is not None else gauss
+                   for gauss, yiel in zip(gausses, yields)]
+    return gausses
 
 
 def test_analytic_integral():
     obs = zfit.Space('obs1', (-2, 5))
+
+
+@pytest.mark.parametrize('yields', [False, [4, 3, 5], [1, 2]])
+def test_frac_behavior(yields):
+    gauss1, gauss2, gauss3 = create_gaussians(yields)
+
+    frac1 = zfit.Parameter('frac1', 0.4)
+    frac2 = zfit.Parameter('frac2', 0.6)
+    for fracs in [frac1, [frac1, frac2]]:
+        sumpdf1 = zfit.pdf.SumPDF([gauss1, gauss2], fracs)
+        assert sumpdf1.fracs[0] == frac1
+        assert len(sumpdf1.fracs) == 2
+        assert len(sumpdf1.params) == 2
+        assert sumpdf1.params['frac_0'] == frac1
+        assert sumpdf1.params['frac_1'] == sumpdf1.fracs[1]
+        assert not sumpdf1.is_extended
+
+        frac2_val = 1 - frac1.value()
+        assert pytest.approx(frac2_val.numpy(), sumpdf1.params['frac_1'].value().numpy())
+        if isinstance(fracs, list) and len(fracs) == 2:
+            assert sumpdf1.params['frac_1'] == frac2
+
+    frac1.set_value(0.3)
+    frac3 = zfit.Parameter('frac3', 0.1)
+
+    for fracs in [[frac1, frac2], [frac1, frac2, frac3]]:
+        sumpdf2 = zfit.pdf.SumPDF([gauss1, gauss2, gauss3], fracs)
+        assert sumpdf2.fracs[0] == frac1
+        assert len(sumpdf2.fracs) == 3
+        assert len(sumpdf2.params) == 3
+        assert sumpdf2.params['frac_0'] == frac1
+        assert sumpdf2.params['frac_1'] == frac2
+        assert pytest.approx(frac3.value().numpy(), sumpdf2.params['frac_2'].value().numpy())
+        assert not sumpdf1.is_extended
+
+        if isinstance(fracs, list) and len(fracs) == 3:
+            assert sumpdf2.params['frac_2'] == frac3

--- a/tests/test_pdf_sumpdf.py
+++ b/tests/test_pdf_sumpdf.py
@@ -1,0 +1,13 @@
+#  Copyright (c) 2020 zfit
+import numpy as np
+import pytest
+
+import zfit
+from zfit import Parameter
+# noinspection PyUnresolvedReferences
+from zfit.core.testing import setup_function, teardown_function, tester
+from zfit.models.dist_tfp import Gauss
+
+
+def test_analytic_integral():
+    obs = zfit.Space('obs1', (-2, 5))

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -26,7 +26,8 @@ from ..settings import ztypes
 from ..util import container as zcontainer, ztyping
 from ..util.cache import Cachable
 from ..util.exception import (BasePDFSubclassingError, MultipleLimitsNotImplementedError, NormRangeNotImplementedError,
-                              ShapeIncompatibleError, SubclassingError, CannotConvertToNumpyError, WorkInProgressError)
+                              ShapeIncompatibleError, SubclassingError, CannotConvertToNumpyError, WorkInProgressError,
+                              SpaceIncompatibleError)
 
 _BaseModel_USER_IMPL_METHODS_TO_CHECK = {}
 
@@ -265,6 +266,9 @@ class BaseModel(BaseNumeric, Cachable, BaseDimensional, ZfitModel):
         """
         if obs is None:  # for simple limits to convert them
             obs = self.obs
+        elif not set(obs).intersection(self.obs):
+            raise SpaceIncompatibleError("The given space {obs} is not compatible with the obs of the pdfs{self.obs};"
+                                         " they are disjoint.")
         space = convert_to_space(obs=obs, axes=axes, limits=limits)
 
         if self.space is not None:  # e.g. not the first call

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -873,7 +873,7 @@ class BaseModel(BaseNumeric, Cachable, BaseDimensional, ZfitModel):
             InvalidArgumentError: if n is not specified and pdf is not extended.
         """
         if not isinstance(n, str):
-            n = tf.convert_to_tensor(n) if not isinstance(n, str) else n
+            n = tf.convert_to_tensor(n)
             n = tf.cast(n, dtype=tf.int32)
 
         limits = self._check_input_limits(limits=limits)

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -272,14 +272,13 @@ class BasePDF(ZfitPDF, BaseModel):
         Returns:
             :py:class:`tf.Tensor`: 1-dimensional :py:class:`tf.Tensor` containing the unnormalized pdf.
         """
-        # if component_norm_range is None:
-        #     component_norm_range = self._get
+        if component_norm_range is not None:
+            raise BreakingAPIChangeError("component norm range should not be given anymore. If you want to set the norm"
+                                         " range for the components, use `set_norm_range(..., propagate=True)")
         with self._convert_sort_x(x) as x:
-            component_norm_range = self._check_input_norm_range(component_norm_range, caller_name=name,
-                                                                none_is_error=False)
-            return self._single_hook_unnormalized_pdf(x, component_norm_range, name)
+            return self._single_hook_unnormalized_pdf(x, name)
 
-    def _single_hook_unnormalized_pdf(self, x, component_norm_range, name):
+    def _single_hook_unnormalized_pdf(self, x, name):
         return self._call_unnormalized_pdf(x=x, name=name)
 
     def _call_unnormalized_pdf(self, x, name):
@@ -509,12 +508,7 @@ class BasePDF(ZfitPDF, BaseModel):
         from ..models.special import SimpleFunctorPDF
 
         def partial_integrate_wrapped(self_simple, x):
-            norm_range = self_simple._get_component_norm_range()
-            if norm_range not in (None, False) and norm_range.has_limits:
-                from zfit.models.functor import BaseFunctor
 
-                if isinstance(self, BaseFunctor):
-                    self._set_component_norm_range(norm_range)
             return self.partial_integrate(x, limits=limits_to_integrate, norm_range=False)
 
         new_pdf = SimpleFunctorPDF(obs=self.space.get_subspace(obs=[obs for obs in self.obs

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -146,34 +146,34 @@ class BasePDF(ZfitPDF, BaseModel):
 
     def _single_hook_integrate(self, limits, norm_range, name='hook_integrate'):
         integral = super()._single_hook_integrate(limits=limits, norm_range=norm_range, name=name)
-        integral = self.apply_yield(integral, norm_range=norm_range)
+        # integral = self.apply_yield(integral, norm_range=norm_range)
         return integral
 
     def _single_hook_analytic_integrate(self, limits, norm_range, name='hook_analytic_integrate'):
         integral = super()._single_hook_analytic_integrate(limits=limits, norm_range=norm_range, name=name)
-        integral = self.apply_yield(integral, norm_range=norm_range)
+        # integral = self.apply_yield(integral, norm_range=norm_range)
         return integral
 
     def _single_hook_numeric_integrate(self, limits, norm_range, name='hook_numeric_integrate'):
         numeric_integral = super()._single_hook_numeric_integrate(limits=limits, norm_range=norm_range, name=name)
-        numeric_integral = self.apply_yield(numeric_integral, norm_range=norm_range)
+        # numeric_integral = self.apply_yield(numeric_integral, norm_range=norm_range)
         return numeric_integral
 
     def _single_hook_partial_integrate(self, x, limits, norm_range, name='hook_partial_integrate'):
         partial_integral = super()._single_hook_partial_integrate(x=x, limits=limits, norm_range=norm_range, name=name)
-        partial_integral = self.apply_yield(partial_integral, norm_range=norm_range)
+        # partial_integral = self.apply_yield(partial_integral, norm_range=norm_range)
         return partial_integral
 
     def _single_hook_partial_analytic_integrate(self, x, limits, norm_range, name='hook_partial_analytic_integrate'):
         part_analytic_int = super()._single_hook_partial_analytic_integrate(x=x, limits=limits, norm_range=norm_range,
                                                                             name=name)
-        part_analytic_int = self.apply_yield(part_analytic_int, norm_range=norm_range)
+        # part_analytic_int = self.apply_yield(part_analytic_int, norm_range=norm_range)
         return part_analytic_int
 
     def _single_hook_partial_numeric_integrate(self, x, limits, norm_range, name='hook_partial_numeric_integrate'):
         part_numeric_int = super()._single_hook_partial_numeric_integrate(x=x, limits=limits, norm_range=norm_range,
                                                                           name=name)
-        part_numeric_int = self.apply_yield(part_numeric_int, norm_range=norm_range)
+        # part_numeric_int = self.apply_yield(part_numeric_int, norm_range=norm_range)
         return part_numeric_int
 
     @property

--- a/zfit/core/coordinates.py
+++ b/zfit/core/coordinates.py
@@ -414,10 +414,11 @@ def convert_to_obs_str(obs, container=tuple):
     """
     if obs is None:
         return obs
-    obs = convert_to_container(value=obs, container=container)
     if isinstance(obs, ZfitDimensional):
         new_obs = obs.obs
+
     else:
+        obs = convert_to_container(value=obs, container=container)
         new_obs = []
         for ob in obs:
 

--- a/zfit/core/coordinates.py
+++ b/zfit/core/coordinates.py
@@ -44,6 +44,8 @@ class Coordinates(ZfitOrderableDimensional):
             if axes is not None:
                 if not len(obs) == len(axes):
                     raise CoordinatesIncompatibleError("obs and axes do not have the same length.")
+        if not (obs or axes):
+            raise CoordinatesUnderdefinedError(f"Neither obs {obs} nor axes {axes} are defined.")
         return obs, axes, n_obs
 
     @property
@@ -108,6 +110,9 @@ class Coordinates(ZfitOrderableDimensional):
             if self.obs is None:
                 new_coords = type(self)(obs=obs, axes=self.axes)
             else:
+                if not set(obs).intersection(self.obs):
+                    raise ObsIncompatibleError(f"The requested obs {obs} are not compatible with the current obs "
+                                               f"{self.obs}")
 
                 if not frozenset(obs) == frozenset(self.obs):
 
@@ -173,6 +178,9 @@ class Coordinates(ZfitOrderableDimensional):
             if self.axes is None:
                 new_coords = type(self)(obs=self.obs, axes=axes)
             else:
+                if not set(axes).intersection(self.axes):
+                    raise AxesIncompatibleError(f"The requested axes {axes} are not compatible with the current axes "
+                                                f"{self.axes}")
                 if not frozenset(axes) == frozenset(self.axes):
                     if not allow_superset and set(axes) - set(self.axes):
                         raise AxesIncompatibleError(

--- a/zfit/core/dimension.py
+++ b/zfit/core/dimension.py
@@ -1,6 +1,6 @@
 #  Copyright (c) 2020 zfit
 
-from typing import Iterable, List, Union
+from typing import Iterable, List, Union, Dict, Set
 
 import numpy as np
 
@@ -149,3 +149,26 @@ def common_axes(spaces: ztyping.SpaceOrSpacesTypeInput) -> Union[List[str], bool
             if ax not in all_axes:
                 all_axes.append(ax)
     return all_axes
+
+
+def obs_subsets(dimensionals: Iterable[ZfitDimensional]) -> Dict[Set[str], ZfitDimensional]:
+    """Split `dimensionals` into the smallest subgroup of obs and return a dict.
+
+    Args:
+        dimensionals: An Iterable containing two or more ZfitDimensional that should be split into the smallest subset.
+
+    Returns:
+        dict: dict with the keys being sets of observables and the values, an iterable, containing the ZfitDimensional
+    """
+    obs_dims = {}
+    for dim in dimensionals:
+        for obs in obs_dims:
+            if obs.intersection(dim.obs):
+                union = obs.union(dim.obs)
+                obs_dims[union] = obs_dims.pop(obs)
+                obs_dims[union].append(dim)
+                break  # we had a match, go to the next dim
+        else:
+            obs_dims[frozenset(dim.obs)] = [dim]
+
+    return obs_dims

--- a/zfit/core/operations.py
+++ b/zfit/core/operations.py
@@ -174,7 +174,7 @@ def _convert_to_known(object1, object2):
 def add_pdf_pdf(pdf1: ZfitPDF, pdf2: ZfitPDF, name: str = "add_pdf_pdf") -> "SumPDF":
     if not (isinstance(pdf1, ZfitPDF) and isinstance(pdf2, ZfitPDF)):
         raise TypeError("`pdf1` and `pdf2` need to be `ZfitPDF` and not {}, {}".format(pdf1, pdf2))
-    if not pdf1.is_extended and pdf2.is_extended:
+    if not (pdf1.is_extended and pdf2.is_extended):
         raise BreakingAPIChangeError("Adding (non-extended) pdfs is not allowed anymore due to disambiguity."
                                      "Use the `zfit.pdf.SumPDF([pdf, other_pdf], frac)` syntax instead.")
     from ..models.functor import SumPDF

--- a/zfit/core/operations.py
+++ b/zfit/core/operations.py
@@ -201,7 +201,7 @@ def add_param_param(param1: ZfitParameter, param2: ZfitParameter) -> ZfitParamet
     if not (isinstance(param1, ZfitParameter) and isinstance(param2, ZfitParameter)):
         raise TypeError("`param1` and `param2` need to be `ZfitParameter` and not {}, {}".format(param1, param2))
     # use the default behavior of variables
-    return param1 + param2
+    return tf.add(param1, param2)
 
 
 # Conversions

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -415,7 +415,7 @@ class Parameter(ZfitParameterMixin, TFBaseVariable, BaseParameter):
         step_size = self._step_size
         if step_size is None:
             # auto-infer from limits
-            step_splits = 1e4
+            step_splits = 1e5
             if self.has_limits:
                 step_size = (self.upper_limit - self.lower_limit) / step_splits  # TODO improve? can be tensor?
             else:

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -510,6 +510,10 @@ class BaseComposedParameter(BaseZParameter):
         super().__init__(value_fn=value_fn, name=name, params=params, **kwargs)
         # self.params = params
 
+    @property  # TODO: hacky way, proper name for params
+    def name(self):
+        return self._name
+
     def _get_dependents(self):
         dependents = self._extract_dependents(list(self.params.values()))
         return dependents

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -2,7 +2,7 @@
 #  Copyright (c) 2020 zfit
 from collections import OrderedDict
 from contextlib import suppress
-from typing import Callable, Iterable, Union
+from typing import Callable, Iterable, Union, Optional
 
 import numpy as np
 import tensorflow as tf
@@ -300,8 +300,12 @@ class Parameter(ZfitParameterMixin, TFBaseVariable, BaseParameter):
     _independent_params = []
     DEFAULT_STEP_SIZE = 0.001
 
-    def __init__(self, name, value, lower_limit=None, upper_limit=None, step_size=None, floating=True,
-                 dtype=ztypes.float, **kwargs):
+    def __init__(self, name: str, value: ztyping.NumericalScalarType,
+                 lower_limit: Optional[ztyping.NumericalScalarType] = None,
+                 upper_limit: Optional[ztyping.NumericalScalarType] = None,
+                 step_size: Optional[ztyping.NumericalScalarType] = None,
+                 floating: bool = True,
+                 dtype: tf.DType = ztypes.float, **kwargs):
         """
             name : name of the parameter,
             value : starting value
@@ -552,6 +556,10 @@ class ConstantParameter(BaseZParameter):
 
     def _get_dependents(self) -> ztyping.DependentsType:
         return OrderedSet()
+
+    def __repr__(self):
+        value = self.value()
+        return f"<zfit.{self.__class__.__name__} '{self.name}' dtype={self.dtype.name} value={value:.4g}>"
 
 
 register_tensor_conversion(ConstantParameter, overload_operators=True)

--- a/zfit/core/space.py
+++ b/zfit/core/space.py
@@ -2191,11 +2191,12 @@ def compare_multispace(space1: ZfitSpace, space2: ZfitSpace, comparator: Callabl
     obs_not_none = space1.obs is not None and space2.obs is not None
     if not (axes_not_none or obs_not_none):  # if both are None
         return False
-    if axes_not_none:
-        if set(space1.axes) != set(space2.axes):
-            return False
+
     if obs_not_none:
         if set(space1.obs) != set(space2.obs):
+            return False
+    elif axes_not_none:  # axes only matter if there are no obs
+        if set(space1.axes) != set(space2.axes):
             return False
     # check limits
     if not space1.limits_are_set:

--- a/zfit/core/testing.py
+++ b/zfit/core/testing.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from typing import Callable, Tuple, List, Union, Iterable
 
 import scipy.stats
+import tensorflow as tf
 
 from .interfaces import ZfitPDF
 from .parameter import ZfitParameterMixin
@@ -25,6 +26,7 @@ def teardown_function():
     ZfitParameterMixin._existing_names.clear()
 
     clear_caches()
+    tf.compat.v1.reset_default_graph()
 
 
 class BaseTester:

--- a/zfit/minimizers/baseminimizer.py
+++ b/zfit/minimizers/baseminimizer.py
@@ -299,5 +299,5 @@ def print_gradients(params, values, gradients, loss=None):
     for param, value, grad in zip(params, values, gradients):
         table.add_row([param.name, value, grad])
     if loss is not None:
-        table.add_row(["Loss value:", loss])
+        table.add_row(["Loss value:", loss, "|"])
     print(table.draw())

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -59,12 +59,13 @@ def _covariance_np(result, params):
     if any([data.weights is not None for data in result.loss.data]):
         raise WeightsNotImplementedError("Weights are not supported with hesse numpy.")
 
-    numgrad_was_none = settings.options.numerical_grad is None
-    if numgrad_was_none:
-        settings.options.numerical_grad = True
+    # TODO: maybe activate again? currently fails due to numerical problems
+    # numgrad_was_none = settings.options.numerical_grad is None
+    # if numgrad_was_none:
+    #     settings.options.numerical_grad = True
     covariance = np.linalg.inv(result.loss.value_gradients_hessian(params)[2])
-    if numgrad_was_none:
-        settings.options.numerical_grad = None
+    # if numgrad_was_none:
+    #     settings.options.numerical_grad = None
 
     return matrix_to_dict(params, covariance)
 

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -1,17 +1,17 @@
 #  Copyright (c) 2020 zfit
 
+import itertools
 from collections import OrderedDict
 from typing import Dict, Union, Callable, Optional
-import itertools
 
 import numpy as np
 
-import zfit
-from zfit.util.exception import WeightsNotImplementedError, WorkInProgressError
 from .interface import ZfitMinimizer, ZfitResult
 from ..core.interfaces import ZfitLoss, ZfitParameter
 from ..util.container import convert_to_container
+from ..util.exception import WeightsNotImplementedError
 from ..util.ztyping import ParamsTypeOpt
+from .. import settings
 
 
 def _minos_minuit(result, params, sigma=1.0):
@@ -30,7 +30,6 @@ def _minos_minuit(result, params, sigma=1.0):
 
 
 def _covariance_minuit(result, params):
-
     # check if no weights in data
     if any([data.weights is not None for data in result.loss.data]):
         raise WeightsNotImplementedError("Weights are not supported with minuit hesse.")
@@ -56,12 +55,16 @@ def _covariance_minuit(result, params):
 
 
 def _covariance_np(result, params):
-
     # check if no weights in data
     if any([data.weights is not None for data in result.loss.data]):
         raise WeightsNotImplementedError("Weights are not supported with hesse numpy.")
 
+    numgrad_was_none = settings.options.numerical_grad is None
+    if numgrad_was_none:
+        settings.options.numerical_grad = True
     covariance = np.linalg.inv(result.loss.value_gradients_hessian(params)[2])
+    if numgrad_was_none:
+        settings.options.numerical_grad = None
 
     return matrix_to_dict(params, covariance)
 
@@ -71,7 +74,6 @@ class FitResult(ZfitResult):
     _hesse_methods = {"minuit_hesse": _covariance_minuit, "hesse_np": _covariance_np}
     _default_error = "minuit_minos"
     _error_methods = {"minuit_minos": _minos_minuit}
-
 
     def __init__(self, params: Dict[ZfitParameter, float], edm: float, fmin: float, status: int, converged: bool,
                  info: dict, loss: ZfitLoss, minimizer: "ZfitMinimizer"):
@@ -337,7 +339,6 @@ def matrix_to_dict(params, matrix):
                 matrix_dict[(pj, pi)] = matrix[i, j]
 
     return matrix_dict
-
 
 # def set_error_method(self, method):
 #     if isinstance(method, str):

--- a/zfit/models/basefunctor.py
+++ b/zfit/models/basefunctor.py
@@ -43,8 +43,8 @@ def extract_daughter_input_obs(obs: ztyping.ObsTypeInput, spaces: Iterable[ZfitS
             obs = obs
         else:
             obs = Space(obs=obs)
-        if not frozenset(obs.obs) == frozenset(models_space.obs):  # not needed, example projection
-            raise SpaceIncompatibleError("The given obs do not coincide with the obs from the daughter models.")
+        # if not frozenset(obs.obs) == frozenset(models_space.obs):  # not needed, example projection
+        #     raise SpaceIncompatibleError("The given obs do not coincide with the obs from the daughter models.")
         if not obs.obs == models_space.obs and not obs.limits_are_set:
             obs = models_space.with_obs(obs.obs)
 

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -6,7 +6,6 @@ build larger models.
 #  Copyright (c) 2020 zfit
 
 import math as mt
-import warnings
 
 import numpy as np
 import tensorflow as tf
@@ -15,7 +14,7 @@ from zfit import z
 from ..core.basepdf import BasePDF
 from ..core.space import Space, ANY_LOWER, ANY_UPPER
 from ..util import ztyping
-from ..util.temporary import TemporarilySet
+from ..util.warnings import warn_advanced_feature
 
 infinity = mt.inf
 
@@ -60,12 +59,27 @@ class Exponential(BasePDF):
         """
         params = {'lambda': lambda_}
         super().__init__(obs, name=name, params=params, **kwargs)
-        self._numerics_data_shift = None
+        if not self.space.has_limits:
+            warn_advanced_feature("Exponential pdf relies on a shift of the input towards 0 to keep the numerical "
+                                  f"stability high. The space {self.space} does not have limits set and no shift"
+                                  f" will occure. To set it manually, set _numerics_data_shift to the expected"
+                                  f" average values given to this function _in case you want things to be set_."
+                                  f"If this sounds unfamiliar, regard this as an error and use a normalization range.",
+                                  identifier='exp_shift')
+        self._set_numerics_data_shift(self.space)
 
     def _unnormalized_pdf(self, x):
         lambda_ = self.params['lambda']
         x = x.unstack_x()
-        return self._numerics_shifted_exp(x=x, lambda_=lambda_)  # Don't use exp! will overflow.
+        probs = self._numerics_shifted_exp(x=x, lambda_=lambda_)
+        tf.debugging.assert_all_finite(probs, f"Exponendial pdf {self} has non valid values. This is likely caused"
+                                              f"by numerical problems: if the exponential is too steep, this will"
+                                              f"yield NaNs or infs. Make sure that your lambda is small enough and/or"
+                                              f" the initial space is in the same"
+                                              f" region as your data (and norm_range, if explicitly set differently)."
+                                              f" If this issue still persists, please oben an issue on Github:"
+                                              f"https://github.com/zfit/zfit")
+        return probs  # Don't use exp! will overflow.
 
     def _numerics_shifted_exp(self, x, lambda_):  # needed due to overflow in exp otherwise, prevents by shift
         return z.exp(lambda_ * (x - self._numerics_data_shift))
@@ -82,72 +96,66 @@ class Exponential(BasePDF):
         value = (upper_val + lower_val) / 2
         value = z.unstable.gather(value, 0, axis=-1)  # removing the last dimension
 
-        if max(abs(lower_val - value), abs(upper_val - value)) > 710:
-            warnings.warn(
-                "Boundaries can be too wide for exponential (assuming lambda ~ 1), expect `inf` in exp(x) and `NaN`s."
-                "(upper - lower) * lambda should be smaller than 1400 roughly",
-                category=RuntimeWarning)
+        # if max(abs(lower_val - value), abs(upper_val - value)) > 710:
+        #     warnings.warn(
+        #         "Boundaries can be too wide for exponential (assuming lambda ~ 1), expect `inf` in exp(x) and `NaN`s."
+        #         "(upper - lower) * lambda should be smaller than 1400 roughly",
+        #         category=RuntimeWarning)
 
-        def setter(value):
-            self._numerics_data_shift = value
-
-        def getter():
-            return self._numerics_data_shift
-
-        return TemporarilySet(value=value, getter=getter, setter=setter)
+        self._numerics_data_shift = value
 
     # All hooks are needed to set the right shift when "entering" the pdf. The norm range is taken where both are
     # available. No special need needs to be taken for sampling (it samples from the correct region, the limits, and
     # uses the predictions by the `unnormalized_prob` -> that is shifted correctly
-    def _single_hook_integrate(self, limits, norm_range, name='_hook_integrate'):
-        with self._set_numerics_data_shift(limits=limits):
-            return super()._single_hook_integrate(limits, norm_range, name)
-
-    def _single_hook_analytic_integrate(self, limits, norm_range, name="_hook_analytic_integrate"):
-        with self._set_numerics_data_shift(limits=limits):
-            return super()._single_hook_analytic_integrate(limits, norm_range, name)
-
-    def _single_hook_numeric_integrate(self, limits, norm_range, name='_hook_numeric_integrate'):
-        with self._set_numerics_data_shift(limits=limits):
-            return super()._single_hook_numeric_integrate(limits, norm_range, name)
-
-    def _single_hook_partial_integrate(self, x, limits, norm_range, name='_hook_partial_integrate'):
-        with self._set_numerics_data_shift(limits=limits):
-            return super()._single_hook_partial_integrate(x, limits, norm_range, name)
-
-    def _single_hook_partial_analytic_integrate(self, x, limits, norm_range, name='_hook_partial_analytic_integrate'):
-        with self._set_numerics_data_shift(limits=limits):
-            return super()._single_hook_partial_analytic_integrate(x, limits, norm_range, name)
-
-    def _single_hook_partial_numeric_integrate(self, x, limits, norm_range, name='_hook_partial_numeric_integrate'):
-        with self._set_numerics_data_shift(limits=limits):
-            return super()._single_hook_partial_numeric_integrate(x, limits, norm_range, name)
-
-    def _single_hook_normalization(self, limits, name):
-        with self._set_numerics_data_shift(limits=limits):
-            return super()._single_hook_normalization(limits, name)
-
-    # TODO: remove component_norm_range? But needed for integral?
-    def _single_hook_unnormalized_pdf(self, x, component_norm_range, name):
-        if component_norm_range.limits_are_false:
-            component_norm_range = self.space
-        if component_norm_range.limits_are_set:
-            with self._set_numerics_data_shift(limits=component_norm_range):
-                return super()._single_hook_unnormalized_pdf(x, component_norm_range, name)
-        else:
-            return super()._single_hook_unnormalized_pdf(x, component_norm_range, name)
-
-    def _single_hook_pdf(self, x, norm_range, name):
-        with self._set_numerics_data_shift(limits=norm_range):
-            return super()._single_hook_pdf(x, norm_range, name)
-
-    def _single_hook_log_pdf(self, x, norm_range, name):
-        with self._set_numerics_data_shift(limits=norm_range):
-            return super()._single_hook_log_pdf(x, norm_range, name)
-
-    def _single_hook_sample(self, n, limits, name):
-        with self._set_numerics_data_shift(limits=limits):
-            return super()._single_hook_sample(n, limits, name)
+    # def _single_hook_integrate(self, limits, norm_range, name='_hook_integrate'):
+    #     with self._set_numerics_data_shift(limits=limits):
+    #         return super()._single_hook_integrate(limits, norm_range, name)
+    #
+    # def _single_hook_analytic_integrate(self, limits, norm_range, name="_hook_analytic_integrate"):
+    #     with self._set_numerics_data_shift(limits=limits):
+    #         return super()._single_hook_analytic_integrate(limits, norm_range, name)
+    #
+    # def _single_hook_numeric_integrate(self, limits, norm_range, name='_hook_numeric_integrate'):
+    #     with self._set_numerics_data_shift(limits=limits):
+    #         return super()._single_hook_numeric_integrate(limits, norm_range, name)
+    #
+    # def _single_hook_partial_integrate(self, x, limits, norm_range, name='_hook_partial_integrate'):
+    #     with self._set_numerics_data_shift(limits=limits):
+    #         return super()._single_hook_partial_integrate(x, limits, norm_range, name)
+    #
+    # def _single_hook_partial_analytic_integrate(self, x, limits, norm_range, name='_hook_partial_analytic_integrate'):
+    #     with self._set_numerics_data_shift(limits=limits):
+    #         return super()._single_hook_partial_analytic_integrate(x, limits, norm_range, name)
+    #
+    # def _single_hook_partial_numeric_integrate(self, x, limits, norm_range, name='_hook_partial_numeric_integrate'):
+    #     with self._set_numerics_data_shift(limits=limits):
+    #         return super()._single_hook_partial_numeric_integrate(x, limits, norm_range, name)
+    #
+    # def _single_hook_normalization(self, limits, name):
+    #     with self._set_numerics_data_shift(limits=limits):
+    #         return super()._single_hook_normalization(limits, name)
+    #
+    # # TODO: remove component_norm_range? But needed for integral?
+    # def _single_hook_unnormalized_pdf(self, x, name):
+    #     if component_norm_range.limits_are_false:
+    #         component_norm_range = self.space
+    #     if component_norm_range.limits_are_set:
+    #         with self._set_numerics_data_shift(limits=component_norm_range):
+    #             return super()._single_hook_unnormalized_pdf(x, name)
+    #     else:
+    #         return super()._single_hook_unnormalized_pdf(x, name)
+    #
+    # def _single_hook_pdf(self, x, norm_range, name):
+    #     with self._set_numerics_data_shift(limits=norm_range):
+    #         return super()._single_hook_pdf(x, norm_range, name)
+    #
+    # def _single_hook_log_pdf(self, x, norm_range, name):
+    #     with self._set_numerics_data_shift(limits=norm_range):
+    #         return super()._single_hook_log_pdf(x, norm_range, name)
+    #
+    # def _single_hook_sample(self, n, limits, name):
+    #     with self._set_numerics_data_shift(limits=limits):
+    #         return super()._single_hook_sample(n, limits, name)
 
 
 def _exp_integral_from_any_to_any(limits, params, model):

--- a/zfit/models/functor.py
+++ b/zfit/models/functor.py
@@ -239,7 +239,7 @@ class SumPDF(BaseFunctor):
     @supports(multiple_limits=True)
     def _integrate(self, limits, norm_range):
         pdfs = self.pdfs
-        fracs = self.params.values()
+        fracs = self.fracs
         # TODO(SUM): why was this needed?
         # assert norm_range not in (None, False), "Bug, who requested an unnormalized integral?"
         integrals = [frac * pdf.integrate(limits=limits)  # do NOT propagate the norm_range!
@@ -252,7 +252,7 @@ class SumPDF(BaseFunctor):
     @supports(multiple_limits=True)
     def _analytic_integrate(self, limits, norm_range):
         pdfs = self.pdfs
-        fracs = self.params.values()
+        fracs = self.fracs
         # TODO(SUM): why was this needed?
         # assert norm_range not in (None, False), "Bug, who requested an unnormalized integral?"
         try:
@@ -272,7 +272,7 @@ class SumPDF(BaseFunctor):
     def _partial_integrate(self, x, limits, norm_range):
 
         pdfs = self.pdfs
-        fracs = self.params.values()
+        fracs = self.fracs
 
         partial_integral = [pdf.partial_integrate(x=x, limits=limits)  # do NOT propagate the norm_range!
                             for pdf in zip(pdfs, fracs)]
@@ -282,7 +282,7 @@ class SumPDF(BaseFunctor):
     @supports(multiple_limits=True)
     def _partial_analytic_integrate(self, x, limits, norm_range):
         pdfs = self.pdfs
-        fracs = self.params.values()
+        fracs = self.fracs
         try:
             partial_integral = [pdf.partial_analytic_integrate(x=x, limits=limits)  # do NOT propagate the norm_range!
                                 for pdf in zip(pdfs, fracs)]

--- a/zfit/settings.py
+++ b/zfit/settings.py
@@ -50,5 +50,6 @@ options = DotDict({'epsilon': 1e-8,
 
 advanced_warnings = DotDict({
     'sum_extended_frac': True,
+    'exp_shift': True,
     'all': True,
 })

--- a/zfit/settings.py
+++ b/zfit/settings.py
@@ -1,9 +1,7 @@
-#  Copyright (c) 2019 zfit
+#  Copyright (c) 2020 zfit
 
 import numpy as np
 import tensorflow as tf
-
-
 
 from .util.container import DotDict
 from .util.execution import RunManager
@@ -18,19 +16,22 @@ def set_seed(seed):
     np.random.seed(seed)
     tf.compat.v1.random.set_random_seed(seed)
 
+
 _verbosity = 5
+
 
 def set_verbosity(verbosity):
     global _verbosity
     _verbosity = verbosity
+
 
 def get_verbosity():
     return _verbosity
 
 
 ztypes = DotDict({'float': tf.float64,
-                 'complex': tf.complex128,
-                 'int': tf.int64,
+                  'complex': tf.complex128,
+                  'int': tf.int64,
                   tf.float16: tf.float64,
                   tf.float32: tf.float64,
                   tf.float64: tf.float64,
@@ -40,8 +41,14 @@ ztypes = DotDict({'float': tf.float64,
                   tf.int16: tf.int64,
                   tf.int32: tf.int64,
                   tf.int64: tf.int64,
-                 'auto_upcast': True,
+                  'auto_upcast': True,
                   })
 
 options = DotDict({'epsilon': 1e-8,
-                   'numerical_grad': None})
+                   'numerical_grad': None,
+                   'advanced_warning': True})
+
+advanced_warnings = DotDict({
+    'sum_extended_frac': True,
+    'all': True,
+})

--- a/zfit/util/exception.py
+++ b/zfit/util/exception.py
@@ -51,6 +51,10 @@ class LimitsUnderdefinedError(UnderdefinedError):
     pass
 
 
+class NormRangeUnderdefinedError(UnderdefinedError):
+    pass
+
+
 class OverdefinedError(IntentionAmbiguousError):
     pass
 

--- a/zfit/util/exception.py
+++ b/zfit/util/exception.py
@@ -11,6 +11,10 @@ class LogicalUndefinedOperationError(Exception):
     pass
 
 
+class OperationNotAllowedError(Exception):
+    pass
+
+
 class ExtendedPDFError(Exception):
     pass
 
@@ -133,8 +137,10 @@ class ModelIncompatibleError(IncompatibleError):
 class WeightsNotImplementedError(Exception):
     pass
 
+
 class DataIsBatchedError(Exception):
     pass
+
 
 # Parameter errors
 class ParameterNotIndependentError(Exception):
@@ -148,7 +154,6 @@ class NotMinimizedError(Exception):
 
 
 # Runtime Errors
-
 
 
 class IllegalInGraphModeError(Exception):

--- a/zfit/util/warnings.py
+++ b/zfit/util/warnings.py
@@ -19,3 +19,18 @@ def warn_experimental_feature(func):
         return func(*args, **kwargs)
 
     return wrapped_func
+
+
+class AdvancedFeatureWarning(UserWarning):
+    pass
+
+
+def warn_advanced_feature(message, identifier):
+    from .. import settings
+
+    if settings.advanced_warnings[identifier] and settings.advanced_warnings.all:
+        warnings.warn(
+            "Either you're using an advanced feature OR causing unwanted behavior. "
+            "To turn this warning off, use `zfit.settings.advanced_warnings.{identifier}` = False`\n"
+            " or 'all' (dangerous) with `zfit.settings.advanced_warnings.all = False"
+            + message, category=AdvancedFeatureWarning, stacklevel=2)

--- a/zfit/util/ztyping.py
+++ b/zfit/util/ztyping.py
@@ -43,6 +43,7 @@ AxesTypeReturn = Union[Tuple[int], None]
 
 ObsTypeInput = Union[str, Iterable[str], "zfit.Space"]
 ObsTypeReturn = Union[Tuple[str, ...], None]
+ObsType = Tuple[str]
 
 # Space
 SpaceOrSpacesTypeInput = Union["zfit.Space", Iterable["zfit.Space"]]

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -121,9 +121,9 @@ def numerical_hessian(func: Callable, params: Iterable["zfit.Parameter"], hessia
     original_vals = [param.read_value() for param in params]
 
     if hessian == 'diag':
-        hesse_func = numdifftools.Hessdiag(wrapped_func)
+        hesse_func = numdifftools.Hessdiag(wrapped_func, step=1e-4)
     else:
-        hesse_func = numdifftools.Hessian(wrapped_func)
+        hesse_func = numdifftools.Hessian(wrapped_func, base_step=1e-4)
     computed_hessian = tf.py_function(hesse_func, inp=[param_vals],
                                       Tout=tf.float64)
     n_params = param_vals.shape[0]

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -121,9 +121,14 @@ def numerical_hessian(func: Callable, params: Iterable["zfit.Parameter"], hessia
     original_vals = [param.read_value() for param in params]
 
     if hessian == 'diag':
-        hesse_func = numdifftools.Hessdiag(wrapped_func, step=1e-4)
+        hesse_func = numdifftools.Hessdiag(wrapped_func,
+                                           # TODO: maybe add step to remove numerical problems?
+                                           # step=1e-4
+                                           )
     else:
-        hesse_func = numdifftools.Hessian(wrapped_func, base_step=1e-4)
+        hesse_func = numdifftools.Hessian(wrapped_func,
+                                          # base_step=1e-4
+                                          )
     computed_hessian = tf.py_function(hesse_func, inp=[param_vals],
                                       Tout=tf.float64)
     n_params = param_vals.shape[0]

--- a/zfit/z/random.py
+++ b/zfit/z/random.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2019 zfit
+#  Copyright (c) 2020 zfit
 
 from typing import Union, Iterable, Sized
 
@@ -23,7 +23,7 @@ def counts_multinomial(total_count: Union[int, tf.Tensor], probs: Iterable[Union
         logits: Same as probs but from [-inf, inf] (will be transformet to [0, 1])
 
     Returns:
-        :py:class.`tf.Tensor`: shape (k,) tensor containing the number of draws.
+        :py:class:`tf.Tensor`: shape (k,) tensor containing the number of draws.
     """
     total_count = tf.convert_to_tensor(total_count)
     probs = tf.convert_to_tensor(probs) if probs is not None else probs


### PR DESCRIPTION
Fixes #


## Proposed Changes

  - fracs are mandatory and do never make a pdf extended. Only if *all* pdfs are extended, the fracs argument can be omitted.
  -
  -

## Tests added

  -
  -
  -
  
## Checklist

 - [x] change approved
 - [x] implementation finished
 - [x] correct namespace imported
 - [x] tests added
 - [x] CHANGELOG updated

