### PR TITLE
Remove type hints in docstrings.

### DIFF
--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -18,7 +18,7 @@ def nll_gaussian(params: ztyping.ParamTypeInput, observation: ztyping.NumericalS
         uncertainty: Uncertainties or covariance/error
             matrix of the observed values. Can either be a single value, a list of values, an array or a tensor
     Returns:
-        the constraint object
+        The constraint object
     Raises:
         ShapeIncompatibleError: if params, mu and sigma don't have the same size
     """

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -13,9 +13,9 @@ def nll_gaussian(params: ztyping.ParamTypeInput, observation: ztyping.NumericalS
                  uncertainty: ztyping.NumericalScalarType) -> tf.Tensor:
     """Return negative log likelihood graph for gaussian constraints on a list of parameters.
     Args:
-        params (list(zfit.Parameter)): The parameters to constraint
-        observation (numerical, list(numerical)): observed values of the parameter
-        uncertainty (numerical, list(numerical) or array/tensor): Uncertainties or covariance/error
+        params: The parameters to constraint
+        observation: observed values of the parameter
+        uncertainty: Uncertainties or covariance/error
             matrix of the observed values. Can either be a single value, a list of values, an array or a tensor
     Returns:
         `GaussianConstraint`: the constraint object

--- a/zfit/constraint.py
+++ b/zfit/constraint.py
@@ -18,7 +18,7 @@ def nll_gaussian(params: ztyping.ParamTypeInput, observation: ztyping.NumericalS
         uncertainty: Uncertainties or covariance/error
             matrix of the observed values. Can either be a single value, a list of values, an array or a tensor
     Returns:
-        `GaussianConstraint`: the constraint object
+        the constraint object
     Raises:
         ShapeIncompatibleError: if params, mu and sigma don't have the same size
     """

--- a/zfit/core/basefunc.py
+++ b/zfit/core/basefunc.py
@@ -77,7 +77,7 @@ class BaseFunc(BaseModel, ZfitFunc):
         """Create a PDF out of the function
 
         Returns:
-            a PDF with the current function as the unnormalized probability.
+            A PDF with the current function as the unnormalized probability.
         """
         from zfit.core.operations import convert_func_to_pdf
         return convert_func_to_pdf(func=self)

--- a/zfit/core/basefunc.py
+++ b/zfit/core/basefunc.py
@@ -48,8 +48,8 @@ class BaseFunc(BaseModel, ZfitFunc):
         """The function evaluated at `x`.
 
         Args:
-            x (`Data`):
-            name (str):
+            x:
+            name:
 
         Returns:
             tf.Tensor:  # TODO(Mayou36): or dataset? Update: rather not, what would obs be?

--- a/zfit/core/basefunc.py
+++ b/zfit/core/basefunc.py
@@ -52,7 +52,7 @@ class BaseFunc(BaseModel, ZfitFunc):
             name:
 
         Returns:
-            tf.Tensor:  # TODO(Mayou36): or dataset? Update: rather not, what would obs be?
+             # TODO(Mayou36): or dataset? Update: rather not, what would obs be?
         """
         with self._convert_sort_x(x) as x:
             return self._single_hook_value(x=x, name=name)
@@ -77,7 +77,7 @@ class BaseFunc(BaseModel, ZfitFunc):
         """Create a PDF out of the function
 
         Returns:
-            :py:class:`~zfit.core.interfaces.ZfitPDF`: a PDF with the current function as the unnormalized probability.
+            a PDF with the current function as the unnormalized probability.
         """
         from zfit.core.operations import convert_func_to_pdf
         return convert_func_to_pdf(func=self)

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -291,7 +291,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
                 unnormalized probability
 
         Returns:
-            :py:class`tf.Tensor`: the integral value as a scalar with shape ()
+            the integral value as a scalar with shape ()
         """
         norm_range = self._check_input_norm_range(norm_range)
         limits = self._check_input_limits(limits=limits)
@@ -413,7 +413,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             norm_range: the limits to normalize over
 
         Returns:
-            Tensor: the integral value
+            the integral value
         Raises:
             AnalyticIntegralNotImplementedError: If no analytical integral is available (for this limits).
             NormRangeNotImplementedError: if the *norm_range* argument is not supported. This
@@ -484,7 +484,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             norm_range: the limits to normalize over
 
         Returns:
-            Tensor: the integral value
+            the integral value
 
         """
         norm_range = self._check_input_norm_range(norm_range)
@@ -545,7 +545,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
-            Tensor: the value of the partially integrated function evaluated at `x`.
+            the value of the partially integrated function evaluated at `x`.
         """
         norm_range = self._check_input_norm_range(norm_range=norm_range)
         limits = self._check_input_limits(limits=limits)
@@ -628,7 +628,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
-            Tensor: the value of the partially integrated function evaluated at `x`.
+            the value of the partially integrated function evaluated at `x`.
 
         Raises:
             AnalyticIntegralNotImplementedError: if the *analytic* integral (over this limits) is not implemented
@@ -706,7 +706,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
-            Tensor: the value of the partially integrated function evaluated at `x`.
+            the value of the partially integrated function evaluated at `x`.
         """
         norm_range = self._check_input_norm_range(norm_range)
         limits = self._check_input_limits(limits=limits)

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -40,7 +40,7 @@ def _BaseModel_register_check_support(has_support: bool):
     """Marks a method that the subclass either *has* to or *can't* use the `@supports` decorator.
 
     Args:
-        has_support (bool): If True, flags that it **requires** the `@supports` decorator. If False,
+        has_support: If True, flags that it **requires** the `@supports` decorator. If False,
             flags that the `@supports` decorator is **not allowed**.
 
     """
@@ -51,7 +51,7 @@ def _BaseModel_register_check_support(has_support: bool):
         """Register a method to be checked to (if True) *has* `support` or (if False) has *no* `support`.
 
         Args:
-            func (function):
+            func:
 
         Returns:
             function:
@@ -89,9 +89,9 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         """The base model to inherit from and overwrite `_unnormalized_pdf`.
 
         Args:
-            dtype (DType): the dtype of the model
-            name (str): the name of the model
-            params (Dict(str, :py:class:`~zfit.Parameter`)): A dictionary with the internal name of the parameter and
+            dtype: the dtype of the model
+            name: the name of the model
+            params: A dictionary with the internal name of the parameter and
                 the parameters itself the model depends on
         """
         super().__init__(name=name, dtype=dtype, params=params, **kwargs)
@@ -203,8 +203,8 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         """Set the integration options.
 
         Args:
-            draws_per_dim (int): The draws for MC integration to do
-            mc_sampler ():
+            draws_per_dim: The draws for MC integration to do
+            mc_sampler:
         """
         # mc_options = {} if mc_options is None else mc_options
         # numeric_options = {} if numeric_options is None else numeric_options
@@ -225,8 +225,8 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         """Convert to :py:class:`~zfit.Space`.
 
         Args:
-            norm_range (None or :py:class:`~zfit.Space` compatible):
-            none_is_error (bool): if both `norm_range` and `self.norm_range` are None, the default
+            norm_range:
+            none_is_error: if both `norm_range` and `self.norm_range` are None, the default
                 value is `False` (meaning: no range specified-> no normalization to be done). If
                 this is set to true, two `None` will raise a Value error.
 
@@ -257,9 +257,9 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         own `obs`.
 
         Args:
-            obs ():
-            axes ():
-            limits ():
+            obs:
+            axes:
+            limits:
 
         Returns:
 
@@ -286,8 +286,8 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         """Integrate the function over `limits` (normalized over `norm_range` if not False).
 
         Args:
-            limits (tuple, :py:class:`~zfit.ZfitSpace`): the limits to integrate over
-            norm_range (tuple, :py:class:`~zfit.ZfitSpace`): the limits to normalize over or False to integrate the
+            limits: the limits to integrate over
+            norm_range: the limits to normalize over or False to integrate the
                 unnormalized probability
 
         Returns:
@@ -364,7 +364,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         """Register an analytic integral with the class.
 
         Args:
-            func (callable): A function that calculates the (partial) integral over the axes `limits`.
+            func: A function that calculates the (partial) integral over the axes `limits`.
                 The signature has to be the following:
 
                     * x (:py:class:`~zfit.core.interfaces.ZfitData`, None): the data for the remaining axes in a partial
@@ -375,13 +375,13 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
                     * params (Dict[param_name, :py:class:`zfit.Parameters`]): The parameters of the model.
                     * model (:py:class:`~zfit.core.interfaces.ZfitModel`):The model that is being integrated.
 
-            limits (): |limits_arg_descr|
-            priority (int): Priority of the function. If multiple functions cover the same space, the one with the
+            limits: |limits_arg_descr|
+            priority: Priority of the function. If multiple functions cover the same space, the one with the
                 highest priority will be used.
-            supports_multiple_limits (bool): If `True`, the `limits` given to the integration function can have
+            supports_multiple_limits: If `True`, the `limits` given to the integration function can have
                 multiple limits. If `False`, only simple limits will pass through and multiple limits will be
                 auto-handled.
-            supports_norm_range (bool): If `True`, `norm_range` argument to the function may not be `None`.
+            supports_norm_range: If `True`, `norm_range` argument to the function may not be `None`.
                 If `False`, `norm_range` will always be `None` and care is taken of the normalization automatically.
 
         """
@@ -393,7 +393,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         """Register an inverse analytical integral, the inverse (unnormalized) cdf.
 
         Args:
-            func (): A function with the signature `func(x, params)`, where `x` is a Data object
+            func: A function with the signature `func(x, params)`, where `x` is a Data object
                 and `params` is a dict.
         """
         if cls._inverse_analytic_integral:
@@ -409,8 +409,8 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         """Analytical integration over function and raise Error if not possible.
 
         Args:
-            limits (tuple, :py:class:`~zfit.ZfitSpace`): the limits to integrate over
-            norm_range (tuple, :py:class:`~zfit.ZfitSpace`, `False`): the limits to normalize over
+            limits: the limits to integrate over
+            norm_range: the limits to normalize over
 
         Returns:
             Tensor: the integral value
@@ -480,8 +480,8 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         """Numerical integration over the model.
 
         Args:
-            limits (tuple, :py:class:`~zfit.ZfitSpace`): the limits to integrate over
-            norm_range (tuple, :py:class:`~zfit.ZfitSpace`, False): the limits to normalize over
+            limits: the limits to integrate over
+            norm_range: the limits to normalize over
 
         Returns:
             Tensor: the integral value
@@ -540,9 +540,9 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         to the dimensions of `norm_range` (if not False)
 
         Args:
-            x (numerical): The value at which the partially integrated function will be evaluated
-            limits (tuple, :py:class:`~zfit.ZfitSpace`): the limits to integrate over. Can contain only some axes
-            norm_range (tuple, :py:class:`~zfit.ZfitSpace`, False): the limits to normalize over. Has to have all axes
+            x: The value at which the partially integrated function will be evaluated
+            limits: the limits to integrate over. Can contain only some axes
+            norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
             Tensor: the value of the partially integrated function evaluated at `x`.
@@ -623,9 +623,9 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         to the dimensions of `norm_range` (if not False)
 
         Args:
-            x (numerical): The value at which the partially integrated function will be evaluated
-            limits (tuple, :py:class:`~zfit.ZfitSpace`): the limits to integrate over. Can contain only some axes
-            norm_range (tuple, :py:class:`~zfit.ZfitSpace`, False): the limits to normalize over. Has to have all axes
+            x: The value at which the partially integrated function will be evaluated
+            limits: the limits to integrate over. Can contain only some axes
+            norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
             Tensor: the value of the partially integrated function evaluated at `x`.
@@ -701,9 +701,9 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         to the dimensions of `norm_range` (if not False)
 
         Args:
-            x (numerical): The value at which the partially integrated function will be evaluated
-            limits (tuple, :py:class:`~zfit.ZfitSpace`): the limits to integrate over. Can contain only some axes
-            norm_range (tuple, :py:class:`~zfit.ZfitSpace`, False): the limits to normalize over. Has to have all axes
+            x: The value at which the partially integrated function will be evaluated
+            limits: the limits to integrate over. Can contain only some axes
+            norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
             Tensor: the value of the partially integrated function evaluated at `x`.
@@ -782,13 +782,13 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
 
 
         Args:
-            n (int, tf.Tensor, str): The number of samples to be generated. Can be a Tensor that will be
+            n: The number of samples to be generated. Can be a Tensor that will be
                 or a valid string. Currently implemented:
 
                     - 'extended': samples `poisson(yield)` from each pdf that is extended.
 
-            limits (): From which space to sample.
-            fixed_params (): A list of `Parameters` that will be fixed during several `resample` calls.
+            limits: From which space to sample.
+            fixed_params: A list of `Parameters` that will be fixed during several `resample` calls.
                 If True, all are fixed, if False, all are floating. If a :py:class:`~zfit.Parameter` is not fixed and
                 its
                 value gets updated (e.g. by a `Parameter.set_value()` call), this will be reflected in
@@ -845,11 +845,11 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         If `n` is None and the model is an extended pdf, 'extended' is used by default.
 
         Args:
-            n (int, tf.Tensor, str): The number of samples to be generated. Can be a Tensor that will be
+            n: The number of samples to be generated. Can be a Tensor that will be
                 or a valid string. Currently implemented:
 
                     - 'extended': samples `poisson(yield)` from each pdf that is extended.
-            limits (tuple, :py:class:`~zfit.ZfitSpace`): In which region to sample in
+            limits: In which region to sample in
 
         Returns:
             SampleData(n_obs, n_samples)

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -54,7 +54,7 @@ def _BaseModel_register_check_support(has_support: bool):
             func:
 
         Returns:
-            function:
+            Function:
         """
         name = func.__name__
         _BaseModel_USER_IMPL_METHODS_TO_CHECK[name] = has_support
@@ -291,7 +291,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
                 unnormalized probability
 
         Returns:
-            the integral value as a scalar with shape ()
+            The integral value as a scalar with shape ()
         """
         norm_range = self._check_input_norm_range(norm_range)
         limits = self._check_input_limits(limits=limits)
@@ -413,7 +413,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             norm_range: the limits to normalize over
 
         Returns:
-            the integral value
+            The integral value
         Raises:
             AnalyticIntegralNotImplementedError: If no analytical integral is available (for this limits).
             NormRangeNotImplementedError: if the *norm_range* argument is not supported. This
@@ -484,7 +484,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             norm_range: the limits to normalize over
 
         Returns:
-            the integral value
+            The integral value
 
         """
         norm_range = self._check_input_norm_range(norm_range)
@@ -545,7 +545,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
-            the value of the partially integrated function evaluated at `x`.
+            The value of the partially integrated function evaluated at `x`.
         """
         norm_range = self._check_input_norm_range(norm_range=norm_range)
         limits = self._check_input_limits(limits=limits)
@@ -628,7 +628,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
-            the value of the partially integrated function evaluated at `x`.
+            The value of the partially integrated function evaluated at `x`.
 
         Raises:
             AnalyticIntegralNotImplementedError: if the *analytic* integral (over this limits) is not implemented
@@ -706,7 +706,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
-            the value of the partially integrated function evaluated at `x`.
+            The value of the partially integrated function evaluated at `x`.
         """
         norm_range = self._check_input_norm_range(norm_range)
         limits = self._check_input_limits(limits=limits)

--- a/zfit/core/baseobject.py
+++ b/zfit/core/baseobject.py
@@ -21,7 +21,7 @@ _COPY_DOCSTRING = """Creates a copy of the {zfit_type}.
         initialization arguments.
 
         Args:
-          name (str):
+          name:
           **overwrite_parameters: String/value dictionary of initialization
             arguments to override with new value.
 

--- a/zfit/core/baseobject.py
+++ b/zfit/core/baseobject.py
@@ -26,7 +26,7 @@ _COPY_DOCSTRING = """Creates a copy of the {zfit_type}.
             arguments to override with new value.
 
         Returns:
-          {zfit_type}: A new instance of `type(self)` initialized from the union
+          A new instance of `type(self)` initialized from the union
             of self.parameters and override_parameters_kwargs, i.e.,
             `dict(self.parameters, **overwrite_params)`.
         """

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -80,7 +80,7 @@ def _BasePDF_register_check_support(has_support: bool):
     """Marks a method that the subclass either *has* to or *can't* use the `@supports` decorator.
 
     Args:
-        has_support (bool): If True, flags that it **requires** the `@supports` decorator. If False,
+        has_support: If True, flags that it **requires** the `@supports` decorator. If False,
             flags that the `@supports` decorator is **not allowed**.
 
     """
@@ -91,7 +91,7 @@ def _BasePDF_register_check_support(has_support: bool):
         """Register a method to be checked to (if True) *has* `support` or (if False) has *no* `support`.
 
         Args:
-            func (function):
+            func:
 
         Returns:
             function:
@@ -160,7 +160,7 @@ class BasePDF(ZfitPDF, BaseModel):
         """Set the normalization range (temporarily if used with contextmanager).
 
         Args:
-            norm_range (tuple, :py:class:`~zfit.Space`):
+            norm_range:
 
         """
         norm_range = self._check_input_norm_range(norm_range=norm_range)
@@ -195,7 +195,7 @@ class BasePDF(ZfitPDF, BaseModel):
         """Return the normalization of the function (usually the integral over `limits`).
 
         Args:
-            limits (tuple, :py:class:`~zfit.Space`): The limits on where to normalize over
+            limits: The limits on where to normalize over
 
         Returns:
             Tensor: the normalization value
@@ -227,8 +227,8 @@ class BasePDF(ZfitPDF, BaseModel):
         """PDF "unnormalized". Use `functions` for unnormalized pdfs. this is only for performance in special cases.
 
         Args:
-            x (numerical): The value, have to be convertible to a Tensor
-            component_norm_range (:py:class:`~zfit.Space`): The normalization range for the components. Needed for
+            x: The value, have to be convertible to a Tensor
+            component_norm_range: The normalization range for the components. Needed for
             certain composition
                 pdfs.
 
@@ -259,8 +259,8 @@ class BasePDF(ZfitPDF, BaseModel):
         """Probability density function scaled by yield, normalized over `norm_range`.
 
         Args:
-          x (numerical): `float` or `double` `Tensor`.
-          norm_range (tuple, :py:class:`~zfit.Space`): :py:class:`~zfit.Space` to normalize over
+          x: `float` or `double` `Tensor`.
+          norm_range: :py:class:`~zfit.Space` to normalize over
 
         Returns:
           :py:class:`tf.Tensor` of type `self.dtype`.
@@ -274,8 +274,8 @@ class BasePDF(ZfitPDF, BaseModel):
         """Log of probability density function scaled by yield, normalized over `norm_range`.
 
         Args:
-          x (numerical): `float` or `double` `Tensor`.
-          norm_range (tuple, :py:class:`~zfit.Space`): :py:class:`~zfit.Space` to normalize over
+          x: `float` or `double` `Tensor`.
+          norm_range: :py:class:`~zfit.Space` to normalize over
 
         Returns:
           :py:class:`tf.Tensor` of type `self.dtype`.
@@ -294,8 +294,8 @@ class BasePDF(ZfitPDF, BaseModel):
         """Probability density function, normalized over `norm_range`.
 
         Args:
-          x (numerical): `float` or `double` `Tensor`.
-          norm_range (tuple, :py:class:`~zfit.Space`): :py:class:`~zfit.Space` to normalize over
+          x: `float` or `double` `Tensor`.
+          norm_range: :py:class:`~zfit.Space` to normalize over
 
         Returns:
           :py:class:`tf.Tensor` of type `self.dtype`.
@@ -337,8 +337,8 @@ class BasePDF(ZfitPDF, BaseModel):
         """Log probability density function normalized over `norm_range`.
 
         Args:
-          x (numerical): `float` or `double` `Tensor`.
-          norm_range (tuple, :py:class:`~zfit.Space`): :py:class:`~zfit.Space` to normalize over
+          x: `float` or `double` `Tensor`.
+          norm_range: :py:class:`~zfit.Space` to normalize over
 
         Returns:
           log_pdf: a `Tensor` of type `self.dtype`.
@@ -375,8 +375,8 @@ class BasePDF(ZfitPDF, BaseModel):
         """Integrate the function over `limits` (normalized over `norm_range` if not False).
 
         Args:
-            limits (tuple, :py:class:`~zfit.ZfitSpace`): the limits to integrate over
-            norm_range (tuple, :py:class:`~zfit.ZfitSpace`): the limits to normalize over or False to integrate the
+            limits: the limits to integrate over
+            norm_range: the limits to normalize over or False to integrate the
                 unnormalized probability
 
         Returns:
@@ -401,9 +401,9 @@ class BasePDF(ZfitPDF, BaseModel):
         """If a norm_range is given, the value will be multiplied by the yield.
 
         Args:
-            value (numerical):
-            norm_range ():
-            log (bool):
+            value:
+            norm_range:
+            log:
 
         Returns:
             numerical
@@ -420,7 +420,7 @@ class BasePDF(ZfitPDF, BaseModel):
         probability density function anymore but corresponds to a number probability.
 
         Args:
-            value ():
+            value:
         """
 
         self._set_yield(value=value)
@@ -429,8 +429,8 @@ class BasePDF(ZfitPDF, BaseModel):
         """Return an extended version of this pdf with yield `yield_`. The parameters are shared.
 
         Args:
-            yield_ (numeric, :py:class:`~zfit.Parameter`):
-            name_addition (str):
+            yield_:
+            name_addition:
 
         Returns:
             :py:class:`~zfit.core.interfaces.ZfitPDF`
@@ -514,7 +514,7 @@ class BasePDF(ZfitPDF, BaseModel):
         The new projection pdf is still fully dependent on the pdf it was created with.
 
         Args:
-            limits_to_integrate (:py:class:`~zfit.Space`):
+            limits_to_integrate:
 
         Returns:
             ZfitPDF: a pdf without the dimensions from `limits_to_integrate`.
@@ -604,7 +604,7 @@ class BasePDF(ZfitPDF, BaseModel):
         """Return a `Function` with the function `model(x, norm_range=norm_range)`.
 
         Args:
-            norm_range ():
+            norm_range:
         """
         from .operations import convert_pdf_to_func  # prevent circular import
 

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -148,7 +148,7 @@ class BasePDF(ZfitPDF, BaseModel):
         """Return the current normalization range. If None and the `obs` have limits, they are returned.
 
         Returns:
-            :py:class:`~zfit.Space` or None: The current normalization range.
+            The current normalization range.
         """
         norm_range = self._norm_range
         if norm_range is None:
@@ -198,7 +198,7 @@ class BasePDF(ZfitPDF, BaseModel):
             limits: The limits on where to normalize over
 
         Returns:
-            Tensor: the normalization value
+            the normalization value
         """
         limits = self._check_input_limits(limits=limits)
 
@@ -233,7 +233,7 @@ class BasePDF(ZfitPDF, BaseModel):
                 pdfs.
 
         Returns:
-            :py:class:`tf.Tensor`: 1-dimensional :py:class:`tf.Tensor` containing the unnormalized pdf.
+            1-dimensional :py:class:`tf.Tensor` containing the unnormalized pdf.
         """
         if component_norm_range is not None:
             raise BreakingAPIChangeError("component norm range should not be given anymore. If you want to set the norm"
@@ -341,7 +341,7 @@ class BasePDF(ZfitPDF, BaseModel):
           norm_range: :py:class:`~zfit.Space` to normalize over
 
         Returns:
-          log_pdf: a `Tensor` of type `self.dtype`.
+          a `Tensor` of type `self.dtype`.
         """
         norm_range = self._check_input_norm_range(norm_range)
         with self._convert_sort_x(x) as x:
@@ -380,7 +380,7 @@ class BasePDF(ZfitPDF, BaseModel):
                 unnormalized probability
 
         Returns:
-            :py:class`tf.Tensor`: the integral value as a scalar with shape ()
+            the integral value as a scalar with shape ()
         """
         norm_range = self._check_input_norm_range(norm_range)
         limits = self._check_input_limits(limits=limits)
@@ -484,7 +484,7 @@ class BasePDF(ZfitPDF, BaseModel):
         """Return the yield (only for extended models).
 
         Returns:
-            :py:class:`~zfit.Parameter`: the yield of the current model or None
+            the yield of the current model or None
         """
         # if not self.is_extended:
         #     raise zexception.ExtendedPDFError("PDF is not extended, cannot get yield.")
@@ -517,7 +517,7 @@ class BasePDF(ZfitPDF, BaseModel):
             limits_to_integrate:
 
         Returns:
-            ZfitPDF: a pdf without the dimensions from `limits_to_integrate`.
+            a pdf without the dimensions from `limits_to_integrate`.
         """
         from ..models.special import SimpleFunctorPDF
 
@@ -541,7 +541,7 @@ class BasePDF(ZfitPDF, BaseModel):
             arguments to override with new value.
 
         Returns:
-          model: A new instance of `type(self)` initialized from the union
+          A new instance of `type(self)` initialized from the union
             of self.parameters and override_parameters, i.e.,
             `dict(self.parameters, **override_parameters)`.
         """

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -94,7 +94,7 @@ def _BasePDF_register_check_support(has_support: bool):
             func:
 
         Returns:
-            function:
+            Function:
         """
         name = func.__name__
         _BasePDF_USER_IMPL_METHODS_TO_CHECK[name] = has_support
@@ -198,7 +198,7 @@ class BasePDF(ZfitPDF, BaseModel):
             limits: The limits on where to normalize over
 
         Returns:
-            the normalization value
+            The normalization value
         """
         limits = self._check_input_limits(limits=limits)
 
@@ -341,7 +341,7 @@ class BasePDF(ZfitPDF, BaseModel):
           norm_range: :py:class:`~zfit.Space` to normalize over
 
         Returns:
-          a `Tensor` of type `self.dtype`.
+          A `Tensor` of type `self.dtype`.
         """
         norm_range = self._check_input_norm_range(norm_range)
         with self._convert_sort_x(x) as x:
@@ -380,7 +380,7 @@ class BasePDF(ZfitPDF, BaseModel):
                 unnormalized probability
 
         Returns:
-            the integral value as a scalar with shape ()
+            The integral value as a scalar with shape ()
         """
         norm_range = self._check_input_norm_range(norm_range)
         limits = self._check_input_limits(limits=limits)
@@ -406,7 +406,7 @@ class BasePDF(ZfitPDF, BaseModel):
             log:
 
         Returns:
-            numerical
+            Numerical
         """
         norm_range = self._check_input_norm_range(norm_range=norm_range)
         return self._apply_yield(value=value, norm_range=norm_range, log=log)
@@ -461,7 +461,7 @@ class BasePDF(ZfitPDF, BaseModel):
         """Flag to tell whether the model is extended or not.
 
         Returns:
-            bool:
+            A boolean.
         """
         return self._yield is not None
 
@@ -484,7 +484,7 @@ class BasePDF(ZfitPDF, BaseModel):
         """Return the yield (only for extended models).
 
         Returns:
-            the yield of the current model or None
+            The yield of the current model or None
         """
         # if not self.is_extended:
         #     raise zexception.ExtendedPDFError("PDF is not extended, cannot get yield.")
@@ -517,7 +517,7 @@ class BasePDF(ZfitPDF, BaseModel):
             limits_to_integrate:
 
         Returns:
-            a pdf without the dimensions from `limits_to_integrate`.
+            A pdf without the dimensions from `limits_to_integrate`.
         """
         from ..models.special import SimpleFunctorPDF
 

--- a/zfit/core/constraint.py
+++ b/zfit/core/constraint.py
@@ -126,7 +126,6 @@ class ProbabilityConstraint(BaseConstraint):
         Args:
             n: The number of samples to be generated.
         Returns:
-            Dict(Parameter: n_samples)
         """
         sample = self._sample(n=n)
         return {p: sample[:, i] for i, p in enumerate(self.observation)}

--- a/zfit/core/constraint.py
+++ b/zfit/core/constraint.py
@@ -30,9 +30,9 @@ class BaseConstraint(ZfitConstraint, BaseNumeric):
         """Base class for constraints.
 
         Args:
-            dtype (DType): the dtype of the constraint
-            name (str): the name of the constraint
-            params (Dict(str, :py:class:`~zfit.Parameter`)): A dictionary with the internal name of the
+            dtype: the dtype of the constraint
+            name: the name of the constraint
+            params: A dictionary with the internal name of the
                 parameter and the parameters itself the constrains depends on
         """
         super().__init__(name=name, dtype=dtype, params=params, **kwargs)
@@ -80,10 +80,10 @@ class ProbabilityConstraint(BaseConstraint):
         """Base class for constraints using a probability density function.
 
         Args:
-            dtype (DType): the dtype of the constraint
-            name (str): the name of the constraint
-            params (list(zfit.Parameter)): The parameters to constraint
-            observation (list(numerical) or list(zfit.Parameter)): Observed values of the parameter
+            dtype: the dtype of the constraint
+            name: the name of the constraint
+            params: The parameters to constraint
+            observation: Observed values of the parameter
                 to constraint obtained from auxiliary measurements.
         """
 
@@ -124,7 +124,7 @@ class ProbabilityConstraint(BaseConstraint):
         """Sample `n` points from the probability density function for the observed value of the parameters.
 
         Args:
-            n (int, tf.Tensor): The number of samples to be generated.
+            n: The number of samples to be generated.
         Returns:
             Dict(Parameter: n_samples)
         """
@@ -149,7 +149,7 @@ class TFProbabilityConstraint(ProbabilityConstraint):
         """ Base class for constraints using a probability density function from `tensorflow_probability`.
 
         Args:
-            distribution (`tensorflow_probability.distributions.Distribution`): The probability density function
+            distribution: The probability density function
                 used to constraint the parameters
 
         """

--- a/zfit/core/coordinates.py
+++ b/zfit/core/coordinates.py
@@ -95,7 +95,7 @@ class Coordinates(ZfitOrderableDimensional):
             is raised.
 
         Returns:
-            object: a copy of the object with the new ordering/observables
+            a copy of the object with the new ordering/observables
 
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
@@ -163,7 +163,7 @@ class Coordinates(ZfitOrderableDimensional):
             is raised.
 
         Returns:
-            object: a copy of the object with the new ordering/axes
+            a copy of the object with the new ordering/axes
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
             AxesIncompatibleError: if `axes` is a superset and allow_superset is False or a subset and
@@ -221,7 +221,7 @@ class Coordinates(ZfitOrderableDimensional):
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
-            object: the object with the new axes
+            the object with the new axes
 
         Raises:
             AxesIncompatibleError: if the axes are already set and `overwrite` is False.
@@ -256,7 +256,7 @@ class Coordinates(ZfitOrderableDimensional):
                 return the indices that could be used to reorder.
 
         Returns:
-            tuple(int): New indices that would reorder the instances obs to be obs respectively axes.
+            New indices that would reorder the instances obs to be obs respectively axes.
 
         Raises:
             CoordinatesUnderdefinedError: If neither `obs` nor `axes` is given
@@ -308,7 +308,7 @@ class Coordinates(ZfitOrderableDimensional):
                 self.axes to be the axes of x.
 
         Returns:
-            tensor-like: the reordered array-like object
+            the reordered array-like object
         """
 
         x_reorder = x_obs is not None or x_axes is not None

--- a/zfit/core/coordinates.py
+++ b/zfit/core/coordinates.py
@@ -95,7 +95,7 @@ class Coordinates(ZfitOrderableDimensional):
             is raised.
 
         Returns:
-            a copy of the object with the new ordering/observables
+            A copy of the object with the new ordering/observables
 
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
@@ -163,7 +163,7 @@ class Coordinates(ZfitOrderableDimensional):
             is raised.
 
         Returns:
-            a copy of the object with the new ordering/axes
+            A copy of the object with the new ordering/axes
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
             AxesIncompatibleError: if `axes` is a superset and allow_superset is False or a subset and
@@ -221,7 +221,7 @@ class Coordinates(ZfitOrderableDimensional):
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
-            the object with the new axes
+            The object with the new axes
 
         Raises:
             AxesIncompatibleError: if the axes are already set and `overwrite` is False.
@@ -308,7 +308,7 @@ class Coordinates(ZfitOrderableDimensional):
                 self.axes to be the axes of x.
 
         Returns:
-            the reordered array-like object
+            The reordered array-like object
         """
 
         x_reorder = x_obs is not None or x_axes is not None

--- a/zfit/core/coordinates.py
+++ b/zfit/core/coordinates.py
@@ -217,7 +217,7 @@ class Coordinates(ZfitOrderableDimensional):
 
 
         Args:
-            overwrite (bool): If axes are already set, replace the axes with the autofilled ones.
+            overwrite: If axes are already set, replace the axes with the autofilled ones.
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
@@ -297,7 +297,7 @@ class Coordinates(ZfitOrderableDimensional):
         Switching `func_obs` for `x_obs` resp. `func_axes` for `x_axes` inverts the reordering of x.
 
         Args:
-            x (tensor-like): Tensor to be reordered, last dimension should be n_obs resp. n_axes
+            x: Tensor to be reordered, last dimension should be n_obs resp. n_axes
             x_obs: Observables associated with x. If both, x_obs and x_axes are given, this has precedency over the
                 latter.
             x_axes: Axes associated with x.

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -131,7 +131,7 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
         """Set (temporarily) the weights of the dataset.
 
         Args:
-            weights (`tf.Tensor`, np.ndarray, None):
+            weights:
 
 
         """
@@ -182,16 +182,16 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
         """Create a `Data` from a ROOT file. Arguments are passed to `uproot`.
 
         Args:
-            path (str):
-            treepath (str):
-            branches (List[str]]):
-            branches_alias (dict): A mapping from the `branches` (as keys) to the actual `observables` (as values).
+            path:
+            treepath:
+            branches:
+            branches_alias: A mapping from the `branches` (as keys) to the actual `observables` (as values).
                 This allows to have different `observable` names, independent of the branch name in the file.
-            weights (tf.Tensor, None, np.ndarray, str]): Weights of the data. Has to be 1-D and match the shape
+            weights: Weights of the data. Has to be 1-D and match the shape
                 of the data (nevents). Can be a column of the ROOT file by using a string corresponding to a
                 column.
-            name (str):
-            root_dir_options ():
+            name:
+            root_dir_options:
 
         Returns:
             `zfit.Data`:
@@ -240,11 +240,11 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
         """Create a `Data` from a pandas DataFrame. If `obs` is `None`, columns are used as obs.
 
         Args:
-            df (`pandas.DataFrame`):
-            weights (tf.Tensor, None, np.ndarray, str]): Weights of the data. Has to be 1-D and match the shape
+            df:
+            weights: Weights of the data. Has to be 1-D and match the shape
                 of the data (nevents).
-            obs (`zfit.Space`):
-            name (str):
+            obs:
+            name:
         """
         if obs is None:
             obs = list(df.columns)
@@ -257,9 +257,9 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
         """Create `Data` from a `np.array`.
 
         Args:
-            obs ():
-            array (numpy.ndarray):
-            name (str):
+            obs:
+            array:
+            name:
 
         Returns:
             zfit.Data:
@@ -278,9 +278,9 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
         """Create a `Data` from a `tf.Tensor`. `Value` simply returns the tensor (in the right order).
 
         Args:
-            obs (Union[str, List[str]):
-            tensor (`tf.Tensor`):
-            name (str):
+            obs:
+            tensor:
+            name:
 
         Returns:
             zfit.core.Data:
@@ -302,7 +302,7 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
         """Create a `pd.DataFrame` from `obs` as columns and return it.
 
         Args:
-            obs (): The observables to use as columns. If `None`, all observables are used.
+            obs: The observables to use as columns. If `None`, all observables are used.
 
         Returns:
 
@@ -319,8 +319,8 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
         """Return the unstacked data: a list of tensors or a single Tensor.
 
         Args:
-            obs (): which observables to return
-            always_list (bool): If True, always return a list (also if length 1)
+            obs: which observables to return
+            always_list: If True, always return a list (also if length 1)
 
         Returns:
             List(tf.Tensor)
@@ -491,9 +491,9 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
         own `obs`.
 
         Args:
-            obs ():
-            axes ():
-            limits ():
+            obs:
+            axes:
+            limits:
 
         Returns:
 
@@ -601,9 +601,9 @@ class Sampler(Data):
         a mapping with `param_values` from `Parameter` to the temporary `value`.
 
         Args:
-            param_values (Dict): a mapping from :py:class:`~zfit.Parameter` to a `value`. For the current sampling,
+            param_values: a mapping from :py:class:`~zfit.Parameter` to a `value`. For the current sampling,
                 `Parameter` will use the `value`.
-            n (int, tf.Tensor): the number of samples to produce. If the `Sampler` was created with
+            n: the number of samples to produce. If the `Sampler` was created with
                 anything else then a numerical or tf.Tensor, this can't be used.
         """
         if n is None:

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -262,7 +262,7 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
             name:
 
         Returns:
-            zfit.Data:
+
         """
 
         if not isinstance(array, (np.ndarray)) and not (tf.is_tensor(array) and hasattr(array, 'numpy')):
@@ -283,7 +283,7 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
             name:
 
         Returns:
-            zfit.core.Data:
+
         """
         # dataset = LightDataset.from_tensor(tensor=tensor)
         if dtype is None:

--- a/zfit/core/dependents.py
+++ b/zfit/core/dependents.py
@@ -34,7 +34,7 @@ def _extract_dependencies(zfit_objects: Iterable[ZfitObject]) -> ztyping.Depende
         zfit_objects:
 
     Returns:
-        set(zfit.Parameter): A set of independent Parameters
+        A set of independent Parameters
     """
     zfit_objects = convert_to_container(zfit_objects)
     dependents = (obj.get_cache_deps(only_floating=False) for obj in zfit_objects)

--- a/zfit/core/dependents.py
+++ b/zfit/core/dependents.py
@@ -19,7 +19,7 @@ class BaseDependentsMixin(ZfitDependenciesMixin):
         """Return a set of all independent :py:class:`~zfit.Parameter` that this object depends on.
 
         Args:
-            only_floating (bool): If `True`, only return floating :py:class:`~zfit.Parameter`
+            only_floating: If `True`, only return floating :py:class:`~zfit.Parameter`
         """
         dependencies = self._get_dependencies()
         if only_floating:
@@ -31,7 +31,7 @@ def _extract_dependencies(zfit_objects: Iterable[ZfitObject]) -> ztyping.Depende
     """Calls the :py:meth:`~BaseDependentsMixin.get_dependents` method on every object and returns a combined set.
 
     Args:
-        zfit_objects ():
+        zfit_objects:
 
     Returns:
         set(zfit.Parameter): A set of independent Parameters

--- a/zfit/core/dimension.py
+++ b/zfit/core/dimension.py
@@ -65,7 +65,7 @@ def limits_overlap(spaces: ztyping.SpaceOrSpacesTypeInput, allow_exact_match: bo
             `allow_exact_match` is True.
 
     Returns:
-        bool: if there are overlapping limits.
+        if there are overlapping limits.
     """
     # TODO(Mayou36): add approx comparison global in zfit
     eps = 1e-8  # epsilon for float comparisons
@@ -113,7 +113,7 @@ def common_obs(spaces: ztyping.SpaceOrSpacesTypeInput) -> Union[List[str], bool]
         spaces: :py:class:`~zfit.Space`s to extract the obs from
 
     Returns:
-        List[str]: The observables as `str` or False if not every space has observables
+        The observables as `str` or False if not every space has observables
     """
     spaces = convert_to_container(spaces, container=tuple)
     all_obs = []
@@ -140,7 +140,7 @@ def common_axes(spaces: ztyping.SpaceOrSpacesTypeInput) -> Union[List[str], bool
         spaces: :py:class:`~zfit.Space`s to extract the axes from
 
     Returns:
-        List[int] or False: The axes as int or False if not every space has axes
+        The axes as int or False if not every space has axes
     """
     spaces = convert_to_container(spaces, container=tuple)
     all_axes = []
@@ -160,7 +160,7 @@ def obs_subsets(dimensionals: Iterable[ZfitDimensional]) -> Dict[Set[str], ZfitD
         dimensionals: An Iterable containing two or more ZfitDimensional that should be split into the smallest subset.
 
     Returns:
-        dict: dict with the keys being sets of observables and the values, an iterable, containing the ZfitDimensional
+        dict with the keys being sets of observables and the values, an iterable, containing the ZfitDimensional
     """
     obs_dims = {}
     for dim in dimensionals:

--- a/zfit/core/dimension.py
+++ b/zfit/core/dimension.py
@@ -65,7 +65,7 @@ def limits_overlap(spaces: ztyping.SpaceOrSpacesTypeInput, allow_exact_match: bo
             `allow_exact_match` is True.
 
     Returns:
-        if there are overlapping limits.
+        If there are overlapping limits.
     """
     # TODO(Mayou36): add approx comparison global in zfit
     eps = 1e-8  # epsilon for float comparisons
@@ -160,7 +160,7 @@ def obs_subsets(dimensionals: Iterable[ZfitDimensional]) -> Dict[Set[str], ZfitD
         dimensionals: An Iterable containing two or more ZfitDimensional that should be split into the smallest subset.
 
     Returns:
-        dict with the keys being sets of observables and the values, an iterable, containing the ZfitDimensional
+        Dict with the keys being sets of observables and the values, an iterable, containing the ZfitDimensional
     """
     obs_dims = {}
     for dim in dimensionals:

--- a/zfit/core/dimension.py
+++ b/zfit/core/dimension.py
@@ -59,8 +59,8 @@ def limits_overlap(spaces: ztyping.SpaceOrSpacesTypeInput, allow_exact_match: bo
 
 
     Args:
-        spaces (Iterable[zfit.Space]):
-        allow_exact_match (bool): An exact overlap of two limits is counted as "not overlapping".
+        spaces:
+        allow_exact_match: An exact overlap of two limits is counted as "not overlapping".
             Example: limits from -1 to 3 and 4 to 5 to *NOT* overlap with the limits 4 to 5 *iff*
             `allow_exact_match` is True.
 
@@ -110,7 +110,7 @@ def common_obs(spaces: ztyping.SpaceOrSpacesTypeInput) -> Union[List[str], bool]
         returns ['obs1', 'obs3', 'obs2']
 
     Args:
-        spaces (): :py:class:`~zfit.Space`s to extract the obs from
+        spaces: :py:class:`~zfit.Space`s to extract the obs from
 
     Returns:
         List[str]: The observables as `str` or False if not every space has observables
@@ -137,7 +137,7 @@ def common_axes(spaces: ztyping.SpaceOrSpacesTypeInput) -> Union[List[str], bool
         returns [1, 3, 2]
 
     Args:
-        spaces (): :py:class:`~zfit.Space`s to extract the axes from
+        spaces: :py:class:`~zfit.Space`s to extract the axes from
 
     Returns:
         List[int] or False: The axes as int or False if not every space has axes

--- a/zfit/core/integration.py
+++ b/zfit/core/integration.py
@@ -69,7 +69,7 @@ def mc_integrate(func: Callable, limits: ztyping.LimitsType, axes: Optional[ztyp
         importance_sampling:
 
     Returns:
-        the integral
+        The integral
     """
     if axes is not None and n_axes is not None:
         raise ValueError("Either specify axes or n_axes")

--- a/zfit/core/integration.py
+++ b/zfit/core/integration.py
@@ -56,17 +56,17 @@ def mc_integrate(func: Callable, limits: ztyping.LimitsType, axes: Optional[ztyp
     """Monte Carlo integration of `func` over `limits`.
 
     Args:
-        func (callable): The function to be integrated over
-        limits (:py:class:`~ZfitSpace`): The limits of the integral
-        axes (tuple(int)): The row to integrate over. None means integration over all value
-        x (numeric): If a partial integration is performed, this are the value where x will be evaluated.
-        n_axes (int): the number of total dimensions (old?)
-        draws_per_dim (int): How many random points to draw per dimensions
-        method (str): Which integration method to use
-        dtype (dtype): |dtype_arg_descr|
-        mc_sampler (callable): A function that takes one argument (`n_draws` or similar) and returns
+        func: The function to be integrated over
+        limits: The limits of the integral
+        axes: The row to integrate over. None means integration over all value
+        x: If a partial integration is performed, this are the value where x will be evaluated.
+        n_axes: the number of total dimensions (old?)
+        draws_per_dim: How many random points to draw per dimensions
+        method: Which integration method to use
+        dtype: |dtype_arg_descr|
+        mc_sampler: A function that takes one argument (`n_draws` or similar) and returns
             random value between 0 and 1.
-        importance_sampling ():
+        importance_sampling:
 
     Returns:
         numerical: the integral
@@ -307,8 +307,8 @@ class PartialIntegralSampleData(BaseDimensional, ZfitData):
         """Takes a list of tensors and "fakes" a dataset. Useful for tensors with non-matching shapes.
 
         Args:
-            sample (List[tf.Tensor]):
-            space ():
+            sample:
+            space:
         """
         if not isinstance(sample, list):
             raise TypeError("Sample has to be a list of tf.Tensors")
@@ -373,8 +373,8 @@ class AnalyticIntegral:
         """Return the maximal available axes to integrate over analytically for given limits
 
         Args:
-            limits (:py:class:`~zfit.Space`): The integral function will be able to integrate over this limits
-            axes (tuple): The axes over which (or over a subset) it will integrate
+            limits: The integral function will be able to integrate over this limits
+            axes: The axes over which (or over a subset) it will integrate
 
         Returns:
             Tuple[int]:
@@ -407,8 +407,8 @@ class AnalyticIntegral:
         """Return the integral over the `limits` with `axes` (or a subset of them).
 
         Args:
-            limits (:py:class:`~zfit.ZfitSpace`):
-            axes (Tuple[int]):
+            limits:
+            axes:
 
         Returns:
             Union[None, Integral]: Return a callable that integrated over the given limits.
@@ -427,14 +427,14 @@ class AnalyticIntegral:
         """Register an analytic integral.
 
         Args:
-            func (callable): The integral function. Takes 1 argument.
-            axes (tuple): |dims_arg_descr|
-            limits (:py:class:`~zfit.ZfitSpace`): |limits_arg_descr| `Limits` can be None if `func` works for any
+            func: The integral function. Takes 1 argument.
+            axes: |dims_arg_descr|
+            limits: |limits_arg_descr| `Limits` can be None if `func` works for any
             possible limits
-            priority (int): If two or more integrals can integrate over certain limits, the one with the higher
+            priority: If two or more integrals can integrate over certain limits, the one with the higher
                 priority is taken (usually around 0-100).
-            supports_norm_range (bool): If True, norm_range will (if needed) be given to `func` as an argument.
-            supports_multiple_limits (bool): If True, multiple limits may be given as an argument to `func`.
+            supports_norm_range: If True, norm_range will (if needed) be given to `func` as an argument.
+            supports_multiple_limits: If True, multiple limits may be given as an argument to `func`.
         """
 
         # if limits is False:
@@ -462,12 +462,12 @@ class AnalyticIntegral:
 
 
         Args:
-            x (numeric): If a partial integration is made, x are the value to be evaluated for the partial
+            x: If a partial integration is made, x are the value to be evaluated for the partial
                 integrated function. If a full integration is performed, this should be `None`.
-            limits (:py:class:`~zfit.ZfitSpace`): The limits to integrate
-            axes (Tuple[int]): The dimensions to integrate over
-            norm_range (bool): |norm_range_arg_descr|
-            params (dict): The parameters of the function
+            limits: The limits to integrate
+            axes: The dimensions to integrate over
+            norm_range: |norm_range_arg_descr|
+            params: The parameters of the function
 
 
         Returns:

--- a/zfit/core/integration.py
+++ b/zfit/core/integration.py
@@ -69,7 +69,7 @@ def mc_integrate(func: Callable, limits: ztyping.LimitsType, axes: Optional[ztyp
         importance_sampling:
 
     Returns:
-        numerical: the integral
+        the integral
     """
     if axes is not None and n_axes is not None:
         raise ValueError("Either specify axes or n_axes")
@@ -411,7 +411,7 @@ class AnalyticIntegral:
             axes:
 
         Returns:
-            Union[None, Integral]: Return a callable that integrated over the given limits.
+            Return a callable that integrated over the given limits.
         """
         limits = convert_to_space(limits=limits, axes=axes)
 

--- a/zfit/core/interfaces.py
+++ b/zfit/core/interfaces.py
@@ -73,7 +73,7 @@ class ZfitOrderableDimensional(ZfitDimensional, metaclass=ABCMeta):
             is raised.
 
         Returns:
-            object: a copy of the object with the new ordering/observables
+            a copy of the object with the new ordering/observables
 
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
@@ -113,7 +113,7 @@ class ZfitOrderableDimensional(ZfitDimensional, metaclass=ABCMeta):
                 is raised.
 
             Returns:
-                object: a copy of the object with the new ordering/axes
+                a copy of the object with the new ordering/axes
 
             Raises:
                 CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
@@ -146,7 +146,7 @@ class ZfitOrderableDimensional(ZfitDimensional, metaclass=ABCMeta):
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
-            object: the object with the new axes
+            the object with the new axes
 
         Raises:
             AxesIncompatibleError: if the axes are already set and `overwrite` is False.
@@ -184,7 +184,7 @@ class ZfitOrderableDimensional(ZfitDimensional, metaclass=ABCMeta):
                 self.axes to be the axes of x.
 
         Returns:
-            tensor-like: the reordered array-like object
+            the reordered array-like object
         """
         raise NotImplementedError
 
@@ -202,7 +202,7 @@ class ZfitOrderableDimensional(ZfitDimensional, metaclass=ABCMeta):
                 return the indices that could be used to reorder.
 
         Returns:
-            tuple(int): New indices that would reorder the instances obs to be obs respectively axes.
+            New indices that would reorder the instances obs to be obs respectively axes.
 
         Raises:
             CoordinatesUnderdefinedError: If neither `obs` nor `axes` is given
@@ -245,7 +245,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
             `limits_are_false` and `limits_are_set`.
 
         Returns:
-            tuple(np.ndarray/tf.Tensor, np.ndarray/tf.Tensor) or bool or None: The lower and upper limits.
+            The lower and upper limits.
         Raises:
             LimitsNotSpecifiedError: If there are not limits set or they are False.
         """
@@ -264,7 +264,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
         `limits_are_false` and `limits_are_set`.
 
         Returns:
-            (lower, upper): A tuple of two `np.ndarray` with shape (1, n_obs) typically. The last
+            A tuple of two `np.ndarray` with shape (1, n_obs) typically. The last
                 dimension is always `n_obs`, the first can be vectorized. This allows unstacking
                 with `z.unstack_x()` as can be done with data.
 
@@ -316,7 +316,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
             guarantee_limits: Guarantee that the values are already inside the rectangular limits.
 
         Returns:
-            tensor-like: Return a boolean tensor-like object with the same shape as the input `x` except of the
+            Return a boolean tensor-like object with the same shape as the input `x` except of the
                 last dimension removed.
         """
         raise NotImplementedError
@@ -337,7 +337,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
             axis: The axis to remove the elements from. Defaults to 0.
 
         Returns:
-            tensor-like: Return an object with the same shape as `x` except that along `axis` elements have been
+            Return an object with the same shape as `x` except that along `axis` elements have been
                 removed.
         """
 
@@ -354,7 +354,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
         If a limit with tensors is evaluated inside a graph context, comparison operations will fail.
 
         Returns:
-            bool: if the rectangular limits are tensors.
+            if the rectangular limits are tensors.
         """
         raise NotImplementedError
 
@@ -364,7 +364,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
         """If the limits have been set to a limit or are False.
 
         Returns:
-            bool: Whether the limits have been set or not.
+            Whether the limits have been set or not.
         """
         raise NotImplementedError
 
@@ -399,7 +399,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
         """Dimensionality, the number of observables, of the limits. Equals to the last axis in rectangular limits.
 
         Returns:
-            int: Dimensionality of the limits.
+            Dimensionality of the limits.
         """
         raise NotImplementedError
 
@@ -408,7 +408,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
         """Shape of the first dimension, usually reflects the number of events.
 
         Returns:
-            int, None: Return the number of events, the dimension of the first shape. If this is > 1 or None,
+            Return the number of events, the dimension of the first shape. If this is > 1 or None,
                 it's vectorized.
         """
         raise NotImplementedError
@@ -420,7 +420,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
         If called inside a graph context *and* the limits are tensors, this will return a symbolic `tf.Tensor`.
 
         Returns:
-            bool: result of the comparison
+            result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -454,7 +454,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
             allow_graph: If False and the function returns a symbolic tensor, raise IllegalInGraphModeError instead.
 
         Returns:
-            bool: result of the comparison
+            result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
 
@@ -468,7 +468,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
         This can be used to determine whether a fitting range specification can handle another limit.
 
         Returns:
-            bool: result of the comparison
+            result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -481,7 +481,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
         If this is not possible, if the limits are not rectangular, just returns itself.
 
         Returns:
-            Iterable[ZfitLimits]: The sublimits if it was able to split.
+            The sublimits if it was able to split.
         """
         raise NotImplementedError
 
@@ -540,7 +540,7 @@ class ZfitSpace(ZfitLimit, ZfitOrderableDimensional, ZfitObject, metaclass=ABCMe
             name: Human readable name
 
         Returns:
-            :py:class:`~zfit.Space`: Copy of the current object with the new limits.
+            Copy of the current object with the new limits.
         """
         raise NotImplementedError
 
@@ -700,7 +700,7 @@ class ZfitIndependentParameter(ZfitParameter, metaclass=ABCMeta):
             sampler: A sampler with the same interface as `tf.random.uniform`
 
         Returns:
-            `tf.Tensor`: The sampled value
+            The sampled value
         """
         raise NotImplementedError
 
@@ -732,7 +732,7 @@ class ZfitIndependentParameter(ZfitParameter, metaclass=ABCMeta):
         """If the value is at the limit (or over it).
 
         Returns:
-            `tf.Tensor`: Boolean `tf.Tensor` that tells whether the value is at the limits.
+            Boolean `tf.Tensor` that tells whether the value is at the limits.
 
         """
         raise NotImplementedError
@@ -747,7 +747,7 @@ class ZfitIndependentParameter(ZfitParameter, metaclass=ABCMeta):
         If the step size is not set, the `DEFAULT_STEP_SIZE` is used.
 
         Returns:
-            :py:class:`tf.Tensor`: the step size
+            the step size
         """
         raise NotImplementedError
 
@@ -818,7 +818,7 @@ class ZfitModel(ZfitNumericParametrized, ZfitDimensional):
             name:
 
         Returns:
-            Tensor: the integral value
+            the integral value
         """
         raise NotImplementedError
 
@@ -856,7 +856,7 @@ class ZfitModel(ZfitNumericParametrized, ZfitDimensional):
             norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
-            Tensor: the value of the partially integrated function evaluated at `x`.
+            the value of the partially integrated function evaluated at `x`.
         """
         raise NotImplementedError
 

--- a/zfit/core/interfaces.py
+++ b/zfit/core/interfaces.py
@@ -73,7 +73,7 @@ class ZfitOrderableDimensional(ZfitDimensional, metaclass=ABCMeta):
             is raised.
 
         Returns:
-            a copy of the object with the new ordering/observables
+            A copy of the object with the new ordering/observables
 
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
@@ -113,7 +113,7 @@ class ZfitOrderableDimensional(ZfitDimensional, metaclass=ABCMeta):
                 is raised.
 
             Returns:
-                a copy of the object with the new ordering/axes
+                A copy of the object with the new ordering/axes
 
             Raises:
                 CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
@@ -146,7 +146,7 @@ class ZfitOrderableDimensional(ZfitDimensional, metaclass=ABCMeta):
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
-            the object with the new axes
+            The object with the new axes
 
         Raises:
             AxesIncompatibleError: if the axes are already set and `overwrite` is False.
@@ -184,7 +184,7 @@ class ZfitOrderableDimensional(ZfitDimensional, metaclass=ABCMeta):
                 self.axes to be the axes of x.
 
         Returns:
-            the reordered array-like object
+            The reordered array-like object
         """
         raise NotImplementedError
 
@@ -354,7 +354,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
         If a limit with tensors is evaluated inside a graph context, comparison operations will fail.
 
         Returns:
-            if the rectangular limits are tensors.
+            If the rectangular limits are tensors.
         """
         raise NotImplementedError
 
@@ -371,21 +371,13 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
     @property
     @abstractmethod
     def limits_are_false(self) -> bool:
-        """If the limits have been set to False, so the object on purpose does not contain limits.
-
-        Returns:
-            bool:
-        """
+        """Returns if the limits have been set to False, so the object on purpose does not contain limits."""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def has_limits(self) -> bool:
-        """Whether there are limits set and they are not false.
-
-        Returns:
-            bool:
-        """
+        """Whether there are limits set and they are not false."""
         raise NotImplementedError
 
     # TODO: remove from API?
@@ -420,7 +412,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
         If called inside a graph context *and* the limits are tensors, this will return a symbolic `tf.Tensor`.
 
         Returns:
-            result of the comparison
+            Result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -429,9 +421,6 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
     @abstractmethod
     def __eq__(self, other: object) -> bool:
         """Compares two Limits for equality without graph mode allowed.
-
-        Returns:
-            bool:
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -454,7 +443,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
             allow_graph: If False and the function returns a symbolic tensor, raise IllegalInGraphModeError instead.
 
         Returns:
-            result of the comparison
+            Result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
 
@@ -468,7 +457,7 @@ class ZfitLimit(abc.ABC, metaclass=ABCMeta):
         This can be used to determine whether a fitting range specification can handle another limit.
 
         Returns:
-            result of the comparison
+            Result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -719,11 +708,7 @@ class ZfitIndependentParameter(ZfitParameter, metaclass=ABCMeta):
     @property
     @abstractmethod
     def has_limits(self) -> bool:
-        """If the parameter has limits set or not
-
-        Returns:
-            bool
-        """
+        """If the parameter has limits set or not."""
         raise NotImplementedError
 
     @property
@@ -747,7 +732,7 @@ class ZfitIndependentParameter(ZfitParameter, metaclass=ABCMeta):
         If the step size is not set, the `DEFAULT_STEP_SIZE` is used.
 
         Returns:
-            the step size
+            The step size
         """
         raise NotImplementedError
 
@@ -818,7 +803,7 @@ class ZfitModel(ZfitNumericParametrized, ZfitDimensional):
             name:
 
         Returns:
-            the integral value
+            The integral value
         """
         raise NotImplementedError
 
@@ -856,7 +841,7 @@ class ZfitModel(ZfitNumericParametrized, ZfitDimensional):
             norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
-            the value of the partially integrated function evaluated at `x`.
+            The value of the partially integrated function evaluated at `x`.
         """
         raise NotImplementedError
 

--- a/zfit/core/interfaces.py
+++ b/zfit/core/interfaces.py
@@ -142,7 +142,7 @@ class ZfitOrderableDimensional(ZfitDimensional, metaclass=ABCMeta):
 
 
         Args:
-            overwrite (bool): If axes are already set, replace the axes with the autofilled ones.
+            overwrite: If axes are already set, replace the axes with the autofilled ones.
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
@@ -173,7 +173,7 @@ class ZfitOrderableDimensional(ZfitDimensional, metaclass=ABCMeta):
         Switching `func_obs` for `x_obs` resp. `func_axes` for `x_axes` inverts the reordering of x.
 
         Args:
-            x (tensor-like): Tensor to be reordered, last dimension should be n_obs resp. n_axes
+            x: Tensor to be reordered, last dimension should be n_obs resp. n_axes
             x_obs: Observables associated with x. If both, x_obs and x_axes are given, this has precedency over the
                 latter.
             x_axes: Axes associated with x.
@@ -549,9 +549,9 @@ class ZfitSpace(ZfitLimit, ZfitOrderableDimensional, ZfitObject, metaclass=ABCMe
         """Create a :py:class:`~zfit.Space` consisting of only a subset of the `obs`/`axes` (only one allowed).
 
         Args:
-            obs (str, Tuple[str]):
-            axes (int, Tuple[int]):
-            name ():
+            obs:
+            axes:
+            name:
 
         Returns:
 
@@ -695,9 +695,9 @@ class ZfitIndependentParameter(ZfitParameter, metaclass=ABCMeta):
 
 
         Args:
-            minval (Numerical): The lower bound of the sampler. If not given, `lower_limit` is used.
-            maxval (Numerical): The upper bound of the sampler. If not given, `upper_limit` is used.
-            sampler (): A sampler with the same interface as `tf.random.uniform`
+            minval: The lower bound of the sampler. If not given, `lower_limit` is used.
+            maxval: The upper bound of the sampler. If not given, `upper_limit` is used.
+            sampler: A sampler with the same interface as `tf.random.uniform`
 
         Returns:
             `tf.Tensor`: The sampled value
@@ -712,7 +712,7 @@ class ZfitIndependentParameter(ZfitParameter, metaclass=ABCMeta):
         manager.
 
         Args:
-            value (float): The value the parameter will take on.
+            value: The value the parameter will take on.
         """
         raise NotImplementedError
 
@@ -812,10 +812,10 @@ class ZfitModel(ZfitNumericParametrized, ZfitDimensional):
         """Integrate the function over `limits` (normalized over `norm_range` if not False).
 
         Args:
-            limits (tuple, :py:class:`~zfit.Space`): the limits to integrate over
-            norm_range (tuple, :py:class:`~zfit.Space`): the limits to normalize over or False to integrate the
+            limits: the limits to integrate over
+            norm_range: the limits to normalize over or False to integrate the
                 unnormalized probability
-            name (str):
+            name:
 
         Returns:
             Tensor: the integral value
@@ -831,11 +831,11 @@ class ZfitModel(ZfitNumericParametrized, ZfitDimensional):
         """Register an analytic integral with the class.
 
         Args:
-            func ():
-            limits (): |limits_arg_descr|
-            priority (int):
-            supports_multiple_limits (bool):
-            supports_norm_range (bool):
+            func:
+            limits: |limits_arg_descr|
+            priority:
+            supports_multiple_limits:
+            supports_norm_range:
 
         Returns:
 
@@ -851,9 +851,9 @@ class ZfitModel(ZfitNumericParametrized, ZfitDimensional):
         to the dimensions of `norm_range` (if not False)
 
         Args:
-            x (numerical): The value at which the partially integrated function will be evaluated
-            limits (tuple, :py:class:`~zfit.Space`): the limits to integrate over. Can contain only some axes
-            norm_range (tuple, :py:class:`~zfit.Space`, False): the limits to normalize over. Has to have all axes
+            x: The value at which the partially integrated function will be evaluated
+            limits: the limits to integrate over. Can contain only some axes
+            norm_range: the limits to normalize over. Has to have all axes
 
         Returns:
             Tensor: the value of the partially integrated function evaluated at `x`.
@@ -866,7 +866,7 @@ class ZfitModel(ZfitNumericParametrized, ZfitDimensional):
         """Register an inverse analytical integral, the inverse (unnormalized) cdf.
 
         Args:
-            func ():
+            func:
         """
         raise NotImplementedError
 
@@ -875,9 +875,9 @@ class ZfitModel(ZfitNumericParametrized, ZfitDimensional):
         """Sample `n` points within `limits` from the model.
 
         Args:
-            n (int): The number of samples to be generated
-            limits (tuple, :py:class:`~zfit.Space`): In which region to sample in
-            name (str):
+            n: The number of samples to be generated
+            limits: In which region to sample in
+            name:
 
         Returns:
             Tensor(n_obs, n_samples)

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -32,7 +32,7 @@ def _unbinned_nll_tf(model: ztyping.PDFInputType, data: ztyping.DataInputType, f
         fit_range:
 
     Returns:
-        the unbinned nll
+        The unbinned nll
 
     Raises:
         ValueError: if both `probs` and `log_probs` are specified.

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -32,7 +32,7 @@ def _unbinned_nll_tf(model: ztyping.PDFInputType, data: ztyping.DataInputType, f
         fit_range:
 
     Returns:
-        graph: the unbinned nll
+        the unbinned nll
 
     Raises:
         ValueError: if both `probs` and `log_probs` are specified.

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -27,9 +27,9 @@ def _unbinned_nll_tf(model: ztyping.PDFInputType, data: ztyping.DataInputType, f
     """Return unbinned negative log likelihood graph for a PDF
 
     Args:
-        model (ZfitModel): PDFs with a `.pdf` method. Has to be as many models as data
-        data (ZfitData):
-        fit_range ():
+        model: PDFs with a `.pdf` method. Has to be as many models as data
+        data:
+        fit_range:
 
     Returns:
         graph: the unbinned nll
@@ -86,12 +86,12 @@ class BaseLoss(ZfitLoss, BaseNumeric):
         to the loss. The length of each has to match the length of the others.
 
         Args:
-            model (Iterable[ZfitModel]): The model or models to evaluate the data on
-            data (Iterable[ZfitData]): Data to use
-            fit_range (Iterable[:py:class:`~zfit.Space`]): The fitting range. It's the norm_range for the models (if
+            model: The model or models to evaluate the data on
+            data: Data to use
+            fit_range: The fitting range. It's the norm_range for the models (if
             they
                 have a norm_range) and the data_range for the data.
-            constraints (Iterable[tf.Tensor): A Tensor representing a loss constraint. Using
+            constraints: A Tensor representing a loss constraint. Using
                 `zfit.constraint.*` allows for easy use of predefined constraints.
         """
         super().__init__(name=type(self).__name__, params={})

--- a/zfit/core/operations.py
+++ b/zfit/core/operations.py
@@ -15,8 +15,8 @@ def multiply(object1: ztyping.BaseObjectType, object2: ztyping.BaseObjectType) -
     """Multiply two objects and return a new object (may depending on the old).
 
     Args:
-        object1 (): A ZfitParameter, ZfitFunc or ZfitPDF to multiply with object2
-        object2 (): A ZfitParameter, ZfitFunc or ZfitPDF to multiply with object1
+        object1: A ZfitParameter, ZfitFunc or ZfitPDF to multiply with object2
+        object2: A ZfitParameter, ZfitFunc or ZfitPDF to multiply with object1
     Raises:
         TypeError: if one of the objects is neither a ZfitFunc, ZfitPDF or convertable to a ZfitParameter
     """
@@ -120,8 +120,8 @@ def add(object1: ztyping.BaseObjectType, object2: ztyping.BaseObjectType) -> zty
     """Add two objects and return a new object (may depending on the old).
 
     Args:
-        object1 (): A ZfitParameter, ZfitFunc or ZfitPDF to add with object2
-        object2 (): A ZfitParameter, ZfitFunc or ZfitPDF to add with object1
+        object1: A ZfitParameter, ZfitFunc or ZfitPDF to add with object2
+        object2: A ZfitParameter, ZfitFunc or ZfitPDF to add with object1
     """
     # converting the objects to known types
     object1, object2 = _convert_to_known(object1, object2)

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -544,7 +544,7 @@ class Parameter(ZfitParameterMixin, TFBaseVariable, BaseParameter, ZfitIndepende
         manager.
 
         Args:
-            value (float): The value the parameter will take on.
+            value: The value the parameter will take on.
         """
         super_assign = super().assign
 
@@ -563,9 +563,9 @@ class Parameter(ZfitParameterMixin, TFBaseVariable, BaseParameter, ZfitIndepende
 
 
         Args:
-            minval (Numerical): The lower bound of the sampler. If not given, `lower_limit` is used.
-            maxval (Numerical): The upper bound of the sampler. If not given, `upper_limit` is used.
-            sampler (): A sampler with the same interface as `tf.random.uniform`
+            minval: The lower bound of the sampler. If not given, `lower_limit` is used.
+            maxval: The upper bound of the sampler. If not given, `upper_limit` is used.
+            sampler: A sampler with the same interface as `tf.random.uniform`
 
         Returns:
             The sampled value

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -443,11 +443,8 @@ class Parameter(ZfitParameterMixin, TFBaseVariable, BaseParameter, ZfitIndepende
 
     @property
     def has_limits(self) -> bool:
-        """If the parameter has limits set or not
+        """If the parameter has limits set or not."""
 
-        Returns:
-            bool
-        """
         no_limits = self._lower_limit is None and self._upper_limit is None
         return not no_limits
 

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -163,7 +163,7 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
         efficiency_estimation: estimation of the initial sampling efficiency.
 
     Returns:
-        tf.Tensor:
+
     """
     prob_max_init = prob_max
     multiple_limits = len(limits) > 1

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -128,11 +128,11 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
     """Accept reject sample from a probability distribution.
 
     Args:
-        prob (function): A function taking x a Tensor as an argument and returning the probability
+        prob: A function taking x a Tensor as an argument and returning the probability
             (or anything that is proportional to the probability).
-        n (int): Number of samples to produce
-        limits (:py:class:`~zfit.Space`): The limits to sample from
-        sample_and_weights_factory (Callable): An (immutable!) factory function that returns the following function:
+        n: Number of samples to produce
+        limits: The limits to sample from
+        sample_and_weights_factory: An (immutable!) factory function that returns the following function:
             A function that returns the sample to insert into `prob` and the weights
             (probability density) of each sample together with the random thresholds. The API looks as follows:
 
@@ -156,11 +156,11 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
                     that the peaks coincide).
                 - n_produced: the number of events produced. Can deviate from the requested number.
 
-        dtype ():
-        prob_max (Union[None, int]): The maximum of the model function for the given limits. If None
+        dtype:
+        prob_max: The maximum of the model function for the given limits. If None
             is given, it will be automatically, safely estimated (by a 10% increase in computation time
             (constant weak scaling)).
-        efficiency_estimation (float): estimation of the initial sampling efficiency.
+        efficiency_estimation: estimation of the initial sampling efficiency.
 
     Returns:
         tf.Tensor:
@@ -397,7 +397,7 @@ def extract_extended_pdfs(pdfs: Union[Iterable[ZfitPDF], ZfitPDF]) -> List[ZfitP
     """Return all extended pdfs that are daughters.
 
     Args:
-        pdfs (Iterable[pdfs]):
+        pdfs:
 
     Returns:
         List[pdfs]:
@@ -427,8 +427,8 @@ def extended_sampling(pdfs: Union[Iterable[ZfitPDF], ZfitPDF], limits: Space) ->
     """Create a sample from extended pdfs by sampling poissonian using the yield.
 
     Args:
-        pdfs (iterable[ZfitPDF]):
-        limits (:py:class:`~zfit.Space`):
+        pdfs:
+        limits:
 
     Returns:
         Union[tf.Tensor]:

--- a/zfit/core/space.py
+++ b/zfit/core/space.py
@@ -865,7 +865,7 @@ class BaseSpace(ZfitSpace, BaseObject):
         """Input check: Convert `NOT_SPECIFIED` to None or check if obs are all strings.
 
         Args:
-            obs (str, List[str], None, NOT_SPECIFIED):
+            obs:
 
         Returns:
             type:
@@ -937,7 +937,7 @@ class BaseSpace(ZfitSpace, BaseObject):
         In case the observables are different, the order of the first space is taken.
 
         Args:
-            other (:py:class:`~zfit.Space`):
+            other:
 
         Returns:
             :py:class:`~zfit.Space`:
@@ -950,7 +950,7 @@ class BaseSpace(ZfitSpace, BaseObject):
         """Combine spaces with different obs (but consistent limits).
 
         Args:
-            other (:py:class:`~zfit.Space`):
+            other:
 
         Returns:
             :py:class:`~zfit.Space`:
@@ -1097,9 +1097,9 @@ class Space(BaseSpace):
 
 
         Args:
-            obs (str, List[str,...]):
-            limits ():
-            name (str):
+            obs:
+            limits:
+            name:
         """
         if name is None:
             name = "Space"
@@ -1119,7 +1119,7 @@ class Space(BaseSpace):
         """Check and sanitize the input limits as well as the rectangular limits.
 
         Args:
-            limit ():
+            limit:
 
         Returns:
             dict(obs/axes: ZfitLimit): Limits dictionary containing the observables and/or the axes as a key matching
@@ -1544,7 +1544,7 @@ class Space(BaseSpace):
         Switching `func_obs` for `x_obs` resp. `func_axes` for `x_axes` inverts the reordering of x.
 
         Args:
-            x (tensor-like): Tensor to be reordered, last dimension should be n_obs resp. n_axes
+            x: Tensor to be reordered, last dimension should be n_obs resp. n_axes
             x_obs: Observables associated with x. If both, x_obs and x_axes are given, this has precedency over the
                 latter.
             x_axes: Axes associated with x.
@@ -1740,7 +1740,7 @@ class Space(BaseSpace):
 
 
         Args:
-            overwrite (bool): If axes are already set, replace the axes with the autofilled ones.
+            overwrite: If axes are already set, replace the axes with the autofilled ones.
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
@@ -1765,8 +1765,8 @@ class Space(BaseSpace):
         """Create a :py:class:`~zfit.Space` consisting of only a subset of the `obs`/`axes` (only one allowed).
 
         Args:
-            obs (str, Tuple[str]): Observables of the subspace to return.
-            axes (int, Tuple[int]): Axes of the subspace to return.
+            obs: Observables of the subspace to return.
+            axes: Axes of the subspace to return.
             name: Human readable names
 
         Returns:
@@ -1811,9 +1811,9 @@ class Space(BaseSpace):
         `overwrite_overwrite_kwargs`.
 
         Args:
-            name (str): The new name. If not given, the new instance will be named the same as the
+            name: The new name. If not given, the new instance will be named the same as the
                 current one.
-            **overwrite_kwargs ():
+            **overwrite_kwargs:
 
         Returns:
             :py:class:`~zfit.Space`
@@ -1873,9 +1873,9 @@ class Space(BaseSpace):
 
         Args:
             rect_limits:
-            axes ():
-            limits ():
-            name (str):
+            axes:
+            limits:
+            name:
 
         Returns:
             :py:class:`~zfit.Space`
@@ -1939,7 +1939,7 @@ def add_spaces(*spaces: Iterable["ZfitSpace"], name=None):
     """Add two spaces and merge their limits if possible or return False.
 
     Args:
-        spaces (Iterable[:py:class:`~zfit.Space`]):
+        spaces:
 
     Returns:
         Union[None, :py:class:`~zfit.Space`, bool]:
@@ -1967,7 +1967,7 @@ def combine_spaces(*spaces: Iterable[Space]):
     is not unambiguous and `False` is returned
 
     Args:
-        spaces (List[:py:class:`~zfit.Space`]):
+        spaces:
 
     Returns:
         `zfit.Space` or False: Returns False if the limits don't coincide in one or more obs. Otherwise
@@ -2593,7 +2593,7 @@ class MultiSpace(BaseSpace):
 
 
         Args:
-            overwrite (bool): If axes are already set, replace the axes with the autofilled ones.
+            overwrite: If axes are already set, replace the axes with the autofilled ones.
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
@@ -2619,8 +2619,8 @@ class MultiSpace(BaseSpace):
         """Create a :py:class:`~zfit.Space` consisting of only a subset of the `obs`/`axes` (only one allowed).
 
         Args:
-            obs (str, Tuple[str]): Observables of the subspace to return.
-            axes (int, Tuple[int]): Axes of the subspace to return.
+            obs: Observables of the subspace to return.
+            axes: Axes of the subspace to return.
             name: Human readable names
 
         Returns:
@@ -2680,14 +2680,14 @@ def convert_to_space(obs: Optional[ztyping.ObsTypeInput] = None, axes: Optional[
     """Convert *limits* to a :py:class:`~zfit.Space` object if not already None or False.
 
     Args:
-        obs (Union[Tuple[float, float], :py:class:`~zfit.Space`]):
-        limits ():
-        axes ():
-        overwrite_limits (bool): If `obs` or `axes` is a :py:class:`~zfit.Space` _and_ `limits` are given, return an instance
+        obs:
+        limits:
+        axes:
+        overwrite_limits: If `obs` or `axes` is a :py:class:`~zfit.Space` _and_ `limits` are given, return an instance
             of :py:class:`~zfit.Space` with the new limits. If the flag is `False`, the `limits` argument will be
             ignored if
-        one_dim_limits_only (bool):
-        simple_limits_only (bool):
+        one_dim_limits_only:
+        simple_limits_only:
 
     Returns:
         Union[:py:class:`~zfit.Space`, False, None]:
@@ -2801,8 +2801,8 @@ def supports(*, norm_range: bool = False, multiple_limits: bool = False) -> Call
     be catched by an earlier function that knows how to handle things.
 
     Args:
-        norm_range (bool): If False, no norm_range argument will be passed through resp. will be `None`
-        multiple_limits (bool): If False, only simple limits are to be expected and no iteration is
+        norm_range: If False, no norm_range argument will be passed through resp. will be `None`
+        multiple_limits: If False, only simple limits are to be expected and no iteration is
             therefore required.
     """
     decorator_stack = []
@@ -2849,7 +2849,7 @@ def limits_consistent(spaces: Iterable["zfit.Space"]):
     This function is useful to check if several spaces with *different* observables can be _combined_.
 
     Args:
-        spaces (List[zfit.Space]):
+        spaces:
 
     Returns:
         bool:
@@ -2866,7 +2866,7 @@ def add_spaces_old(spaces: Iterable["zfit.Space"]):
     """Add two spaces and merge their limits if possible or return False.
 
     Args:
-        spaces (Iterable[:py:class:`~zfit.Space`]):
+        spaces:
 
     Returns:
         Union[None, :py:class:`~zfit.Space`, bool]:

--- a/zfit/core/space.py
+++ b/zfit/core/space.py
@@ -361,7 +361,7 @@ class Limit(ZfitLimit):
             `limits_are_false` and `limits_are_set`.
 
         Returns:
-            tuple(np.ndarray/tf.Tensor, np.ndarray/tf.Tensor) or bool or None: The lower and upper limits.
+            The lower and upper limits.
         Raises:
             LimitsNotSpecifiedError: If there are not limits set or they are False.
         """
@@ -389,7 +389,7 @@ class Limit(ZfitLimit):
 
 
         Returns:
-            (lower, upper): A tuple of two `np.ndarray` with shape (1, n_obs) typically. The last
+            A tuple of two `np.ndarray` with shape (1, n_obs) typically. The last
                 dimension is always `n_obs`, the first can be vectorized. This allows unstacking
                 with `z.unstack_x()` as can be done with data.
 
@@ -436,7 +436,7 @@ class Limit(ZfitLimit):
             guarantee_limits: Guarantee that the values are already inside the rectangular limits.
 
         Returns:
-            tensor-like: Return a boolean tensor-like object with the same shape as the input `x` except of the
+            Return a boolean tensor-like object with the same shape as the input `x` except of the
                 last dimension removed.
         """
         x = _sanitize_x_input(x, n_obs=self.n_obs)
@@ -469,7 +469,7 @@ class Limit(ZfitLimit):
             axis: The axis to remove the elements from. Defaults to 0.
 
         Returns:
-            tensor-like: Return an object with the same shape as `x` except that along `axis` elements have been
+            Return an object with the same shape as `x` except that along `axis` elements have been
                 removed.
         """
 
@@ -497,7 +497,7 @@ class Limit(ZfitLimit):
         If a limit with tensors is evaluated inside a graph context, comparison operations will fail.
 
         Returns:
-            bool: if the rectangular limits are tensors.
+            if the rectangular limits are tensors.
         """
         try:
             _ = self.rect_limits_np
@@ -538,7 +538,7 @@ class Limit(ZfitLimit):
         """Dimensionality, the number of observables, of the limits. Equals to the last axis in rectangular limits.
 
         Returns:
-            int: Dimensionality of the limits.
+            Dimensionality of the limits.
         """
         return self._n_obs
 
@@ -547,7 +547,7 @@ class Limit(ZfitLimit):
         """
 
         Returns:
-            int, None: Return the number of events, the dimension of the first shape. If this is > 1 or None,
+            Return the number of events, the dimension of the first shape. If this is > 1 or None,
                 it's vectorized.
         """
         if not self.has_limits:
@@ -564,7 +564,7 @@ class Limit(ZfitLimit):
             allow_graph: If False and the function returns a symbolic tensor, raise IllegalInGraphModeError instead.
 
         Returns:
-            bool, tf.Tensor: Either a Python boolean or a `tf.Tensor`
+            Either a Python boolean or a `tf.Tensor`
          Raises:
              IllegalInGraphModeError: if `allow_graph`
         """
@@ -609,7 +609,7 @@ class Limit(ZfitLimit):
 
 
         Returns:
-            bool: result of the comparison
+            result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
 
@@ -624,7 +624,7 @@ class Limit(ZfitLimit):
         This can be used to determine whether a fitting range specification can handle another limit.
 
         Returns:
-            bool: result of the comparison
+            result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -638,7 +638,7 @@ class Limit(ZfitLimit):
         If this is not possible, if the limits are not rectangular, just returns itself.
 
         Returns:
-            Iterable[ZfitLimits]: The sublimits if it was able to split.
+            The sublimits if it was able to split.
         """
         return self._sublimits
 
@@ -750,7 +750,7 @@ class BaseSpace(ZfitSpace, BaseObject):
             guarantee_limits: Guarantee that the values are already inside the rectangular limits.
 
         Returns:
-            tensor-like: Return a boolean tensor-like object with the same shape as the input `x` except of the
+            Return a boolean tensor-like object with the same shape as the input `x` except of the
                 last dimension removed.
         """
         x = _sanitize_x_input(x, n_obs=self.n_obs)
@@ -778,7 +778,7 @@ class BaseSpace(ZfitSpace, BaseObject):
             axis: The axis to remove the elements from. Defaults to 0.
 
         Returns:
-            tensor-like: Return an object with the same shape as `x` except that along `axis` elements have been
+            Return an object with the same shape as `x` except that along `axis` elements have been
                 removed.
         """
         if self.has_rect_limits and guarantee_limits:
@@ -837,7 +837,7 @@ class BaseSpace(ZfitSpace, BaseObject):
                 return the indices that could be used to reorder.
 
         Returns:
-            tuple(int): New indices that would reorder the instances obs to be obs respectively axes.
+            New indices that would reorder the instances obs to be obs respectively axes.
 
         Raises:
             CoordinatesUnderdefinedError: If neither `obs` nor `axes` is given
@@ -976,7 +976,7 @@ class BaseSpace(ZfitSpace, BaseObject):
         If called inside a graph context *and* the limits are tensors, this will return a symbolic `tf.Tensor`.
 
         Returns:
-            bool: result of the comparison
+            result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -1009,7 +1009,7 @@ class BaseSpace(ZfitSpace, BaseObject):
             allow_graph: If False and the function returns a symbolic tensor, raise IllegalInGraphModeError instead.
 
         Returns:
-            bool: result of the comparison
+            result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -1023,7 +1023,7 @@ class BaseSpace(ZfitSpace, BaseObject):
         This can be used to determine whether a fitting range specification can handle another limit.
 
         Returns:
-            bool: result of the comparison
+            result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -1122,7 +1122,7 @@ class Space(BaseSpace):
             limit:
 
         Returns:
-            dict(obs/axes: ZfitLimit): Limits dictionary containing the observables and/or the axes as a key matching
+            Limits dictionary containing the observables and/or the axes as a key matching
                 `ZfitLimits` objects.
 
         """
@@ -1252,7 +1252,7 @@ class Space(BaseSpace):
             `limits_are_false` and `limits_are_set`.
 
         Returns:
-            tuple(np.ndarray/tf.Tensor, np.ndarray/tf.Tensor) or bool or None: The lower and upper limits.
+            The lower and upper limits.
         Raises:
             LimitsNotSpecifiedError: If there are not limits set or they are False.
         """
@@ -1287,7 +1287,7 @@ class Space(BaseSpace):
         `limits_are_false` and `limits_are_set`.
 
         Returns:
-            (lower, upper): A tuple of two `np.ndarray` with shape (1, n_obs) typically. The last
+            A tuple of two `np.ndarray` with shape (1, n_obs) typically. The last
                 dimension is always `n_obs`, the first can be vectorized. This allows unstacking
                 with `z.unstack_x()` as can be done with data.
 
@@ -1357,7 +1357,7 @@ class Space(BaseSpace):
         If a limit with tensors is evaluated inside a graph context, comparison operations will fail.
 
         Returns:
-            bool: if the rectangular limits are tensors.
+            if the rectangular limits are tensors.
         """
         try:
             _ = self.rect_limits_np
@@ -1384,7 +1384,7 @@ class Space(BaseSpace):
         """If the limits have been set to False, so the object on purpose does not contain limits.
 
         Returns:
-            bool: True if limits is False
+            True if limits is False
         """
         return all(limit.limits_are_false
                    for limit in self._limits_dict['obs' if self.obs else 'axes'].values())
@@ -1408,7 +1408,7 @@ class Space(BaseSpace):
         """Return the number of events, the dimension of the first shape.
 
         Returns:
-            int, None: Number of events, the dimension of the first shape. If this is > 1 or None,
+            Number of events, the dimension of the first shape. If this is > 1 or None,
                 it's vectorized.
         """
         if not self.has_limits:
@@ -1423,7 +1423,7 @@ class Space(BaseSpace):
         """Simplified `limits` for exactly 2 obs, 1 limit: return the tuple(low_obs1, low_obs2, up_obs1, up_obs2).
 
         Returns:
-            tuple(float, float, float, float): so `low_x, low_y, up_x, up_y = space.limit2d` for a single, 2 obs limit.
+            so `low_x, low_y, up_x, up_y = space.limit2d` for a single, 2 obs limit.
                 low_x is the lower limit in x, up_x is the upper limit in x etc.
 
         Raises:
@@ -1440,7 +1440,7 @@ class Space(BaseSpace):
         """Simplified `.limits` for exactly 1 obs, n limits: return the tuple(low_1, ..., low_n, up_1, ..., up_n).
 
         Returns:
-            tuple(float, float, ...): so `low_1, low_2, up_1, up_2 = space.limits1d` for several, 1 obs limits.
+            so `low_1, low_2, up_1, up_2 = space.limits1d` for several, 1 obs limits.
                 low_1 to up_1 is the first interval, low_2 to up_2 is the second interval etc.
 
         Raises:
@@ -1519,7 +1519,7 @@ class Space(BaseSpace):
             name: Human readable name
 
         Returns:
-            :py:class:`~zfit.Space`: Copy of the current object with the new limits.
+            Copy of the current object with the new limits.
         """
         new_space = type(self)(obs=self.coords, limits=limits, rect_limits=rect_limits,
                                name=name)
@@ -1555,7 +1555,7 @@ class Space(BaseSpace):
                 self.axes to be the axes of x.
 
         Returns:
-            tensor-like: the reordered array-like object
+            the reordered array-like object
         """
         return self.coords.reorder_x(x=x, x_obs=x_obs, x_axes=x_axes, func_obs=func_obs, func_axes=func_axes)
 
@@ -1591,7 +1591,7 @@ class Space(BaseSpace):
             is raised.
 
         Returns:
-            :py:class:`~zfit.Space`: a copy of the object with the new ordering/observables
+            a copy of the object with the new ordering/observables
 
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
@@ -1643,7 +1643,7 @@ class Space(BaseSpace):
             is raised.
 
         Returns:
-            :py:class:`~zfit.Space`: a copy of the object with the new ordering/axes
+            a copy of the object with the new ordering/axes
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
             AxesIncompatibleError: if `axes` is a superset and allow_superset is False or a subset and
@@ -1744,7 +1744,7 @@ class Space(BaseSpace):
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
-            ZfitSpace: the object with the new axes
+            the object with the new axes
 
         Raises:
             AxesIncompatibleError: if the axes are already set and `overwrite` is False.
@@ -1770,7 +1770,7 @@ class Space(BaseSpace):
             name: Human readable names
 
         Returns:
-            :py:class:`~zfit.Space`: A space containing only a subspace (and sublimits etc.)
+            A space containing only a subspace (and sublimits etc.)
         """
         if obs is not None and axes is not None:
             raise ValueError("Cannot specify `obs` *and* `axes` to get subspace.")
@@ -1851,7 +1851,7 @@ class Space(BaseSpace):
         """Simplified limits getter for 1 obs, 1 limit only: return the tuple(lower, upper).
 
         Returns:
-            tuple(float, float): so :code:`lower, upper = space.limit1d` for a simple, 1 obs limit.
+            so :code:`lower, upper = space.limit1d` for a simple, 1 obs limit.
 
         Raises:
             RuntimeError: if the conditions (n_obs or n_limits) are not satisfied.
@@ -1970,7 +1970,7 @@ def combine_spaces(*spaces: Iterable[Space]):
         spaces:
 
     Returns:
-        `zfit.Space` or False: Returns False if the limits don't coincide in one or more obs. Otherwise
+        Returns False if the limits don't coincide in one or more obs. Otherwise
             return the :py:class:`~zfit.Space` with all obs from `spaces` sorted by the order of `spaces` and with the
             combined limits.
     Raises:
@@ -2381,7 +2381,7 @@ class MultiSpace(BaseSpace):
         If a limit with tensors is evaluated inside a graph context, comparison operations will fail.
 
         Returns:
-            bool: if the rectangular limits are tensors.
+            if the rectangular limits are tensors.
         """
         return all(space.limits_are_tensors for space in self)
 
@@ -2397,7 +2397,7 @@ class MultiSpace(BaseSpace):
         """If the limits have been set to False, so the object on purpose does not contain limits.
 
         Returns:
-            bool: True if limits is False
+            True if limits is False
         """
         return all(space.limits_are_false for space in self.spaces)
 
@@ -2420,7 +2420,7 @@ class MultiSpace(BaseSpace):
         """If the limits have been set to a limit or are False.
 
         Returns:
-            bool: Whether the limits have been set or not.
+            Whether the limits have been set or not.
         """
         return all(space.limits_are_set for space in self.spaces)
 
@@ -2429,7 +2429,7 @@ class MultiSpace(BaseSpace):
         """Shape of the first dimension, usually reflects the number of events.
 
         Returns:
-            int, None: Return the number of events, the dimension of the first shape. If this is > 1 or None,
+            Return the number of events, the dimension of the first shape. If this is > 1 or None,
                 it's vectorized.
         """
         # get the first numeric n_events. Is None if a Tensor and not specified yet.
@@ -2451,7 +2451,7 @@ class MultiSpace(BaseSpace):
             name: Human readable name
 
         Returns:
-            :py:class:`~zfit.MultiSpace`: Copy of the current object with the new limits.
+            Copy of the current object with the new limits.
         """
         new_space = self.copy(spaces=[space.with_limits(limits=limits, rect_limits=rect_limits)
                                       for space in self],
@@ -2492,7 +2492,7 @@ class MultiSpace(BaseSpace):
             is raised.
 
         Returns:
-            :py:class:`~zfit.MultiSpace`: a copy of the object with the new ordering/observables
+            a copy of the object with the new ordering/observables
 
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
@@ -2534,7 +2534,7 @@ class MultiSpace(BaseSpace):
                 is raised.
 
             Returns:
-                :py:class:`~zfit.Space`: a copy of the object with the new ordering/axes
+                a copy of the object with the new ordering/axes
             Raises:
                 CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
                 AxesIncompatibleError: if `axes` is a superset and allow_superset is False or a subset and
@@ -2597,7 +2597,7 @@ class MultiSpace(BaseSpace):
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
-            object: the object with the new axes
+            the object with the new axes
 
         Raises:
             AxesIncompatibleError: if the axes are already set and `overwrite` is False.
@@ -2624,7 +2624,7 @@ class MultiSpace(BaseSpace):
             name: Human readable names
 
         Returns:
-            :py:class:`MultiSpace`: A space containing only a subspace (and sublimits etc.)
+            A space containing only a subspace (and sublimits etc.)
         """
         spaces = [space.get_subspace(obs=obs, axes=axes) for space in self.spaces]
         return self.copy(spaces=spaces)

--- a/zfit/core/space.py
+++ b/zfit/core/space.py
@@ -331,7 +331,7 @@ class Limit(ZfitLimit):
             limit:
 
         Returns:
-            limit object, bool
+
         """
         if is_range_definition(limit):  # as the above ANY
             dtype = object
@@ -497,7 +497,7 @@ class Limit(ZfitLimit):
         If a limit with tensors is evaluated inside a graph context, comparison operations will fail.
 
         Returns:
-            if the rectangular limits are tensors.
+            If the rectangular limits are tensors.
         """
         try:
             _ = self.rect_limits_np
@@ -511,7 +511,7 @@ class Limit(ZfitLimit):
         """If the limits have never explicitly been set to a limit or to False.
 
         Returns:
-            bool:
+
         """
         return self._rect_limits is not None
 
@@ -520,7 +520,7 @@ class Limit(ZfitLimit):
         """If the limits have been set to False, so the object on purpose does not contain limits.
 
         Returns:
-            bool:
+
         """
         return self._rect_limits is False
 
@@ -529,7 +529,7 @@ class Limit(ZfitLimit):
         """If there are limits set and they are not false.
 
         Returns:
-            bool:
+
         """
         return not (self.limits_are_false or (not self.limits_are_set))
 
@@ -576,7 +576,7 @@ class Limit(ZfitLimit):
         """Compares two Limits for equality without graph mode allowed.
 
         Returns:
-            bool:
+
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -609,7 +609,7 @@ class Limit(ZfitLimit):
 
 
         Returns:
-            result of the comparison
+            Result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
 
@@ -624,7 +624,7 @@ class Limit(ZfitLimit):
         This can be used to determine whether a fitting range specification can handle another limit.
 
         Returns:
-            result of the comparison
+            Result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -868,7 +868,7 @@ class BaseSpace(ZfitSpace, BaseObject):
             obs:
 
         Returns:
-            type:
+
         """
         if obs is None:
             if allow_none:
@@ -976,7 +976,7 @@ class BaseSpace(ZfitSpace, BaseObject):
         If called inside a graph context *and* the limits are tensors, this will return a symbolic `tf.Tensor`.
 
         Returns:
-            result of the comparison
+            Result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -988,7 +988,7 @@ class BaseSpace(ZfitSpace, BaseObject):
         """Compares two Limits for equality without graph mode allowed.
 
         Returns:
-            bool:
+
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -1009,7 +1009,7 @@ class BaseSpace(ZfitSpace, BaseObject):
             allow_graph: If False and the function returns a symbolic tensor, raise IllegalInGraphModeError instead.
 
         Returns:
-            result of the comparison
+            Result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -1023,7 +1023,7 @@ class BaseSpace(ZfitSpace, BaseObject):
         This can be used to determine whether a fitting range specification can handle another limit.
 
         Returns:
-            result of the comparison
+            Result of the comparison
         Raises:
              IllegalInGraphModeError: it the comparison happens with tensors in a graph context.
         """
@@ -1357,7 +1357,7 @@ class Space(BaseSpace):
         If a limit with tensors is evaluated inside a graph context, comparison operations will fail.
 
         Returns:
-            if the rectangular limits are tensors.
+            If the rectangular limits are tensors.
         """
         try:
             _ = self.rect_limits_np
@@ -1394,7 +1394,7 @@ class Space(BaseSpace):
         """Whether there are limits set and they are not false.
 
         Returns:
-            bool:
+
         """
         return self.limits_are_set and not self.limits_are_false
 
@@ -1423,7 +1423,7 @@ class Space(BaseSpace):
         """Simplified `limits` for exactly 2 obs, 1 limit: return the tuple(low_obs1, low_obs2, up_obs1, up_obs2).
 
         Returns:
-            so `low_x, low_y, up_x, up_y = space.limit2d` for a single, 2 obs limit.
+            So `low_x, low_y, up_x, up_y = space.limit2d` for a single, 2 obs limit.
                 low_x is the lower limit in x, up_x is the upper limit in x etc.
 
         Raises:
@@ -1440,7 +1440,7 @@ class Space(BaseSpace):
         """Simplified `.limits` for exactly 1 obs, n limits: return the tuple(low_1, ..., low_n, up_1, ..., up_n).
 
         Returns:
-            so `low_1, low_2, up_1, up_2 = space.limits1d` for several, 1 obs limits.
+            So `low_1, low_2, up_1, up_2 = space.limits1d` for several, 1 obs limits.
                 low_1 to up_1 is the first interval, low_2 to up_2 is the second interval etc.
 
         Raises:
@@ -1555,7 +1555,7 @@ class Space(BaseSpace):
                 self.axes to be the axes of x.
 
         Returns:
-            the reordered array-like object
+            The reordered array-like object
         """
         return self.coords.reorder_x(x=x, x_obs=x_obs, x_axes=x_axes, func_obs=func_obs, func_axes=func_axes)
 
@@ -1591,7 +1591,7 @@ class Space(BaseSpace):
             is raised.
 
         Returns:
-            a copy of the object with the new ordering/observables
+            A copy of the object with the new ordering/observables
 
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
@@ -1643,7 +1643,7 @@ class Space(BaseSpace):
             is raised.
 
         Returns:
-            a copy of the object with the new ordering/axes
+            A copy of the object with the new ordering/axes
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
             AxesIncompatibleError: if `axes` is a superset and allow_superset is False or a subset and
@@ -1744,7 +1744,7 @@ class Space(BaseSpace):
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
-            the object with the new axes
+            The object with the new axes
 
         Raises:
             AxesIncompatibleError: if the axes are already set and `overwrite` is False.
@@ -1851,7 +1851,7 @@ class Space(BaseSpace):
         """Simplified limits getter for 1 obs, 1 limit only: return the tuple(lower, upper).
 
         Returns:
-            so :code:`lower, upper = space.limit1d` for a simple, 1 obs limit.
+            So :code:`lower, upper = space.limit1d` for a simple, 1 obs limit.
 
         Raises:
             RuntimeError: if the conditions (n_obs or n_limits) are not satisfied.
@@ -2381,7 +2381,7 @@ class MultiSpace(BaseSpace):
         If a limit with tensors is evaluated inside a graph context, comparison operations will fail.
 
         Returns:
-            if the rectangular limits are tensors.
+            If the rectangular limits are tensors.
         """
         return all(space.limits_are_tensors for space in self)
 
@@ -2408,7 +2408,7 @@ class MultiSpace(BaseSpace):
         """Whether there are limits set and they are not false.
 
         Returns:
-            bool:
+
         """
         try:
             return self.limits_are_set and not self.limits_are_false
@@ -2492,7 +2492,7 @@ class MultiSpace(BaseSpace):
             is raised.
 
         Returns:
-            a copy of the object with the new ordering/observables
+            A copy of the object with the new ordering/observables
 
         Raises:
             CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
@@ -2534,7 +2534,7 @@ class MultiSpace(BaseSpace):
                 is raised.
 
             Returns:
-                a copy of the object with the new ordering/axes
+                A copy of the object with the new ordering/axes
             Raises:
                 CoordinatesUnderdefinedError: if obs is None and the instance does not have axes
                 AxesIncompatibleError: if `axes` is a superset and allow_superset is False or a subset and
@@ -2597,7 +2597,7 @@ class MultiSpace(BaseSpace):
                 If axes is already set and `overwrite` is False, raise an error.
 
         Returns:
-            the object with the new axes
+            The object with the new axes
 
         Raises:
             AxesIncompatibleError: if the axes are already set and `overwrite` is False.
@@ -2852,7 +2852,7 @@ def limits_consistent(spaces: Iterable["zfit.Space"]):
         spaces:
 
     Returns:
-        bool:
+
     """
     try:
         new_space = combine_spaces(*spaces)

--- a/zfit/minimizers/baseminimizer.py
+++ b/zfit/minimizers/baseminimizer.py
@@ -222,7 +222,7 @@ class BaseMinimizer(ZfitMinimizer):
             values: New values for the parameters.
 
         Returns:
-            list(empty, :py:class:`~tf.Operation`): List of assign operations if `use_op`, otherwise empty. The output
+            List of assign operations if `use_op`, otherwise empty. The output
                 can therefore be directly used as argument to :py:func:`~tf.control_dependencies`.
         """
         if len(params) == 1 and len(values) > 1:
@@ -256,7 +256,7 @@ class BaseMinimizer(ZfitMinimizer):
                 minimize the `loss`. If `None`, the parameters will be taken from the `loss`.
 
         Returns:
-            `FitResult`: The fit result.
+            The fit result.
         """
         params = self._check_input_params(loss=loss, params=params, only_floating=True)
         try:

--- a/zfit/minimizers/baseminimizer.py
+++ b/zfit/minimizers/baseminimizer.py
@@ -204,7 +204,7 @@ class BaseMinimizer(ZfitMinimizer):
         """Extract the current value if defined, otherwise random.
 
         Arguments:
-            params (Parameter):
+            params:
 
         Return:
             list(const): the current value of parameters
@@ -218,8 +218,8 @@ class BaseMinimizer(ZfitMinimizer):
         """Update `params` with `values`. Returns the assign op (if `use_op`, otherwise use a session to load the value.
 
         Args:
-            params (list(`ZfitParameter`)): The parameters to be updated
-            values (list(float, `np.ndarray`)): New values for the parameters.
+            params: The parameters to be updated
+            values: New values for the parameters.
 
         Returns:
             list(empty, :py:class:`~tf.Operation`): List of assign operations if `use_op`, otherwise empty. The output
@@ -236,7 +236,7 @@ class BaseMinimizer(ZfitMinimizer):
         """Perform a single step in the minimization (if implemented).
 
         Args:
-            params ():
+            params:
 
         Returns:
 
@@ -251,8 +251,8 @@ class BaseMinimizer(ZfitMinimizer):
         """Fully minimize the `loss` with respect to `params`.
 
         Args:
-            loss (ZfitLoss): Loss to be minimized.
-            params (list(`zfit.Parameter`): The parameters with respect to which to
+            loss: Loss to be minimized.
+            params: The parameters with respect to which to
                 minimize the `loss`. If `None`, the parameters will be taken from the `loss`.
 
         Returns:

--- a/zfit/minimizers/errors.py
+++ b/zfit/minimizers/errors.py
@@ -32,7 +32,7 @@ def compute_errors(result, params, sigma=1, rtol=0.001, method="hybr", covarianc
             {'minuit_hesse', 'hesse_np'} or a Callable.
 
     Returns:
-        `OrderedDict`: A `OrderedDict` containing as keys the parameter and as value a `dict` which
+        A `OrderedDict` containing as keys the parameter and as value a `dict` which
             contains two keys 'lower' and 'upper', holding the calculated errors.
             Example: result[par1]['upper'] -> the asymmetric upper error of 'par1'
         `FitResult` or `None`: a fit result is returned when a new minimum is found during the loss scan

--- a/zfit/minimizers/errors.py
+++ b/zfit/minimizers/errors.py
@@ -22,13 +22,13 @@ def compute_errors(result, params, sigma=1, rtol=0.001, method="hybr", covarianc
     Computes asymmetric errors of parameters by profiling the loss function in the fit result.
 
     Args:
-        result (`FitResult`): fit result
-        params (list(:py:class:`~zfit.Parameter`)): The parameters to calculate the
+        result: fit result
+        params: The parameters to calculate the
             errors error. If None, use all parameters.
-        sigma (float): Errors are calculated with respect to `sigma` std deviations.
-        rtol (float, default=0.01): relative tolerance between the computed and the exact roots
-        method (str, defautl='hybr'): type of solver, `method` argument of `scipy.optimize.root_
-        covariance_method (str or Callable): The method to use to calculate the correlation matrix. Valid choices are
+        sigma: Errors are calculated with respect to `sigma` std deviations.
+        rtol: relative tolerance between the computed and the exact roots
+        method: type of solver, `method` argument of `scipy.optimize.root_
+        covariance_method: The method to use to calculate the correlation matrix. Valid choices are
             {'minuit_hesse', 'hesse_np'} or a Callable.
 
     Returns:

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -100,16 +100,16 @@ class FitResult(ZfitResult):
             {parameter: {error_name1: {'low': value, 'high': value or similar}}
 
         Args:
-            params (OrderedDict[:py:class:`~zfit.Parameter`, float]): Result of the fit where each
+            params: Result of the fit where each
                :py:class:`~zfit.Parameter` key has the value from the minimum found by the minimizer.
-            edm (Union[int, float]): The estimated distance to minimum, estimated by the minimizer (if available)
-            fmin (Union[numpy.float64, float]): The minimum of the function found by the minimizer
-            status (int): A status code (if available)
-            converged (bool): Whether the fit has successfully converged or not.
-            info (Dict): Additional information (if available) like *number of function calls* and the
+            edm: The estimated distance to minimum, estimated by the minimizer (if available)
+            fmin: The minimum of the function found by the minimizer
+            status: A status code (if available)
+            converged: Whether the fit has successfully converged or not.
+            info: Additional information (if available) like *number of function calls* and the
                 original minimizer return message.
-            loss (Union[ZfitLoss]): The loss function that was minimized. Contains also the pdf, data etc.
-            minimizer (ZfitMinimizer): Minimizer that was used to obtain this `FitResult` and will be used to
+            loss: The loss function that was minimized. Contains also the pdf, data etc.
+            minimizer: Minimizer that was used to obtain this `FitResult` and will be used to
                 calculate certain errors. If the minimizer is state-based (like "iminuit"), then this is a copy
                 and the state of other `FitResults` or of the *actual* minimizer that performed the minimization
                 won't be altered.
@@ -251,10 +251,10 @@ class FitResult(ZfitResult):
         """Calculate for `params` the symmetric error using the Hessian/covariance matrix.
 
         Args:
-            params (list(:py:class:`~zfit.Parameter`)): The parameters  to calculate the
+            params: The parameters  to calculate the
                 Hessian symmetric error. If None, use all parameters.
-            method (str): the method to calculate the covariance matrix. Can be {'minuit_hesse', 'hesse_np'} or a callable.
-            error_name (str): The name for the error in the dictionary.
+            method: the method to calculate the covariance matrix. Can be {'minuit_hesse', 'hesse_np'} or a callable.
+            error_name: The name for the error in the dictionary.
 
         Returns:
             OrderedDict: Result of the hessian (symmetric) error as dict with each parameter holding
@@ -304,16 +304,16 @@ class FitResult(ZfitResult):
             Use :func:`errors` instead.
 
         Args:
-            params (list(:py:class:`~zfit.Parameter` or str)): The parameters or their names to calculate the
+            params: The parameters or their names to calculate the
                  errors. If `params` is `None`, use all *floating* parameters.
-            method (str or Callable): The method to use to calculate the errors. Valid choices are
+            method: The method to use to calculate the errors. Valid choices are
                 {'minuit_minos'} or a Callable.
-            sigma (float): Errors are calculated with respect to `sigma` std deviations. The definition
+            sigma: Errors are calculated with respect to `sigma` std deviations. The definition
                 of 1 sigma depends on the loss function and is defined there.
 
                 For example, the negative log-likelihood (without the factor of 2) has a correspondents
                 of :math:`\Delta` NLL of 1 corresponds to 1 std deviation.
-            error_name (str): The name for the error in the dictionary.
+            error_name: The name for the error in the dictionary.
 
 
         Returns:
@@ -334,16 +334,16 @@ class FitResult(ZfitResult):
         r"""Calculate and set for `params` the asymmetric error using the set error method.
 
             Args:
-                params (list(:py:class:`~zfit.Parameter` or str)): The parameters or their names to calculate the
+                params: The parameters or their names to calculate the
                      errors. If `params` is `None`, use all *floating* parameters.
-                method (str or Callable): The method to use to calculate the errors. Valid choices are
+                method: The method to use to calculate the errors. Valid choices are
                     {'minuit_minos'} or a Callable.
-                sigma (float): Errors are calculated with respect to `sigma` std deviations. The definition
+                sigma: Errors are calculated with respect to `sigma` std deviations. The definition
                     of 1 sigma depends on the loss function and is defined there.
 
                     For example, the negative log-likelihood (without the factor of 2) has a correspondents
                     of :math:`\Delta` NLL of 1 corresponds to 1 std deviation.
-                error_name (str): The name for the error in the dictionary.
+                error_name: The name for the error in the dictionary.
 
 
             Returns:
@@ -400,11 +400,11 @@ class FitResult(ZfitResult):
         """Calculate the covariance matrix for `params`.
 
             Args:
-                params (list(:py:class:`~zfit.Parameter`)): The parameters to calculate
+                params: The parameters to calculate
                     the covariance matrix. If `params` is `None`, use all *floating* parameters.
-                method (str or Callable): The method to use to calculate the covariance matrix. Valid choices are
+                method: The method to use to calculate the covariance matrix. Valid choices are
                     {'minuit_hesse', 'hesse_np'} or a Callable.
-                as_dict (bool): Default `False`. If `True` then returns a dictionnary.
+                as_dict: Default `False`. If `True` then returns a dictionnary.
 
             Returns:
                 2D `numpy.array` of shape (N, N);
@@ -442,11 +442,11 @@ class FitResult(ZfitResult):
         """Calculate the correlation matrix for `params`.
 
             Args:
-                params (list(:py:class:`~zfit.Parameter`)): The parameters to calculate
+                params: The parameters to calculate
                     the correlation matrix. If `params` is `None`, use all *floating* parameters.
-                method (str or Callable): The method to use to calculate the correlation matrix. Valid choices are
+                method: The method to use to calculate the correlation matrix. Valid choices are
                     {'minuit_hesse', 'hesse_np'} or a Callable.
-                as_dict (bool): Default `False`. If `True` then returns a dictionnary.
+                as_dict: Default `False`. If `True` then returns a dictionnary.
 
             Returns:
                 2D `numpy.array` of shape (N, N);

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -147,7 +147,7 @@ class FitResult(ZfitResult):
             minimizer: Instance of the iminuit Minuit that was used to minimize the loss.
 
         Returns:
-            `FitResult`: A `FitResult` as if zfit Minuit was used.
+            A `FitResult` as if zfit Minuit was used.
         """
 
         from .minimizer_minuit import Minuit
@@ -257,7 +257,7 @@ class FitResult(ZfitResult):
             error_name: The name for the error in the dictionary.
 
         Returns:
-            OrderedDict: Result of the hessian (symmetric) error as dict with each parameter holding
+            Result of the hessian (symmetric) error as dict with each parameter holding
                 the error dict {'error': sym_error}.
 
                 So given param_a (from zfit.Parameter(.))
@@ -317,7 +317,7 @@ class FitResult(ZfitResult):
 
 
         Returns:
-            `OrderedDict`: A `OrderedDict` containing as keys the parameter names and as value a `dict` which
+            A `OrderedDict` containing as keys the parameter names and as value a `dict` which
                 contains (next to probably more things) two keys 'lower' and 'upper',
                 holding the calculated errors.
                 Example: result['par1']['upper'] -> the asymmetric upper error of 'par1'
@@ -347,7 +347,7 @@ class FitResult(ZfitResult):
 
 
             Returns:
-                `OrderedDict`: A `OrderedDict` containing as keys the parameter and as value a `dict` which
+                A `OrderedDict` containing as keys the parameter and as value a `dict` which
                     contains (next to probably more things) two keys 'lower' and 'upper',
                     holding the calculated errors.
                     Example: result[par1]['upper'] -> the asymmetric upper error of 'par1'

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -184,7 +184,7 @@ class FitResult(ZfitResult):
         """The estimated distance to the minimum.
 
         Returns:
-            numeric
+            Numeric
         """
         return self._edm
 
@@ -202,7 +202,7 @@ class FitResult(ZfitResult):
         """Function value at the minimum.
 
         Returns:
-            numeric
+            Numeric
         """
         return self._fmin
 

--- a/zfit/minimizers/interface.py
+++ b/zfit/minimizers/interface.py
@@ -10,9 +10,9 @@ class ZfitResult:
         """Calculate for `params` the symmetric error using the Hessian matrix.
 
         Args:
-            params (list(`zfit.FitParameters`)): The parameters  to calculate the
+            params: The parameters  to calculate the
                 Hessian symmetric error. If None, use all parameters.
-            method (str): the method to calculate the hessian. Can be {'minuit'} or a callable.
+            method: the method to calculate the hessian. Can be {'minuit'} or a callable.
 
         Returns:
             OrderedDict: Result of the hessian (symmetric) error as dict with each parameter holding
@@ -29,9 +29,9 @@ class ZfitResult:
         """Calculate and set for `params` the asymmetric error using the set error method.
 
             Args:
-                params (list(`zfit.FitParameters` or str)): The parameters or their names to calculate the
+                params: The parameters or their names to calculate the
                      errors. If `params` is `None`, use all *floating* parameters.
-                method (str or Callable): The method to use to calculate the errors. Valid choices are
+                method: The method to use to calculate the errors. Valid choices are
                     {'minuit_minos'} or a Callable.
 
             Returns:

--- a/zfit/minimizers/interface.py
+++ b/zfit/minimizers/interface.py
@@ -15,7 +15,7 @@ class ZfitResult:
             method: the method to calculate the hessian. Can be {'minuit'} or a callable.
 
         Returns:
-            OrderedDict: Result of the hessian (symmetric) error as dict with each parameter holding
+            Result of the hessian (symmetric) error as dict with each parameter holding
                 the error dict {'error': sym_error}.
 
                 So given param_a (from zfit.Parameter(.))
@@ -35,7 +35,7 @@ class ZfitResult:
                     {'minuit_minos'} or a Callable.
 
             Returns:
-                `OrderedDict`: A `OrderedDict` containing as keys the parameter names and as value a `dict` which
+                A `OrderedDict` containing as keys the parameter names and as value a `dict` which
                     contains (next to probably more things) two keys 'lower' and 'upper',
                     holding the calculated errors.
                     Example: result['par1']['upper'] -> the asymmetric upper error of 'par1'

--- a/zfit/minimizers/minimizer_minuit.py
+++ b/zfit/minimizers/minimizer_minuit.py
@@ -22,14 +22,14 @@ class Minuit(BaseMinimizer, GraphCachable):
         """
 
         Args:
-            strategy (): A :py:class:`~zfit.minimizer.baseminimizer.ZfitStrategy` object that defines the behavior of
+            strategy: A :py:class:`~zfit.minimizer.baseminimizer.ZfitStrategy` object that defines the behavior of
             the minimizer in certain situations.
-            minimize_strategy (int): A number used by minuit to define the strategy, either 0, 1 or 2.
-            tolerance (float): Stopping criteria: the Estimated Distance to Minimum (EDM) has to be lower then `tolerance`
-            verbosity (int): Regulates how much will be printed during minimization. Values between 0 and 10 are valid.
-            name (str): Name of the minimizer
-            ncall (int): Maximum number of minimization steps.
-            use_minuit_grad (bool): If True, iminuit uses it's internal numerical gradient calculation instead of the
+            minimize_strategy: A number used by minuit to define the strategy, either 0, 1 or 2.
+            tolerance: Stopping criteria: the Estimated Distance to Minimum (EDM) has to be lower then `tolerance`
+            verbosity: Regulates how much will be printed during minimization. Values between 0 and 10 are valid.
+            name: Name of the minimizer
+            ncall: Maximum number of minimization steps.
+            use_minuit_grad: If True, iminuit uses it's internal numerical gradient calculation instead of the
                 (analytic/numerical) gradient provided by TensorFlow/zfit.
         """
         minimizer_options['ncall'] = ncall

--- a/zfit/minimizers/minimizer_tfp.py
+++ b/zfit/minimizers/minimizer_tfp.py
@@ -19,10 +19,10 @@ class BFGS(BaseMinimizer):
         """# Todo write description for api.
 
         Args:
-            strategy (ZfitStrategy): Strategy that handles NaN and more (to come, experimental)
-            tolerance (float): Difference between the function value that suffices to stop minimization
+            strategy: Strategy that handles NaN and more (to come, experimental)
+            tolerance: Difference between the function value that suffices to stop minimization
             verbosity: The higher, the more is printed. Between 1 and 10 typically
-            max_calls (int): Maximum number of calls, approximate
+            max_calls: Maximum number of calls, approximate
             name: Name of the Minimizer
             options: A `dict` containing the options given to the minimization function, overriding the default
         """

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -53,10 +53,10 @@ class Exponential(BasePDF):
         defined as :math:`\\frac{ e^{\\lambda \\cdot x}}{ \\int_{lower}^{upper} e^{\\lambda \\cdot x} dx}`
 
         Args:
-            lambda_ (:py:class:`~zfit.Parameter`): Accessed as parameter "lambda".
-            obs (:py:class:`~zfit.Space`): The :py:class:`~zfit.Space` the pdf is defined in.
-            name (str): Name of the pdf.
-            dtype (DType):
+            lambda_: Accessed as parameter "lambda".
+            obs: The :py:class:`~zfit.Space` the pdf is defined in.
+            name: Name of the pdf.
+            dtype:
         """
         params = {'lambda': lambda_}
         super().__init__(obs, name=name, params=params, **kwargs)

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -32,7 +32,7 @@ def tfd_analytic_sample(n: int, dist: tfd.Distribution, limits: ztyping.ObsTypeI
         limits: Limits to sample from within
 
     Returns:
-        `tf.Tensor` (n, n_obs): The sampled data with the number of samples and the number of observables.
+        The sampled data with the number of samples and the number of observables.
     """
     lower_bound, upper_bound = limits.rect_limits
     lower_prob_lim = dist.cdf(lower_bound)

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -185,10 +185,10 @@ class Gauss(WrapDistribution):
         The normalization changes for different normalization ranges
 
         Args:
-            mu (:py:class:`~zfit.Parameter`): Mean of the gaussian dist
-            sigma (:py:class:`~zfit.Parameter`): Standard deviation or spread of the gaussian
-            obs (:py:class:`~zfit.Space`): Observables and normalization range the pdf is defined in
-            name (str): Name of the pdf
+            mu: Mean of the gaussian dist
+            sigma: Standard deviation or spread of the gaussian
+            obs: Observables and normalization range the pdf is defined in
+            name: Name of the pdf
         """
         mu, sigma = self._check_input_params(mu, sigma)
         params = OrderedDict((('mu', mu), ('sigma', sigma)))
@@ -216,10 +216,10 @@ class Uniform(WrapDistribution):
         """Uniform distribution which is constant between `low`, `high` and zero outside.
 
         Args:
-            low (:py:class:`~zfit.Parameter`): Below this value, the pdf is zero.
-            high (:py:class:`~zfit.Parameter`): Above this value, the pdf is zero.
-            obs (:py:class:`~zfit.Space`): Observables and normalization range the pdf is defined in
-            name (str): Name of the pdf
+            low: Below this value, the pdf is zero.
+            high: Above this value, the pdf is zero.
+            obs: Observables and normalization range the pdf is defined in
+            name: Name of the pdf
         """
         low, high = self._check_input_params(low, high)
         params = OrderedDict((("low", low), ("high", high)))
@@ -236,12 +236,12 @@ class TruncatedGauss(WrapDistribution):
         """Gaussian distribution that is 0 outside of `low`, `high`. Equivalent to the product of Gauss and Uniform.
 
         Args:
-            mu (:py:class:`~zfit.Parameter`): Mean of the gaussian dist
-            sigma (:py:class:`~zfit.Parameter`): Standard deviation or spread of the gaussian
-            low (:py:class:`~zfit.Parameter`): Below this value, the pdf is zero.
-            high (:py:class:`~zfit.Parameter`): Above this value, the pdf is zero.
-            obs (:py:class:`~zfit.Space`): Observables and normalization range the pdf is defined in
-            name (str): Name of the pdf
+            mu: Mean of the gaussian dist
+            sigma: Standard deviation or spread of the gaussian
+            low: Below this value, the pdf is zero.
+            high: Above this value, the pdf is zero.
+            obs: Observables and normalization range the pdf is defined in
+            name: Name of the pdf
         """
         mu, sigma, low, high = self._check_input_params(mu, sigma, low, high)
         params = OrderedDict((("mu", mu), ("sigma", sigma), ("low", low), ("high", high)))

--- a/zfit/models/functions.py
+++ b/zfit/models/functions.py
@@ -20,10 +20,10 @@ class SimpleFunc(BaseFunc):
         """Create a simple function out of of `func` with the observables `obs` depending on `parameters`.
 
         Args:
-            func (function):
-            obs (Union[str, Tuple[str]]):
-            name (str):
-            **params (): The parameters as keyword arguments. E.g. `mu=Parameter(...)`
+            func:
+            obs:
+            name:
+            **params: The parameters as keyword arguments. E.g. `mu=Parameter(...)`
         """
         super().__init__(name=name, obs=obs, params=params)
         self._value_func = self._check_input_x_function(func)

--- a/zfit/models/functor.py
+++ b/zfit/models/functor.py
@@ -81,13 +81,13 @@ class SumPDF(BaseFunctor):
                 frac_integral = pdf.integrate(...) * frac
 
         Args:
-            pdfs (pdf): The pdfs to be added.
-            fracs (iterable): Coefficients for the linear combination of the pdfs. Optional if *all* pdfs are extended.
+            pdfs: The pdfs to be added.
+            fracs: Coefficients for the linear combination of the pdfs. Optional if *all* pdfs are extended.
 
                 - len(frac) == len(basic) - 1 results in the interpretation of a non-extended pdf.
                   The last coefficient will equal to 1 - sum(frac)
                 - len(frac) == len(pdf): the fracs will be used as is and no normalization attempt is taken.
-            name (str): |name_arg_descr|
+            name: |name_arg_descr|
 
         Raises
             ModelIncompatibleError: If model is incompatible.

--- a/zfit/models/physics.py
+++ b/zfit/models/physics.py
@@ -181,17 +181,15 @@ class CrystalBall(BasePDF):
             B = \\frac{n}{\\left| \\alpha \\right|}  - \\left| \\alpha \\right|
 
         Args:
-            mu (`zfit.Parameter`): The mean of the gaussian
-            sigma (`zfit.Parameter`): Standard deviation of the gaussian
-            alpha (`zfit.Parameter`): parameter where to switch from a gaussian to the powertail
-            n (`zfit.Parameter`): Exponent of the powertail
-            obs (:py:class:`~zfit.Space`):
-            name (str):
-            dtype (tf.DType):
+            mu: The mean of the gaussian
+            sigma: Standard deviation of the gaussian
+            alpha: parameter where to switch from a gaussian to the powertail
+            n: Exponent of the powertail
+            obs:
+            name:
+            dtype:
 
         .. _CBShape: https://en.wikipedia.org/wiki/Crystal_Ball_function
-
-        __CBShape_
         """
         params = {'mu': mu,
                   'sigma': sigma,
@@ -243,17 +241,17 @@ class DoubleCB(BasePDF):
             B_{L/R} = \\frac{n_{L/R}}{\\left| \\alpha_{L/R} \\right|}  - \\left| \\alpha_{L/R} \\right|
 
         Args:
-            mu (`zfit.Parameter`): The mean of the gaussian
-            sigma (`zfit.Parameter`): Standard deviation of the gaussian
-            alphal (`zfit.Parameter`): parameter where to switch from a gaussian to the powertail on the left
+            mu: The mean of the gaussian
+            sigma: Standard deviation of the gaussian
+            alphal: parameter where to switch from a gaussian to the powertail on the left
             side
-            nl (`zfit.Parameter`): Exponent of the powertail on the left side
-            alphar (`zfit.Parameter`): parameter where to switch from a gaussian to the powertail on the right
+            nl: Exponent of the powertail on the left side
+            alphar: parameter where to switch from a gaussian to the powertail on the right
             side
-            nr (`zfit.Parameter`): Exponent of the powertail on the right side
-            obs (:py:class:`~zfit.Space`):
-            name (str):
-            dtype (tf.DType):
+            nr: Exponent of the powertail on the right side
+            obs:
+            name:
+            dtype:
         """
         params = {'mu': mu,
                   'sigma': sigma,

--- a/zfit/models/polynomials.py
+++ b/zfit/models/polynomials.py
@@ -22,7 +22,7 @@ def rescale_minus_plus_one(x: tf.Tensor, limits: "zfit.Space") -> tf.Tensor:
         limits: 1-D limits
 
     Returns:
-        tf.Tensor: the rescaled tensor.
+        the rescaled tensor.
     """
     lim_low, lim_high = limits.limit1d
     x = (2 * x - lim_low - lim_high) / (lim_high - lim_low)

--- a/zfit/models/polynomials.py
+++ b/zfit/models/polynomials.py
@@ -22,7 +22,7 @@ def rescale_minus_plus_one(x: tf.Tensor, limits: "zfit.Space") -> tf.Tensor:
         limits: 1-D limits
 
     Returns:
-        the rescaled tensor.
+        The rescaled tensor.
     """
     lim_low, lim_high = limits.limit1d
     x = (2 * x - lim_low - lim_high) / (lim_high - lim_low)

--- a/zfit/models/polynomials.py
+++ b/zfit/models/polynomials.py
@@ -41,8 +41,8 @@ class RecursivePolynomial(BasePDF):
         """Base class to create 1 dimensional recursive polynomials that can be rescaled. Overwrite _poly_func.
 
         Args:
-            coeffs (list): Coefficients for each polynomial. Used to calculate the degree.
-            apply_scaling (bool): Rescale the data so that the actual limits represent (-1, 1).
+            coeffs: Coefficients for each polynomial. Used to calculate the degree.
+            apply_scaling: Rescale the data so that the actual limits represent (-1, 1).
 
                 .. math::
                    x_{n+1} = recurrence(x_{n}, x_{n-1}, n)
@@ -172,10 +172,10 @@ class Legendre(RecursivePolynomial):
 
         Args:
             obs: The default space the PDF is defined in.
-            coeffs (list[params]): A list of the coefficients for the polynomials of order 1+ in the sum.
-            apply_scaling (bool): Rescale the data so that the actual limits represent (-1, 1).
-            coeff0 (param): The scaling factor of the 0th order polynomial. If not given, it is set to 1.
-            name (str): Name of the polynomial
+            coeffs: A list of the coefficients for the polynomials of order 1+ in the sum.
+            apply_scaling: Rescale the data so that the actual limits represent (-1, 1).
+            coeff0: The scaling factor of the 0th order polynomial. If not given, it is set to 1.
+            name: Name of the polynomial
         """
         super().__init__(obs=obs, name=name,
                          coeffs=coeffs, apply_scaling=apply_scaling, coeff0=coeff0)
@@ -231,10 +231,10 @@ class Chebyshev(RecursivePolynomial):
 
         Args:
             obs: The default space the PDF is defined in.
-            coeffs (list[params]): A list of the coefficients for the polynomials of order 1+ in the sum.
-            apply_scaling (bool): Rescale the data so that the actual limits represent (-1, 1).
-            coeff0 (param): The scaling factor of the 0th order polynomial. If not given, it is set to 1.
-            name (str): Name of the polynomial
+            coeffs: A list of the coefficients for the polynomials of order 1+ in the sum.
+            apply_scaling: Rescale the data so that the actual limits represent (-1, 1).
+            coeff0: The scaling factor of the 0th order polynomial. If not given, it is set to 1.
+            name: Name of the polynomial
         """
         super().__init__(obs=obs, name=name,
                          coeffs=coeffs, coeff0=coeff0,
@@ -316,10 +316,10 @@ class Chebyshev2(RecursivePolynomial):
 
         Args:
             obs: The default space the PDF is defined in.
-            coeffs (list[params]): A list of the coefficients for the polynomials of order 1+ in the sum.
-            apply_scaling (bool): Rescale the data so that the actual limits represent (-1, 1).
-            coeff0 (param): The scaling factor of the 0th order polynomial. If not given, it is set to 1.
-            name (str): Name of the polynomial
+            coeffs: A list of the coefficients for the polynomials of order 1+ in the sum.
+            apply_scaling: Rescale the data so that the actual limits represent (-1, 1).
+            coeff0: The scaling factor of the 0th order polynomial. If not given, it is set to 1.
+            name: Name of the polynomial
         """
         super().__init__(obs=obs, name=name,
                          coeffs=coeffs, coeff0=coeff0, apply_scaling=apply_scaling)
@@ -423,10 +423,10 @@ class Laguerre(RecursivePolynomial):
 
         Args:
             obs: The default space the PDF is defined in.
-            coeffs (list[params]): A list of the coefficients for the polynomials of order 1+ in the sum.
-            apply_scaling (bool): Rescale the data so that the actual limits represent (-1, 1).
-            coeff0 (param): The scaling factor of the 0th order polynomial. If not given, it is set to 1.
-            name (str): Name of the polynomial
+            coeffs: A list of the coefficients for the polynomials of order 1+ in the sum.
+            apply_scaling: Rescale the data so that the actual limits represent (-1, 1).
+            coeff0: The scaling factor of the 0th order polynomial. If not given, it is set to 1.
+            name: Name of the polynomial
         """
         super().__init__(obs=obs, name=name, coeffs=coeffs, coeff0=coeff0,
                          apply_scaling=apply_scaling)
@@ -517,10 +517,10 @@ class Hermite(RecursivePolynomial):
 
         Args:
             obs: The default space the PDF is defined in.
-            coeffs (list[params]): A list of the coefficients for the polynomials of order 1+ in the sum.
-            apply_scaling (bool): Rescale the data so that the actual limits represent (-1, 1).
-            coeff0 (param): The scaling factor of the 0th order polynomial. If not given, it is set to 1.
-            name (str): Name of the polynomial
+            coeffs: A list of the coefficients for the polynomials of order 1+ in the sum.
+            apply_scaling: Rescale the data so that the actual limits represent (-1, 1).
+            coeff0: The scaling factor of the 0th order polynomial. If not given, it is set to 1.
+            name: Name of the polynomial
         """
         super().__init__(obs=obs, name=name, coeffs=coeffs, coeff0=coeff0,
                          apply_scaling=apply_scaling)

--- a/zfit/util/cache.py
+++ b/zfit/util/cache.py
@@ -74,8 +74,8 @@ class ZfitGraphCachable:
         """Add dependents that render the cache invalid if they change.
 
         Args:
-            cache_dependents (ZfitGraphCachable):
-            allow_non_cachable (bool): If `True`, allow `cache_dependents` to be non-cachables.
+            cache_dependents:
+            allow_non_cachable: If `True`, allow `cache_dependents` to be non-cachables.
                 If `False`, any `cache_dependents` that is not a `ZfitCachable` will raise an error.
 
         Raises:
@@ -121,7 +121,7 @@ class GraphCachable(ZfitGraphCachable):
         """Register a `cacher` that caches values produces by this instance; a dependent.
 
         Args:
-            cacher ():
+            cacher:
         """
         if not isinstance(cacher, ZfitGraphCachable):
             raise TypeError("`cacher` is not a `ZfitCachable` but {}".format(type(cacher)))
@@ -132,8 +132,8 @@ class GraphCachable(ZfitGraphCachable):
         """Add dependencies that render the cache invalid if they change.
 
         Args:
-            cache_deps (ZfitGraphCachable):
-            allow_non_cachable (bool): If `True`, allow `cache_dependents` to be non-cachables.
+            cache_deps:
+            allow_non_cachable: If `True`, allow `cache_dependents` to be non-cachables.
                 If `False`, any `cache_dependents` that is not a `ZfitCachable` will raise an error.
 
         Raises:
@@ -203,12 +203,12 @@ class FunctionCacheHolder(GraphCachable):
         be created as a call to the `wrapped_func` with the given arguments will result in an outdated graph.
 
         Args:
-            func (function): Python function that serves as a hash of the holder. Notice that equality is different
+            func: Python function that serves as a hash of the holder. Notice that equality is different
                 defined.
-            wrapped_func (tf.function wrapped): Wrapped `func` with `tf.function`. The holder signals via
+            wrapped_func: Wrapped `func` with `tf.function`. The holder signals via
                 `is_valid` whether this function is still valid to be used.
             cachables: objects that are cached. If they change, the cache is invalidated
-            cachables_mapping (Mapping): keyword arguments to the function. If the values change, the cache is
+            cachables_mapping: keyword arguments to the function. If the values change, the cache is
                 invalidated.
         """
         # cache = {} if cache is None else cache

--- a/zfit/util/cache.py
+++ b/zfit/util/cache.py
@@ -243,7 +243,7 @@ class FunctionCacheHolder(GraphCachable):
             kwargs: dict-like
 
         Returns:
-            tuple
+
         """
         # is initialized before the core
         from ..core.interfaces import ZfitData, ZfitParameter, ZfitSpace

--- a/zfit/util/container.py
+++ b/zfit/util/container.py
@@ -18,9 +18,9 @@ def convert_to_container(value: Any, container: Callable = list, non_containers=
     """Convert `value` into a `container` storing `value` if `value` is not yet a python container.
 
     Args:
-        value (object):
-        container (callable): Converts a tuple to a container.
-        non_containers (Optional[List[Container]]): Types that do not count as a container. Has to
+        value:
+        container: Converts a tuple to a container.
+        non_containers: Types that do not count as a container. Has to
             be a list of types. As an example, if `non_containers` is [list, tuple] and the value
             is [5, 3] (-> a list with two entries),this won't be converted to the `container` but end
             up as (if the container is e.g. a tuple): ([5, 3],) (a tuple with one entry).
@@ -50,7 +50,7 @@ def is_container(obj):
     """Check if `object` is a list or a tuple.
 
     Args:
-        obj ():
+        obj:
 
     Returns:
         bool: True if it is a *container*, otherwise False

--- a/zfit/util/container.py
+++ b/zfit/util/container.py
@@ -53,6 +53,6 @@ def is_container(obj):
         obj:
 
     Returns:
-        bool: True if it is a *container*, otherwise False
+        True if it is a *container*, otherwise False
     """
     return isinstance(obj, (list, tuple))

--- a/zfit/util/execution.py
+++ b/zfit/util/execution.py
@@ -302,7 +302,7 @@ class RunManager:
         """Return the current policy for graph building.
 
         Returns:
-            bool, str: The current policy. For more information, check :py:meth:`~zfit.run.set_mode`.
+            The current policy. For more information, check :py:meth:`~zfit.run.set_mode`.
         """
         return self.mode['graph']
 
@@ -316,7 +316,7 @@ class RunManager:
         """The current policy for using the automatic gradient or falling back to the numerical
 
         Returns:
-            bool: If autograd is being used.
+            If autograd is being used.
 
         """
         return self.mode['autograd']

--- a/zfit/util/graph.py
+++ b/zfit/util/graph.py
@@ -19,8 +19,8 @@ def get_dependents_auto(tensor: tf.Tensor, candidates: List[tf.Tensor]) -> List[
     """Return the nodes in `candidates` that `tensor` depends on.
 
     Args:
-        tensor ():
-        candidates ():
+        tensor:
+        candidates:
     """
     try:
         dependent_ops = all_parents(tensor.op)

--- a/zfit/util/logging.py
+++ b/zfit/util/logging.py
@@ -33,10 +33,10 @@ def get_logger(name, stdout_level=None, file_level=None, file_name=None):
         Default logging level at first instantiation is WARNING.
 
     Arguments:
-        name (str): Name of the logger.
-        stdout_level (int, optional): Logging level for the stream handler. Defaults to `logging.WARNING`.
-        file_level (int, optional): Logging level for the file handler. Defaults to `logging.WARNING`.
-        file_name (str, optional): File to log to. If not given, no file logging is performed.
+        name: Name of the logger.
+        stdout_level: Logging level for the stream handler. Defaults to `logging.WARNING`.
+        file_level: Logging level for the file handler. Defaults to `logging.WARNING`.
+        file_name: File to log to. If not given, no file logging is performed.
 
     Return:
         `logging.Logger`: The requested logger.

--- a/zfit/util/temporary.py
+++ b/zfit/util/temporary.py
@@ -39,10 +39,10 @@ class TemporarilySet:
          42
 
         Args:
-            value (Any): The value to be (temporarily) set (and returned if a context manager is applied).
-            setter (Callable): The setter function with a signature that is compatible to the call:
+            value: The value to be (temporarily) set (and returned if a context manager is applied).
+            setter: The setter function with a signature that is compatible to the call:
                 `setter(value, *setter_args, **setter_kwargs)`
-            getter (Callable): The getter function with a signature that is compatible to the call:
+            getter: The getter function with a signature that is compatible to the call:
                 `getter(*getter_args, **getter_kwargs)`
          """
         self.setter = setter

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -15,8 +15,8 @@ def poly_complex(*args, real_x=False):
     """Complex polynomial with the last arg being x.
 
     Args:
-        *args (tf.Tensor or equ.): Coefficients of the polynomial
-        real_x (bool): If True, x is assumed to be real.
+        *args: Coefficients of the polynomial
+        real_x: If True, x is assumed to be real.
 
     Returns:
         tf.Tensor:
@@ -36,8 +36,8 @@ def interpolate(t, c):
     """Multilinear interpolation on a rectangular grid of arbitrary number of dimensions.
 
     Args:
-        t (tf.Tensor): Grid (of rank N)
-        c (tf.Tensor): Tensor of coordinates for which the interpolation is performed
+        t: Grid (of rank N)
+        c: Tensor of coordinates for which the interpolation is performed
 
     Returns:
         tf.Tensor: 1D tensor of interpolated value
@@ -59,8 +59,8 @@ def numerical_gradient(func: Callable, params: Iterable["zfit.Parameter"]) -> tf
     """Calculate numerically the gradients of func() with respect to `params`.
 
     Args:
-        func (Callable): Function without arguments that depends on `params`
-        params (ZfitParameter): Parameters that `func` implicitly depends on and with respect to which the
+        func: Function without arguments that depends on `params`
+        params: Parameters that `func` implicitly depends on and with respect to which the
             derivatives will be taken.
 
     Returns:
@@ -90,8 +90,8 @@ def numerical_value_gradients(func: Callable, params: Iterable["zfit.Parameter"]
     """Calculate numerically the gradients of `func()` with respect to `params`, also returns the value of `func()`.
 
         Args:
-            func (Callable): Function without arguments that depends on `params`
-            params (ZfitParameter): Parameters that `func` implicitly depends on and with respect to which the
+            func: Function without arguments that depends on `params`
+            params: Parameters that `func` implicitly depends on and with respect to which the
                 derivatives will be taken.
 
         Returns:
@@ -104,8 +104,8 @@ def numerical_hessian(func: Callable, params: Iterable["zfit.Parameter"], hessia
     """Calculate numerically the hessian matrix of func with respect to `params`.
 
         Args:
-            func (Callable): Function without arguments that depends on `params`
-            params (ZfitParameter): Parameters that `func` implicitly depends on and with respect to which the
+            func: Function without arguments that depends on `params`
+            params: Parameters that `func` implicitly depends on and with respect to which the
                 derivatives will be taken.
 
         Returns:
@@ -148,8 +148,8 @@ def numerical_value_gradients_hessian(func: Callable, params: Iterable["zfit.Par
     """Calculate numerically the gradients and hessian matrix of `func()` wrt `params`; also return `func()`.
 
         Args:
-            func (Callable): Function without arguments that depends on `params`
-            params (ZfitParameter): Parameters that `func` implicitly depends on and with respect to which the
+            func: Function without arguments that depends on `params`
+            params: Parameters that `func` implicitly depends on and with respect to which the
                 derivatives will be taken.
 
         Returns:
@@ -169,8 +169,8 @@ def autodiff_gradient(func: Callable, params: Iterable["zfit.Parameter"]) -> tf.
     TensorFlow implements this and anything using `tf.*` operations only can use this technique.
 
         Args:
-            func (Callable): Function without arguments that depends on `params`
-            params (ZfitParameter): Parameters that `func` implicitly depends on and with respect to which the
+            func: Function without arguments that depends on `params`
+            params: Parameters that `func` implicitly depends on and with respect to which the
                 derivatives will be taken.
 
         Returns:
@@ -187,8 +187,8 @@ def autodiff_value_gradients(func: Callable, params: Iterable["zfit.Parameter"])
     TensorFlow implements this and anything using `tf.*` operations only can use this technique.
 
         Args:
-            func (Callable): Function without arguments that depends on `params`
-            params (ZfitParameter): Parameters that `func` implicitly depends on and with respect to which the
+            func: Function without arguments that depends on `params`
+            params: Parameters that `func` implicitly depends on and with respect to which the
                 derivatives will be taken.
 
         Returns:
@@ -210,8 +210,8 @@ def autodiff_hessian(func: Callable, params: Iterable["zfit.Parameter"], hessian
     TensorFlow implements this and anything using `tf.*` operations only can use this technique.
 
         Args:
-            func (Callable): Function without arguments that depends on `params`
-            params (ZfitParameter): Parameters that `func` implicitly depends on and with respect to which the
+            func: Function without arguments that depends on `params`
+            params: Parameters that `func` implicitly depends on and with respect to which the
                 derivatives will be taken.
 
         Returns:
@@ -231,8 +231,8 @@ def automatic_value_gradients_hessian(func: Callable = None, params: Iterable["z
     TensorFlow implements this and anything using `tf.*` operations only can use this technique.
 
         Args:
-            func (Callable): Function without arguments that depends on `params`
-            params (ZfitParameter): Parameters that `func` implicitly depends on and with respect to which the
+            func: Function without arguments that depends on `params`
+            params: Parameters that `func` implicitly depends on and with respect to which the
                 derivatives will be taken.
 
         Returns:

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -40,7 +40,7 @@ def interpolate(t, c):
         c: Tensor of coordinates for which the interpolation is performed
 
     Returns:
-        tf.Tensor: 1D tensor of interpolated value
+        1D tensor of interpolated value
     """
     rank = len(t.get_shape())
     ind = tf.cast(tf.floor(c), tf.int32)
@@ -64,7 +64,7 @@ def numerical_gradient(func: Callable, params: Iterable["zfit.Parameter"]) -> tf
             derivatives will be taken.
 
     Returns:
-        `tf.Tensor`: gradients
+        gradients
     """
     params = convert_to_container(params)
 
@@ -95,7 +95,7 @@ def numerical_value_gradients(func: Callable, params: Iterable["zfit.Parameter"]
                 derivatives will be taken.
 
         Returns:
-            tuple(`tf.Tensor`, `tf.Tensor`): value, gradient
+            value, gradient
     """
     return func(), numerical_gradient(func, params)
 
@@ -109,7 +109,7 @@ def numerical_hessian(func: Callable, params: Iterable["zfit.Parameter"], hessia
                 derivatives will be taken.
 
         Returns:
-            `tf.Tensor`: hessian matrix
+            hessian matrix
     """
     params = convert_to_container(params)
 
@@ -153,7 +153,7 @@ def numerical_value_gradients_hessian(func: Callable, params: Iterable["zfit.Par
                 derivatives will be taken.
 
         Returns:
-            tuple(`tf.Tensor`, `tf.Tensor`, `tf.Tensor`): value, gradient and hessian matrix
+            value, gradient and hessian matrix
     """
     value, gradients = numerical_value_gradients(func, params)
     hessian = numerical_hessian(func, params, hessian=hessian)
@@ -174,7 +174,7 @@ def autodiff_gradient(func: Callable, params: Iterable["zfit.Parameter"]) -> tf.
                 derivatives will be taken.
 
         Returns:
-            `tf.Tensor`: gradient
+            gradient
     """
     return autodiff_value_gradients(func, params)[1]
 
@@ -192,7 +192,7 @@ def autodiff_value_gradients(func: Callable, params: Iterable["zfit.Parameter"])
                 derivatives will be taken.
 
         Returns:
-            tuple(`tf.Tensor`, `tf.Tensor`): value and gradient
+            value and gradient
     """
     with tf.GradientTape(persistent=False,  # needs to be persistent for a call from hessian.
                          watch_accessed_variables=False) as tape:
@@ -215,7 +215,7 @@ def autodiff_hessian(func: Callable, params: Iterable["zfit.Parameter"], hessian
                 derivatives will be taken.
 
         Returns:
-            `tf.Tensor`: hessian matrix
+            hessian matrix
     """
 
     return automatic_value_gradients_hessian(func, params, hessian=hessian)[2]
@@ -236,7 +236,7 @@ def automatic_value_gradients_hessian(func: Callable = None, params: Iterable["z
                 derivatives will be taken.
 
         Returns:
-            tuple(`tf.Tensor`, `tf.Tensor`, `tf.Tensor`): value, gradient and hessian matrix
+            value, gradient and hessian matrix
     """
     if params is None:
         raise ValueError("Parameters have to be specified, are currently None.")

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -19,7 +19,7 @@ def poly_complex(*args, real_x=False):
         real_x: If True, x is assumed to be real.
 
     Returns:
-        tf.Tensor:
+
     """
     from .. import z
 
@@ -64,7 +64,7 @@ def numerical_gradient(func: Callable, params: Iterable["zfit.Parameter"]) -> tf
             derivatives will be taken.
 
     Returns:
-        gradients
+        Gradients
     """
     params = convert_to_container(params)
 
@@ -95,7 +95,7 @@ def numerical_value_gradients(func: Callable, params: Iterable["zfit.Parameter"]
                 derivatives will be taken.
 
         Returns:
-            value, gradient
+            Value, gradient
     """
     return func(), numerical_gradient(func, params)
 
@@ -109,7 +109,7 @@ def numerical_hessian(func: Callable, params: Iterable["zfit.Parameter"], hessia
                 derivatives will be taken.
 
         Returns:
-            hessian matrix
+            Hessian matrix
     """
     params = convert_to_container(params)
 
@@ -153,7 +153,7 @@ def numerical_value_gradients_hessian(func: Callable, params: Iterable["zfit.Par
                 derivatives will be taken.
 
         Returns:
-            value, gradient and hessian matrix
+            Value, gradient and hessian matrix
     """
     value, gradients = numerical_value_gradients(func, params)
     hessian = numerical_hessian(func, params, hessian=hessian)
@@ -174,7 +174,7 @@ def autodiff_gradient(func: Callable, params: Iterable["zfit.Parameter"]) -> tf.
                 derivatives will be taken.
 
         Returns:
-            gradient
+            Gradient
     """
     return autodiff_value_gradients(func, params)[1]
 
@@ -192,7 +192,7 @@ def autodiff_value_gradients(func: Callable, params: Iterable["zfit.Parameter"])
                 derivatives will be taken.
 
         Returns:
-            value and gradient
+            Value and gradient
     """
     with tf.GradientTape(persistent=False,  # needs to be persistent for a call from hessian.
                          watch_accessed_variables=False) as tape:
@@ -215,7 +215,7 @@ def autodiff_hessian(func: Callable, params: Iterable["zfit.Parameter"], hessian
                 derivatives will be taken.
 
         Returns:
-            hessian matrix
+            Hessian matrix
     """
 
     return automatic_value_gradients_hessian(func, params, hessian=hessian)[2]
@@ -236,7 +236,7 @@ def automatic_value_gradients_hessian(func: Callable = None, params: Iterable["z
                 derivatives will be taken.
 
         Returns:
-            value, gradient and hessian matrix
+            Value, gradient and hessian matrix
     """
     if params is None:
         raise ValueError("Parameters have to be specified, are currently None.")

--- a/zfit/z/random.py
+++ b/zfit/z/random.py
@@ -17,7 +17,7 @@ def counts_multinomial(total_count: Union[int, tf.Tensor], probs: Iterable[Union
     """Get the number of counts for different classes with given probs/logits.
 
     Args:
-        total_count (int): The total number of draws.
+        total_count: The total number of draws.
         probs: Length k (number of classes) object where the k-1th entry contains the probability to
             get a single draw from the class k. Have to be from [0, 1] and sum up to 1.
         logits: Same as probs but from [-inf, inf] (will be transformet to [0, 1])

--- a/zfit/z/random.py
+++ b/zfit/z/random.py
@@ -23,7 +23,7 @@ def counts_multinomial(total_count: Union[int, tf.Tensor], probs: Iterable[Union
         logits: Same as probs but from [-inf, inf] (will be transformet to [0, 1])
 
     Returns:
-        :py:class:`tf.Tensor`: shape (k,) tensor containing the number of draws.
+        shape (k,) tensor containing the number of draws.
     """
     total_count = tf.convert_to_tensor(total_count)
     probs = tf.convert_to_tensor(probs) if probs is not None else probs

--- a/zfit/z/random.py
+++ b/zfit/z/random.py
@@ -23,7 +23,7 @@ def counts_multinomial(total_count: Union[int, tf.Tensor], probs: Iterable[Union
         logits: Same as probs but from [-inf, inf] (will be transformet to [0, 1])
 
     Returns:
-        shape (k,) tensor containing the number of draws.
+        Shape (k,) tensor containing the number of draws.
     """
     total_count = tf.convert_to_tensor(total_count)
     probs = tf.convert_to_tensor(probs) if probs is not None else probs

--- a/zfit/z/wrapping_tf.py
+++ b/zfit/z/wrapping_tf.py
@@ -62,9 +62,9 @@ def check_numerics(tensor: Any, message: Any, name: Any = None):
     """Check whether a tensor is finite and not NaN. Extends TF by accepting complex types as well.
 
     Args:
-        tensor (:py:class:~`tensorflow.python.framework.ops.Tensor`):
-        message (str):
-        name (Union[None, None, None]):
+        tensor:
+        message:
+        name:
 
     Returns:
         tensorflow.python.framework.ops.Tensor:

--- a/zfit/z/wrapping_tf.py
+++ b/zfit/z/wrapping_tf.py
@@ -67,7 +67,7 @@ def check_numerics(tensor: Any, message: Any, name: Any = None):
         name:
 
     Returns:
-        tensorflow.python.framework.ops.Tensor:
+
     """
     if tensor.dtype in (tf.complex64, tf.complex128):
         real_check = tf.debugging.check_numerics(tensor=tf.math.real(tensor), message=message, name=name)

--- a/zfit/z/zextension.py
+++ b/zfit/z/zextension.py
@@ -38,9 +38,9 @@ def nth_pow(x, n, name=None):
     """Calculate the nth power of the complex Tensor x.
 
     Args:
-        x (tf.Tensor, complex):
-        n (int >= 0): Power
-        name (str): No effect, for API compatibility with tf.pow
+        x:
+        n: Power
+        name: No effect, for API compatibility with tf.pow
     """
     if not n >= 0:
         raise ValueError("n (power) has to be >= 0. Currently, n={}".format(n))
@@ -55,11 +55,11 @@ def unstack_x(value: Any, num: Any = None, axis: int = -1, always_list: bool = F
     """Unstack a Data object and return a list of (or a single) tensors in the right order.
 
     Args:
-        value ():
-        num (Union[]):
-        axis (int):
-        always_list (bool): If True, also return a list if only one element.
-        name (str):
+        value:
+        num:
+        axis:
+        always_list: If True, also return a list if only one element.
+        name:
 
     Returns:
         Union[List[tensorflow.python.framework.ops.Tensor], tensorflow.python.framework.ops.Tensor, None]:
@@ -93,14 +93,14 @@ def safe_where(condition: tf.Tensor, func: Callable, safe_func: Callable, values
     """Like :py:func:`tf.where` but fixes gradient `NaN` if func produces `NaN` with certain `values`.
 
     Args:
-        condition (:py:class:`tf.Tensor`): Same argument as to :py:func:`tf.where`, a boolean :py:class:`tf.Tensor`
-        func (Callable): Function taking `values` as argument and returning the tensor _in case
+        condition: Same argument as to :py:func:`tf.where`, a boolean :py:class:`tf.Tensor`
+        func: Function taking `values` as argument and returning the tensor _in case
             condition is True_. Equivalent `x` of :py:func:`tf.where` but as function.
-        safe_func (Callable): Function taking `values` as argument and returning the tensor
+        safe_func: Function taking `values` as argument and returning the tensor
             _in case the condition is False_, Equivalent `y` of :py:func:`tf.where` but as function.
-        values (:py:class:`tf.Tensor`): Values to be evaluated either by `func` or `safe_func` depending on
+        values: Values to be evaluated either by `func` or `safe_func` depending on
             `condition`.
-        value_safer (Callable): Function taking `values` as arguments and returns "safe" values
+        value_safer: Function taking `values` as arguments and returns "safe" values
             that won't cause troubles when given to`func` or by taking the gradient with respect
             to `func(value_safer(values))`.
 

--- a/zfit/z/zextension.py
+++ b/zfit/z/zextension.py
@@ -39,7 +39,7 @@ def nth_pow(x, n, name=None):
 
     Args:
         x:
-        n: Power
+        n: Power of x, has to be a positive int
         name: No effect, for API compatibility with tf.pow
     """
     if not n >= 0:


### PR DESCRIPTION
Fixes:

- Duplication between docstrings and type annotations.
- sphinx_autodoc_typehints not being able to render the type annotations.

## Proposed Changes

  - Delete all type hints inside the docstrings.

## Tests added

  - None
  
## Checklist

 - [ ] change approved
 - [ ] implementation finished
 - [ ] correct namespace imported
 - [ ] tests added
 - [ ] CHANGELOG updated

