### PR TITLE
Fix GaussianConstraint example

### DIFF
--- a/docs/intro/loss.rst
+++ b/docs/intro/loss.rst
@@ -31,7 +31,9 @@ For example, if we wanted to add a gaussian constraint on the ``mu`` parameter o
 
 .. code-block:: pycon
 
-    >>> constraint = zfit.constraint.GaussianConstraint(params=mu, mu=5279., sigma=10.))
+    >>> constraint = zfit.constraint.GaussianConstraint(params=mu,
+    >>>                                                observation=5279.,
+    >>>                                                uncertainty=10.)
 
     >>> my_loss = zfit.loss.UnbinnedNLL(model_cb,
     >>>                                 data,


### PR DESCRIPTION
## Proposed Changes

  - Fixes the example for GaussianConstraint in the documentation as the keyword arguments were renamed in the constructor.

## Checklist

 - [ ] change approved
 - [ ] implementation finished
 - [ ] correct namespace imported
 - [ ] tests added
 - [ ] CHANGELOG updated

