### PR TITLE
FFT convolution PDF

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Major Features and Improvements
 -------------------------------
 
 - new Poisson PDF
+- Convolution PDF (FFT in 1Dim) added (experimental, feedback welcome!)
 
 Breaking changes
 ------------------
@@ -29,6 +30,8 @@ Requirement changes
 
 - TensorFlow==2.3 (before 2.2)
 - tensorflow_probability==0.11
+- tensorflow-addons  # spline interpolation in convolution
+
 
 Thanks
 ------

--- a/docs/plots/fftconv_spline_linear.py
+++ b/docs/plots/fftconv_spline_linear.py
@@ -1,0 +1,36 @@
+#  Copyright (c) 2020 zfit
+
+import matplotlib.pyplot as plt
+import tensorflow as tf
+
+import zfit
+
+
+def plot_conv_comparison():
+    # test special properties  here
+    n_point_plotting = 2000
+    obs = zfit.Space("obs1", limits=(-5, 5))
+    param1 = zfit.Parameter('param1', -3)
+    param2 = zfit.Parameter('param2', 0.3)
+    gauss1 = zfit.pdf.Gauss(0., param2, obs=obs)
+    func1 = zfit.pdf.Uniform(param1, param2, obs=obs)
+    func2 = zfit.pdf.Uniform(-1.2, -1, obs=obs)
+    func = zfit.pdf.SumPDF([func1, func2], 0.5)
+    n_points_conv = 50
+    conv_lin = zfit.pdf.FFTConvV1(func=func, kernel=gauss1, n=n_points_conv, interpolation='linear')
+    conv_spline = zfit.pdf.FFTConvV1(func=func, kernel=gauss1, n=n_points_conv, interpolation='spline')
+
+    x = tf.linspace(-5., 3., n_point_plotting)
+    probs_lin = conv_lin.pdf(x=x)
+    probs_spline = conv_spline.pdf(x=x)
+
+    plt.figure()
+    plt.plot(x, probs_lin, label='linear')
+    plt.plot(x, probs_spline, label='spline')
+    plt.legend()
+    plt.title(f"FFT Conv with interpolation: {n_points_conv} points")
+    plt.show(block=True)
+
+
+if __name__ == '__main__':
+    plot_conv_comparison()

--- a/docs/plots/fftconv_spline_linear.py
+++ b/docs/plots/fftconv_spline_linear.py
@@ -17,8 +17,8 @@ def plot_conv_comparison():
     func2 = zfit.pdf.Uniform(-1.2, -1, obs=obs)
     func = zfit.pdf.SumPDF([func1, func2], 0.5)
     n_points_conv = 50
-    conv_lin = zfit.pdf.FFTConvV1(func=func, kernel=gauss1, n=n_points_conv, interpolation='linear')
-    conv_spline = zfit.pdf.FFTConvV1(func=func, kernel=gauss1, n=n_points_conv, interpolation='spline')
+    conv_lin = zfit.pdf.FFTConvPDFV1(func=func, kernel=gauss1, n=n_points_conv, interpolation='linear')
+    conv_spline = zfit.pdf.FFTConvPDFV1(func=func, kernel=gauss1, n=n_points_conv, interpolation='spline')
 
     x = tf.linspace(-5., 3., n_point_plotting)
     probs_lin = conv_lin.pdf(x=x)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ colorama
 ordered-set
 numdifftools
 cloudpickle==1.3  # from TFP, why not working with pip?!
+tensorflow-addons

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -15,12 +15,14 @@ param2_true = 1.2
 
 def test_conv_simple():
     # test special properties  here
-    n_points = 2000
+    n_points = 200
     obs = zfit.Space("obs1", limits=(-5, 5))
     param1 = zfit.Parameter('param1', -3)
     param2 = zfit.Parameter('param2', 0.3)
     gauss1 = zfit.pdf.Gauss(0., param2, obs=obs)
-    func = zfit.pdf.Uniform(param1, param2, obs=obs)
+    func1 = zfit.pdf.Uniform(param1, param2, obs=obs)
+    func2 = zfit.pdf.Uniform(-1.2, -1, obs=obs)
+    func = zfit.pdf.SumPDF([func1, func2], 0.5)
     # func = zfit.pdf.(-0.1, obs=obs)
     conv = zfit.models.convolution.FFTConv1DV1(func=func,
                                                kernel=gauss1,
@@ -29,11 +31,12 @@ def test_conv_simple():
 
     x = tf.linspace(-5., 5., n_points)
     probs = conv.pdf(x=x)
+    # probs = func.pdf(x=x)
     integral = conv.integrate(limits=obs)
     probs_np = probs.numpy()
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     assert len(probs_np) == n_points
-    import matplotlib.pyplot as plt
-    plt.plot(x, probs_np)
-    plt.show()
+    # import matplotlib.pyplot as plt
+    # plt.plot(x, probs_np)
+    # plt.show()
     # assert len(conv.get_dependents(only_floating=False)) == 2  # TODO: activate again with fixed params

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -8,9 +8,11 @@ import scipy.stats
 import tensorflow as tf
 
 import zfit.models.convolution
+import zfit
 from zfit import z
 # noinspection PyUnresolvedReferences
 from zfit.core.testing import setup_function, teardown_function, tester
+from zfit.util.exception import WorkInProgressError
 
 param1_true = 0.3
 param2_true = 1.2
@@ -38,17 +40,17 @@ def test_conv_simple(interpolation):
     func1 = zfit.pdf.Uniform(param1, param2, obs=obs)
     func2 = zfit.pdf.Uniform(-1.2, -1, obs=obs)
     func = zfit.pdf.SumPDF([func1, func2], 0.5)
-    conv = zfit.pdf.FFTConvPDFV1(func=func, kernel=gauss, n=400, interpolation=interpolation)
+    conv = zfit.pdf.FFTConvPDFV1(func=func, kernel=gauss, n=100, interpolation=interpolation)
     if interpolation == 'spline:5':
-        assert conv._spline_order == 5
+        assert conv._conv_spline_order == 5
     elif interpolation == 'spline:3':
-        assert conv._spline_order == 3
+        assert conv._conv_spline_order == 3
 
     x = tf.linspace(-5., 5., n_points)
     probs = conv.pdf(x=x)
 
     # true convolution
-    true_conv = true_conv_np(func, gauss, obs, x)
+    true_conv = true_conv_np(func, gauss, obs, x, xkernel=tf.linspace(*obs.limit1d, num=n_points))
 
     integral = conv.integrate(limits=obs)
     probs_np = probs.numpy()
@@ -57,7 +59,6 @@ def test_conv_simple(interpolation):
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     assert len(probs_np) == n_points
 
-    #
     # import matplotlib.pyplot as plt
     # plt.figure()
     # plt.plot(x, probs_np, label='zfit')
@@ -67,30 +68,80 @@ def test_conv_simple(interpolation):
     # plt.show()
 
 
-def test_onedim_sampling():
-    obs_kernel = zfit.Space("obs1", limits=(-3, 3))
+def test_conv_1d_shifted():
+    obs_kernel = zfit.Space("obs1", limits=(-3, 1.5))
     obs = zfit.Space("obs1", limits=(5, 15))
-    param2 = zfit.Parameter('param2', 0.3)
-    # gauss = zfit.pdf.Gauss(0., param2, obs=obs)
-    gauss = zfit.pdf.CrystalBall(0, param2, 0.5, 3, obs=obs_kernel)
-    func1 = zfit.pdf.Uniform(8, 12, obs=obs)
+    func1 = zfit.pdf.Uniform(6, 12, obs=obs)
     func2 = zfit.pdf.Uniform(11, 11.5, obs=obs)
     func = zfit.pdf.SumPDF([func1, func2], 0.5)
-    conv = zfit.pdf.FFTConvPDFV1(func=func, kernel=gauss)
 
-    conv_nosample = FFTConvPDFV1NoSampling(func=func, kernel=gauss, n=1000)
+    func1k = zfit.pdf.Gauss(0., 1, obs=obs_kernel)
+    func2k = zfit.pdf.Gauss(1., 0.4, obs=obs_kernel)
+    funck = zfit.pdf.SumPDF([func1k, func2k], 0.5)
+
+    conv = zfit.pdf.FFTConvPDFV1(func=func, kernel=funck, n=200)
+
+    xnp = tf.linspace(obs_kernel.rect_lower, obs.rect_upper, 4023)
+
+    # true convolution
+    kernel_points = obs_kernel.filter(xnp)
+    x = obs.filter(xnp)
+    probs = conv.pdf(x=x)
+    true_conv = true_conv_np(func, funck, obs, x=x, xkernel=kernel_points)
+
+    integral = conv.integrate(limits=obs)
+    probs_np = probs.numpy()
+    np.testing.assert_allclose(probs_np, true_conv, rtol=0.01, atol=0.01)
+
+    assert pytest.approx(1, rel=1e-3) == integral.numpy()
+    # # assert len(probs_np) == n_points
+    #
+    # #
+    # import matplotlib.pyplot as plt
+    # plt.figure()
+    # plt.plot(x, probs_np, label='zfit')
+    # plt.plot(x, true_conv, label='numpy')
+    # plt.legend()
+    # plt.show()
+
+
+def test_onedim_sampling():
+    zfit.run.set_graph_mode(False)
+    obs_kernel = zfit.Space("obs1", limits=(-3, 3))
+    obs = zfit.Space("obs1", limits=(5, 15))
+    func1 = zfit.pdf.Uniform(6, 12, obs=obs)
+    func2 = zfit.pdf.Uniform(11, 11.5, obs=obs)
+    func = zfit.pdf.SumPDF([func1, func2], 0.5)
+
+    func1k = zfit.pdf.Uniform(-2, 1, obs=obs_kernel)
+    func2k = zfit.pdf.Uniform(-0.5, 1., obs=obs_kernel)
+    funck = zfit.pdf.SumPDF([func1k, func2k], 0.5)
+    conv = zfit.pdf.FFTConvPDFV1(func=func, kernel=funck, n=200)
+
+    conv_nosample = FFTConvPDFV1NoSampling(func=func, kernel=funck, n=200)
     npoints_sample = 10000
     sample = conv.sample(npoints_sample)
     sample_nosample = conv_nosample.sample(npoints_sample)
     x = z.unstack_x(sample)
     xns = z.unstack_x(sample_nosample)
-    assert scipy.stats.ks_2samp(x, xns).pvalue > 1e-10  # can vary a lot, but still means close
+    assert scipy.stats.ks_2samp(x, xns).pvalue > 1e-6  # can vary a lot, but still means close
+    # uni1sample = func1k.sample(npoints_sample // 2)
+    # uni2sample = func2k.sample(npoints_sample // 2)
+    # xcomb = tf.concat([uni1sample.value(), uni2sample.value()], axis=0)
 
     # import matplotlib.pyplot as plt
     # plt.figure()
     # nbins = 50
-    # _, bins, _ = plt.hist(x.numpy(), bins=nbins, label='custom', alpha=0.5)
-    # plt.hist(xns.numpy(), bins=bins, label='fallback', alpha=0.5)
+    # alpha = 0.5
+    # _, bins, _ = plt.hist(xns.numpy(), bins=nbins, label='fallback', alpha=alpha)
+    # plt.hist(x.numpy(), bins=bins, label='custom', alpha=alpha)
+    #
+    # xsum = z.unstack_x(func.sample(n=npoints_sample))
+    # xsumk = z.unstack_x(funck.sample(n=npoints_sample))
+    # xsumk_np = xsumk.numpy()
+    # np.random.shuffle(xsumk_np)
+    # plt.hist(xsumk_np + xsum.numpy(), bins=bins, label='manually convoluted', alpha=alpha)
+    # # plt.hist(xcomb.numpy() + 9, bins=bins, label='true non-convoluted', alpha=alpha)
     # lower, upper = np.min(bins), np.max(bins)
     # linspace = tf.linspace(lower, upper, 1000)
     # plt.plot(linspace, conv.pdf(linspace) * npoints_sample / nbins * (upper - lower))
@@ -98,39 +149,37 @@ def test_onedim_sampling():
     # plt.show()
 
 
-def true_conv_np(func, gauss1, obs, x):
-    # n_points = x.shape[0]
-    # y_kernel = gauss1.pdf(x[n_points // 4:-n_points // 4])
-    y_kernel = gauss1.pdf(x)
+def true_conv_np(func, gauss1, obs, x, xkernel):
+    y_kernel = gauss1.pdf(xkernel)
     y_func = func.pdf(x)
     true_conv = scipy.signal.fftconvolve(y_func, y_kernel, mode='same')
-    # true_conv = true_conv[n_points // 4:  n_points * 5 // 4]
     true_conv /= np.mean(true_conv) * obs.rect_area()
     return true_conv
 
-def true_conv_2d_np(func, gauss1, obs, x):
-    # n_points = x.shape[0]
-    # y_kernel = gauss1.pdf(x[n_points // 4:-n_points // 4])
-    y_kernel = gauss1.pdf(x)
-    y_func = func.pdf(x)
-    n = int(np.sqrt(x.shape[0]))
-    y_kernel = tf.reshape(y_kernel, (n, n))
-    y_func = tf.reshape(y_func, (n, n))
+
+def true_conv_2d_np(func, gauss1, obsfunc, xfunc, xkernel):
+    y_func = func.pdf(xfunc)
+    y_kernel = gauss1.pdf(xkernel)
+    nfunc = int(np.sqrt(xfunc.shape[0]))
+    y_func = tf.reshape(y_func, (nfunc, nfunc))
+    nkernel = int(np.sqrt(xkernel.shape[0]))
+    y_kernel = tf.reshape(y_kernel, (nkernel, nkernel))
     true_conv = scipy.signal.convolve(y_func, y_kernel, mode='same')
-    # true_conv = true_conv[n_points // 4:  n_points * 5 // 4]
-    true_conv /= np.mean(true_conv) * obs.rect_area()
-    return true_conv
+    true_conv /= np.mean(true_conv) * obsfunc.rect_area()
+    return tf.reshape(true_conv, xfunc.shape[0])
 
 
-# @pytest.mark.skip  # not yet implemented
+@pytest.mark.skip  # not yet implemented WIP
 def test_conv_2D_simple():
     zfit.run.set_graph_mode(False)  # TODO: remove, just for debugging
-    n_points = 200
-    obs1 = zfit.Space("obs1", limits=(-5, 5))
-    obs2 = zfit.Space("obs2", limits=(-6, 6))
+    raise WorkInProgressError("2D convolution not yet implemented, re-activate if so")
+    n_points = 1000
+    obs1 = zfit.Space("obs1", limits=(-2, 4))
+    obs2 = zfit.Space("obs2", limits=(-6, 4))
+    obskernel = obs1 * obs2
 
     param2 = zfit.Parameter('param2', 0.4)
-    gauss1 = zfit.pdf.Gauss(0., 0.5, obs=obs1)
+    gauss1 = zfit.pdf.Gauss(1., 0.5, obs=obs1)
     gauss22 = zfit.pdf.CrystalBall(0.0, param2, -0.2, 3, obs=obs2)
 
     obs1func = zfit.Space("obs1", limits=(4, 10))
@@ -151,27 +200,52 @@ def test_conv_2D_simple():
     x_tensor = tf.reshape(x_tensor, (-1, 2))
     linspace = tf.linspace(start, stop, num=n_points)
     linspace = tf.transpose(tf.meshgrid(*tf.unstack(linspace, axis=-1)))
-    linspace = tf.reshape(linspace, (-1, 2))
-    obs2d = obs1 * obs2
+    linspace_func = tf.reshape(linspace, (-1, 2))
+
+    # linspace_full = tf.linspace((-8, -8), (12, 12), num=n_points)
+    # linspace_full = tf.transpose(tf.meshgrid(*tf.unstack(linspace_full, axis=-1)))
+    # linspace_full = tf.reshape(linspace_full, (-1, 2))
+
+    linspace_kernel = tf.linspace(obskernel.rect_lower,
+                                  obskernel.rect_upper, num=n_points)
+    linspace_kernel = tf.transpose(tf.meshgrid(*tf.unstack(linspace_kernel, axis=-1)))
+    linspace_kernel = tf.reshape(linspace_kernel, (-1, 2))
+    # linspace_kernel = obskernel.filter(linspace_full)
+    # linspace_func = obs_func.filter(linspace_full)
+
     x = zfit.Data.from_tensor(obs=obs_func, tensor=x_tensor)
     linspace_data = zfit.Data.from_tensor(obs=obs_func, tensor=linspace)
     probs_rnd = conv.pdf(x=x)
     probs = conv.pdf(x=linspace_data)
 
     # Numpy doesn't support ndim convolution?
-    true_probs = true_conv_2d_np(func, gauss, obs=obs2d, x=linspace)
+    true_probs = true_conv_2d_np(func, gauss, obsfunc=obs_func,
+                                 xfunc=linspace_func, xkernel=linspace_kernel)
+    import matplotlib.pyplot as plt
     # np.testing.assert_allclose(probs, true_probs, rtol=0.2, atol=0.1)
     integral = conv.integrate(limits=obs_func)
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     probs_np = probs_rnd.numpy()
     assert len(probs_np) == n_points
     # probs_plot = np.reshape(probs_np, (-1, n_points))
-    # x_plot = linspace[0]
+    # x_plot = linspace[0:, ]
     # probs_plot_projx = np.sum(probs_plot, axis=0)
     # plt.plot(x_plot, probs_np)
     # probs_plot = np.reshape(probs_np, (n_points, n_points))
     # plt.imshow(probs_plot)
     # plt.show()
+
+    true_probsr = tf.reshape(true_probs, (n_points, n_points))
+    probsr = tf.reshape(probs, (n_points, n_points))
+    plt.figure()
+    plt.imshow(true_probsr, label='true probs')
+    plt.title('true probs')
+
+    plt.figure()
+    plt.imshow(probsr, label='zfit conv')
+    plt.title('zfit conv')
+
+    plt.show(block=False)
 
     # test the sampling
     conv_nosample = FFTConvPDFV1NoSampling(func=func, kernel=gauss)
@@ -181,11 +255,25 @@ def test_conv_2D_simple():
     sample_nosample = conv_nosample.sample(npoints_sample)
     x, y = z.unstack_x(sample)
     xns, yns = z.unstack_x(sample_nosample)
-    import matplotlib.pyplot as plt
-    true_probsr = tf.reshape(true_probs, (n_points, n_points))
-    probsr = tf.reshape(probs, (n_points, n_points))
+
     plt.figure()
-    # plt.hist(x, bins=50, label='custom', alpha=0.5)
-    # plt.hist(xns, bins=50, label='fallback', alpha=0.5)
-    # plt.legend()
-    # plt.show()
+    plt.hist2d(x, y, bins=30)
+    plt.title('custom sampling, addition')
+
+    plt.figure()
+    plt.hist2d(xns, yns, bins=30)
+    plt.title('fallback sampling, accept-reject')
+
+    plt.figure()
+    plt.hist(x.numpy(), bins=50, label='custom', alpha=0.5)
+    plt.hist(xns.numpy(), bins=50, label='fallback', alpha=0.5)
+    plt.legend()
+    plt.title('x')
+    plt.show()
+
+    plt.figure()
+    plt.hist(y.numpy(), bins=50, label='custom', alpha=0.5)
+    plt.hist(yns.numpy(), bins=50, label='fallback', alpha=0.5)
+    plt.title('y')
+    plt.legend()
+    plt.show()

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -1,0 +1,39 @@
+"""Example test for a pdf or function"""
+#  Copyright (c) 2020 zfit
+
+import pytest
+import tensorflow as tf
+
+import zfit.models.convolution
+
+# Important, do the imports below
+
+# specify globals here. Do NOT add any TensorFlow but just pure python
+param1_true = 0.3
+param2_true = 1.2
+
+
+def test_conv_simple():
+    # test special properties  here
+    n_points = 2000
+    obs = zfit.Space("obs1", limits=(-5, 5))
+    param1 = zfit.Parameter('param1', -3)
+    param2 = zfit.Parameter('param2', 0.3)
+    gauss1 = zfit.pdf.Gauss(0., param2, obs=obs)
+    func = zfit.pdf.Uniform(param1, param2, obs=obs)
+    # func = zfit.pdf.(-0.1, obs=obs)
+    conv = zfit.models.convolution.FFTConv1DV1(func=func,
+                                               kernel=gauss1,
+                                               # limits_kernel=(-1, 1)
+                                               )
+
+    x = tf.linspace(-5., 5., n_points)
+    probs = conv.pdf(x=x)
+    integral = conv.integrate(limits=obs)
+    probs_np = probs.numpy()
+    assert pytest.approx(1, rel=1e-3) == integral.numpy()
+    assert len(probs_np) == n_points
+    import matplotlib.pyplot as plt
+    plt.plot(x, probs_np)
+    plt.show()
+    # assert len(conv.get_dependents(only_floating=False)) == 2  # TODO: activate again with fixed params

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -36,7 +36,7 @@ def test_conv_simple():
     probs_np = probs.numpy()
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     assert len(probs_np) == n_points
-    # import matplotlib.pyplot as plt
-    # plt.plot(x, probs_np)
-    # plt.show()
+    import matplotlib.pyplot as plt
+    plt.plot(x, probs_np)
+    plt.show()
     # assert len(conv.get_dependents(only_floating=False)) == 2  # TODO: activate again with fixed params

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -82,7 +82,7 @@ def test_onedim_sampling():
     sample_nosample = conv_nosample.sample(npoints_sample)
     x = z.unstack_x(sample)
     xns = z.unstack_x(sample_nosample)
-    assert scipy.stats.ks_2samp(x, xns).pvalue > 0.001
+    assert scipy.stats.ks_2samp(x, xns).pvalue > 1e-5  # can vary a lot, but still means close
 
     # import matplotlib.pyplot as plt
     # plt.figure()

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pytest
+import scipy.signal
 import scipy.stats
 import tensorflow as tf
 
@@ -15,7 +16,7 @@ param1_true = 0.3
 param2_true = 1.2
 
 
-class FFTConvV1NoSampling(zfit.pdf.FFTConvV1):
+class FFTConvPDFV1NoSampling(zfit.pdf.FFTConvPDFV1):
 
     @zfit.supports()
     def _sample(self, n, limits):
@@ -37,7 +38,7 @@ def test_conv_simple(interpolation):
     func1 = zfit.pdf.Uniform(param1, param2, obs=obs)
     func2 = zfit.pdf.Uniform(-1.2, -1, obs=obs)
     func = zfit.pdf.SumPDF([func1, func2], 0.5)
-    conv = zfit.pdf.FFTConvV1(func=func, kernel=gauss, n=100, interpolation=interpolation)
+    conv = zfit.pdf.FFTConvPDFV1(func=func, kernel=gauss, n=400, interpolation=interpolation)
     if interpolation == 'spline:5':
         assert conv._spline_order == 5
     elif interpolation == 'spline:3':
@@ -47,11 +48,11 @@ def test_conv_simple(interpolation):
     probs = conv.pdf(x=x)
 
     # true convolution
-    true_conv = true_conv_np(func, gauss, n_points, obs, x)
+    true_conv = true_conv_np(func, gauss, obs, x)
 
     integral = conv.integrate(limits=obs)
     probs_np = probs.numpy()
-    np.testing.assert_allclose(probs, true_conv, rtol=0.2, atol=0.1)
+    np.testing.assert_allclose(probs, true_conv, rtol=0.1, atol=0.01)
 
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     assert len(probs_np) == n_points
@@ -67,16 +68,18 @@ def test_conv_simple(interpolation):
 
 
 def test_onedim_sampling():
-    obs = zfit.Space("obs1", limits=(-5, 5))
-    param1 = zfit.Parameter('param1', -3)
+    zfit.run.set_graph_mode(False)
+    obs_kernel = zfit.Space("obs1", limits=(-3, 3))
+    obs = zfit.Space("obs1", limits=(5, 15))
     param2 = zfit.Parameter('param2', 0.3)
-    gauss = zfit.pdf.Gauss(0., param2, obs=obs)
-    func1 = zfit.pdf.Uniform(param1, param2, obs=obs)
-    func2 = zfit.pdf.Uniform(-1.2, -1, obs=obs)
+    # gauss = zfit.pdf.Gauss(0., param2, obs=obs)
+    gauss = zfit.pdf.CrystalBall(0, param2, 0.5, 3, obs=obs_kernel)
+    func1 = zfit.pdf.Uniform(8, 12, obs=obs)
+    func2 = zfit.pdf.Uniform(11, 11.5, obs=obs)
     func = zfit.pdf.SumPDF([func1, func2], 0.5)
-    conv = zfit.pdf.FFTConvV1(func=func, kernel=gauss)
+    conv = zfit.pdf.FFTConvPDFV1(func=func, kernel=gauss)
 
-    conv_nosample = FFTConvV1NoSampling(func=func, kernel=gauss, n=300)
+    conv_nosample = FFTConvPDFV1NoSampling(func=func, kernel=gauss, n=1000)
     npoints_sample = 10000
     sample = conv.sample(npoints_sample)
     sample_nosample = conv_nosample.sample(npoints_sample)
@@ -86,50 +89,68 @@ def test_onedim_sampling():
 
     # import matplotlib.pyplot as plt
     # plt.figure()
-    # plt.hist(x, bins=50, label='custom')
-    # plt.hist(xns, bins=50, label='fallback')
+    # nbins = 50
+    # _, bins, _ = plt.hist(x.numpy(), bins=nbins, label='custom', alpha=0.5)
+    # plt.hist(xns.numpy(), bins=bins, label='fallback', alpha=0.5)
+    # lower, upper = np.min(bins), np.max(bins)
+    # linspace = tf.linspace(lower, upper, 1000)
+    # plt.plot(linspace, conv.pdf(linspace) * npoints_sample / nbins * (upper - lower))
     # plt.legend()
     # plt.show()
 
 
-def true_conv_np(func, gauss1, n_points, obs, x):
-    y_kernel = gauss1.pdf(x[n_points // 4:-n_points // 4])
+def true_conv_np(func, gauss1, obs, x):
+    # n_points = x.shape[0]
+    # y_kernel = gauss1.pdf(x[n_points // 4:-n_points // 4])
+    y_kernel = gauss1.pdf(x)
     y_func = func.pdf(x)
-    true_conv = np.convolve(y_func, y_kernel, mode='full')[n_points // 4:  n_points * 5 // 4]
+    true_conv = scipy.signal.fftconvolve(y_func, y_kernel, mode='same')
+    # true_conv = true_conv[n_points // 4:  n_points * 5 // 4]
     true_conv /= np.mean(true_conv) * obs.rect_area()
     return true_conv
 
 
+@pytest.mark.skip  # not yet implemented
 def test_conv_2D_simple():
-    zfit.run.set_graph_mode(False)
+    zfit.run.set_graph_mode(False)  # TODO: remove, just for debugging
     n_points = 200
     obs1 = zfit.Space("obs1", limits=(-5, 5))
-    obs2 = zfit.Space("obs2", limits=(-6, 8))
+    obs2 = zfit.Space("obs2", limits=(-6, 4))
+
     param1 = zfit.Parameter('param1', -3)
     param2 = zfit.Parameter('param2', 0.4)
-    gauss1 = zfit.pdf.Gauss(0., param2, obs=obs1)
-    gauss21 = zfit.pdf.Gauss(0.5, param2, obs=obs2)
-    gauss22 = zfit.pdf.Gauss(0.3, param2 + 0.7, obs=obs2)
-    func1 = zfit.pdf.Uniform(param1, param2, obs=obs1)
-    func2 = zfit.pdf.Uniform(-1.2, -1, obs=obs1)
+    gauss1 = zfit.pdf.Gauss(0., 0.5, obs=obs1)
+    gauss22 = zfit.pdf.CrystalBall(0.3, param2, -0.2, 3, obs=obs2)
+
+    obs1func = zfit.Space("obs1", limits=(4, 10))
+    obs2func = zfit.Space("obs2", limits=(-6, 4))
+    obs_func = obs1func * obs2func
+
+    gauss21 = zfit.pdf.Gauss(-0.5, param2, obs=obs2func)
+    func1 = zfit.pdf.Uniform(5, 8, obs=obs1func)
+    func2 = zfit.pdf.Uniform(6, 7, obs=obs1func)
     func = zfit.pdf.SumPDF([func1, func2], 0.5)
     func = func * gauss21
     gauss = gauss1 * gauss22
-    conv = zfit.pdf.FFTConvV1(func=func, kernel=gauss)
+    conv = zfit.pdf.FFTConvPDFV1(func=func, kernel=gauss)
 
-    start = (-5., -6.)
-    stop = (5., 6.)
+    start = obs_func.rect_lower
+    stop = obs_func.rect_upper
     x_tensor = tf.random.uniform((n_points, 2), start, stop)
-    linspace = tf.linspace(start, stop, num=n_points)
     x_tensor = tf.reshape(x_tensor, (-1, 2))
+    linspace = tf.linspace(start, stop, num=n_points)
+    linspace = tf.transpose(tf.meshgrid(*tf.unstack(linspace, axis=-1)))
+    linspace = tf.reshape(linspace, (-1, 2))
     obs2d = obs1 * obs2
-    x = zfit.Data.from_tensor(obs=obs2d, tensor=x_tensor)
-    linspace_data = zfit.Data.from_tensor(obs=obs2d, tensor=linspace)
+    x = zfit.Data.from_tensor(obs=obs_func, tensor=x_tensor)
+    linspace_data = zfit.Data.from_tensor(obs=obs_func, tensor=linspace)
     probs_rnd = conv.pdf(x=x)
-    probs = func.pdf(x=linspace_data)
-    true_probs = true_conv_np(func, gauss, n_points=n_points, obs=obs2d, x=linspace)
+    probs = conv.pdf(x=linspace_data)
+
+    # Numpy doesn't support ndim convolution?
+    true_probs = true_conv_np(func, gauss, obs=obs2d, x=linspace)
     np.testing.assert_allclose(probs, true_probs, rtol=0.2, atol=0.1)
-    integral = conv.integrate(limits=obs2d)
+    integral = conv.integrate(limits=obs_func)
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     probs_np = probs_rnd.numpy()
     assert len(probs_np) == n_points
@@ -142,14 +163,14 @@ def test_conv_2D_simple():
     # plt.show()
 
     # test the sampling
-    conv_nosample = FFTConvV1NoSampling(func=func, kernel=gauss)
+    conv_nosample = FFTConvPDFV1NoSampling(func=func, kernel=gauss)
 
     npoints_sample = 10000
     sample = conv.sample(npoints_sample)
     sample_nosample = conv_nosample.sample(npoints_sample)
     x, y = z.unstack_x(sample)
     xns, yns = z.unstack_x(sample_nosample)
-
+    assert True
     # import matplotlib.pyplot as plt
     # plt.figure()
     # plt.hist(x, bins=50, label='custom', alpha=0.5)

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -5,6 +5,8 @@ import pytest
 import tensorflow as tf
 
 import zfit.models.convolution
+# noinspection PyUnresolvedReferences
+from zfit.core.testing import setup_function, teardown_function, tester
 
 # Important, do the imports below
 
@@ -33,6 +35,42 @@ def test_conv_simple():
     probs = conv.pdf(x=x)
     # probs = func.pdf(x=x)
     integral = conv.integrate(limits=obs)
+    probs_np = probs.numpy()
+    assert pytest.approx(1, rel=1e-3) == integral.numpy()
+    assert len(probs_np) == n_points
+    # import matplotlib.pyplot as plt
+    # plt.plot(x, probs_np)
+    # plt.show()
+    # assert len(conv.get_dependents(only_floating=False)) == 2  # TODO: activate again with fixed params
+
+
+def test_conv_2D_simple():
+    # test special properties  here
+    n_points = 200
+    obs1 = zfit.Space("obs1", limits=(-5, 5))
+    obs2 = zfit.Space("obs2", limits=(-6, 3))
+    param1 = zfit.Parameter('param1', -3)
+    param2 = zfit.Parameter('param2', 0.3)
+    gauss1 = zfit.pdf.Gauss(0., param2, obs=obs1)
+    gauss21 = zfit.pdf.Gauss(0.5, param2, obs=obs2)
+    gauss22 = zfit.pdf.Gauss(0.3, param2, obs=obs2)
+    func1 = zfit.pdf.Uniform(param1, param2, obs=obs1)
+    func2 = zfit.pdf.Uniform(-1.2, -1, obs=obs1)
+    func = zfit.pdf.SumPDF([func1, func2], 0.5)
+    func = func * gauss21
+    gauss = gauss1 * gauss22
+    # func = zfit.pdf.(-0.1, obs=obs)
+    conv = zfit.pdf.FFTConv1DV1(func=func,
+                                kernel=gauss,
+                                # limits_kernel=(-1, 1)
+                                )
+
+    # x = tf.linspace((-5., -6), (5., 6), n_points)
+    x = tf.random.uniform((n_points, 2), (-5., -6), (5., 6))
+    x = zfit.Data.from_tensor(obs=obs1 * obs2, tensor=x)
+    probs = conv.pdf(x=x)
+    # probs = func.pdf(x=x)
+    integral = conv.integrate(limits=obs1 * obs2)
     probs_np = probs.numpy()
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     assert len(probs_np) == n_points

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -54,7 +54,7 @@ def test_conv_simple(interpolation):
 
     integral = conv.integrate(limits=obs)
     probs_np = probs.numpy()
-    np.testing.assert_allclose(probs, true_conv, rtol=0.1, atol=0.01)
+    np.testing.assert_allclose(probs, true_conv, rtol=0.01, atol=0.01)
 
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     assert len(probs_np) == n_points
@@ -95,14 +95,13 @@ def test_conv_1d_shifted():
     np.testing.assert_allclose(probs_np, true_conv, rtol=0.01, atol=0.01)
 
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
-    # # assert len(probs_np) == n_points
 
-    import matplotlib.pyplot as plt
-    plt.figure()
-    plt.plot(x, probs_np, label='zfit')
-    plt.plot(x, true_conv, label='numpy')
-    plt.legend()
-    plt.show()
+    # import matplotlib.pyplot as plt
+    # plt.figure()
+    # plt.plot(x, probs_np, label='zfit')
+    # plt.plot(x, true_conv, label='numpy')
+    # plt.legend()
+    # plt.show()
 
 
 def test_onedim_sampling():

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -8,7 +8,6 @@ import scipy.stats
 import tensorflow as tf
 
 import zfit
-import zfit.models.convolution
 from zfit import z
 # noinspection PyUnresolvedReferences
 from zfit.core.testing import setup_function, teardown_function, tester

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -1,8 +1,10 @@
 """Example test for a pdf or function"""
 #  Copyright (c) 2020 zfit
 
+import numpy as np
 import pytest
 import tensorflow as tf
+import scipy
 
 import zfit.models.convolution
 # noinspection PyUnresolvedReferences
@@ -21,7 +23,7 @@ param2_true = 1.2
 ))
 def test_conv_simple(interpolation):
     # test special properties  here
-    n_points = 200
+    n_points = 2432
     obs = zfit.Space("obs1", limits=(-5, 5))
     param1 = zfit.Parameter('param1', -3)
     param2 = zfit.Parameter('param2', 0.3)
@@ -29,25 +31,41 @@ def test_conv_simple(interpolation):
     func1 = zfit.pdf.Uniform(param1, param2, obs=obs)
     func2 = zfit.pdf.Uniform(-1.2, -1, obs=obs)
     func = zfit.pdf.SumPDF([func1, func2], 0.5)
-    # func = zfit.pdf.(-0.1, obs=obs)
-    conv = zfit.pdf.FFTConv1DV1(func=func,
-                                kernel=gauss1,
-                                interpolation=interpolation,
-                                npoints=100,
-                                )
+    conv = zfit.pdf.FFTConvV1(func=func,
+                              kernel=gauss1,
+                              interpolation=interpolation,
+                              npoints=100,
+                              )
 
     x = tf.linspace(-5., 5., n_points)
     probs = conv.pdf(x=x)
-    # probs = func.pdf(x=x)
+
+    # true convolution
+    true_conv = true_conv_np(func, gauss1, n_points, obs, x)
+
     integral = conv.integrate(limits=obs)
     probs_np = probs.numpy()
+    np.testing.assert_allclose(probs, true_conv, rtol=0.2, atol=0.1)
+
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     assert len(probs_np) == n_points
-    import matplotlib.pyplot as plt
-    plt.figure()
-    plt.plot(x, probs_np)
-    plt.title(interpolation)
-    plt.show()
+
+    #
+    # import matplotlib.pyplot as plt
+    # plt.figure()
+    # plt.plot(x, probs_np, label='zfit')
+    # plt.plot(x, true_conv, label='numpy')
+    # plt.legend()
+    # plt.title(interpolation)
+    # plt.show()
+
+
+def true_conv_np(func, gauss1, n_points, obs, x):
+    y_kernel = gauss1.pdf(x[n_points // 4:-n_points // 4])
+    y_func = func.pdf(x)
+    true_conv = np.convolve(y_func, y_kernel, mode='full')[n_points // 4:  n_points * 5 // 4]
+    true_conv /= np.mean(true_conv) * obs.rect_area()
+    return true_conv
 
 
 def test_conv_2D_simple():
@@ -67,25 +85,28 @@ def test_conv_2D_simple():
     func = func * gauss21
     gauss = gauss1 * gauss22
     # func = zfit.pdf.(-0.1, obs=obs)
-    conv = zfit.pdf.FFTConv1DV1(func=func,
-                                kernel=gauss,
-                                # limits_kernel=(-1, 1)
-                                )
+    conv = zfit.pdf.FFTConvV1(func=func,
+                              kernel=gauss,
+                              # limits_kernel=(-1, 1)
+                              )
 
     # x = tf.linspace((-5., -6), (5., 6), n_points)
-    x_tensor = tf.random.uniform((n_points, 2), (-5., -6), (5., 6))
-    # start = (-5., -6.)
-    # stop = (5., 6.)
-    # linspace = tf.transpose(tf.linspace(start, stop, num=n_points))
+    start = (-5., -6.)
+    stop = (5., 6.)
+    x_tensor = tf.random.uniform((n_points, 2), start, stop)
+    linspace = tf.linspace(start, stop, num=n_points)
     # x_tensor = tf.transpose(tf.meshgrid(*linspace))
     x_tensor = tf.reshape(x_tensor, (-1, 2))
     obs2d = obs1 * obs2
     x = zfit.Data.from_tensor(obs=obs2d, tensor=x_tensor)
-    probs = conv.pdf(x=x)
-    # probs = func.pdf(x=x)
+    linspace_data = zfit.Data.from_tensor(obs=obs2d, tensor=linspace)
+    probs_rnd = conv.pdf(x=x)
+    probs = func.pdf(x=linspace_data)
+    true_probs = true_conv_np(func, gauss, n_points=n_points, obs=obs2d, x=linspace)
+    np.testing.assert_allclose(probs, true_probs, rtol=0.2, atol=0.1)
     integral = conv.integrate(limits=obs2d)
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
-    probs_np = probs.numpy()
+    probs_np = probs_rnd.numpy()
     assert len(probs_np) == n_points
     # probs_plot = np.reshape(probs_np, (-1, n_points))
     # x_plot = linspace[0]

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -24,10 +24,10 @@ def test_conv_simple():
     func2 = zfit.pdf.Uniform(-1.2, -1, obs=obs)
     func = zfit.pdf.SumPDF([func1, func2], 0.5)
     # func = zfit.pdf.(-0.1, obs=obs)
-    conv = zfit.models.convolution.FFTConv1DV1(func=func,
-                                               kernel=gauss1,
-                                               # limits_kernel=(-1, 1)
-                                               )
+    conv = zfit.pdf.FFTConv1DV1(func=func,
+                                kernel=gauss1,
+                                # limits_kernel=(-1, 1)
+                                )
 
     x = tf.linspace(-5., 5., n_points)
     probs = conv.pdf(x=x)
@@ -36,7 +36,7 @@ def test_conv_simple():
     probs_np = probs.numpy()
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     assert len(probs_np) == n_points
-    import matplotlib.pyplot as plt
-    plt.plot(x, probs_np)
-    plt.show()
+    # import matplotlib.pyplot as plt
+    # plt.plot(x, probs_np)
+    # plt.show()
     # assert len(conv.get_dependents(only_floating=False)) == 2  # TODO: activate again with fixed params

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -15,7 +15,11 @@ param1_true = 0.3
 param2_true = 1.2
 
 
-def test_conv_simple():
+@pytest.mark.parametrize('interpolation', (
+    'linear',
+    'spline',
+))
+def test_conv_simple(interpolation):
     # test special properties  here
     n_points = 200
     obs = zfit.Space("obs1", limits=(-5, 5))
@@ -28,7 +32,8 @@ def test_conv_simple():
     # func = zfit.pdf.(-0.1, obs=obs)
     conv = zfit.pdf.FFTConv1DV1(func=func,
                                 kernel=gauss1,
-                                # limits_kernel=(-1, 1)
+                                interpolation=interpolation,
+                                npoints=100,
                                 )
 
     x = tf.linspace(-5., 5., n_points)
@@ -38,22 +43,24 @@ def test_conv_simple():
     probs_np = probs.numpy()
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     assert len(probs_np) == n_points
-    # import matplotlib.pyplot as plt
-    # plt.plot(x, probs_np)
-    # plt.show()
-    # assert len(conv.get_dependents(only_floating=False)) == 2  # TODO: activate again with fixed params
+    import matplotlib.pyplot as plt
+    plt.figure()
+    plt.plot(x, probs_np)
+    plt.title(interpolation)
+    plt.show()
 
 
 def test_conv_2D_simple():
     # test special properties  here
+    zfit.run.set_graph_mode(False)
     n_points = 200
     obs1 = zfit.Space("obs1", limits=(-5, 5))
-    obs2 = zfit.Space("obs2", limits=(-6, 3))
+    obs2 = zfit.Space("obs2", limits=(-6, 8))
     param1 = zfit.Parameter('param1', -3)
-    param2 = zfit.Parameter('param2', 0.3)
+    param2 = zfit.Parameter('param2', 0.4)
     gauss1 = zfit.pdf.Gauss(0., param2, obs=obs1)
     gauss21 = zfit.pdf.Gauss(0.5, param2, obs=obs2)
-    gauss22 = zfit.pdf.Gauss(0.3, param2, obs=obs2)
+    gauss22 = zfit.pdf.Gauss(0.3, param2 + 0.7, obs=obs2)
     func1 = zfit.pdf.Uniform(param1, param2, obs=obs1)
     func2 = zfit.pdf.Uniform(-1.2, -1, obs=obs1)
     func = zfit.pdf.SumPDF([func1, func2], 0.5)
@@ -66,15 +73,25 @@ def test_conv_2D_simple():
                                 )
 
     # x = tf.linspace((-5., -6), (5., 6), n_points)
-    x = tf.random.uniform((n_points, 2), (-5., -6), (5., 6))
-    x = zfit.Data.from_tensor(obs=obs1 * obs2, tensor=x)
+    x_tensor = tf.random.uniform((n_points, 2), (-5., -6), (5., 6))
+    # start = (-5., -6.)
+    # stop = (5., 6.)
+    # linspace = tf.transpose(tf.linspace(start, stop, num=n_points))
+    # x_tensor = tf.transpose(tf.meshgrid(*linspace))
+    x_tensor = tf.reshape(x_tensor, (-1, 2))
+    obs2d = obs1 * obs2
+    x = zfit.Data.from_tensor(obs=obs2d, tensor=x_tensor)
     probs = conv.pdf(x=x)
     # probs = func.pdf(x=x)
-    integral = conv.integrate(limits=obs1 * obs2)
-    probs_np = probs.numpy()
+    integral = conv.integrate(limits=obs2d)
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
+    probs_np = probs.numpy()
     assert len(probs_np) == n_points
-    # import matplotlib.pyplot as plt
-    # plt.plot(x, probs_np)
+    # probs_plot = np.reshape(probs_np, (-1, n_points))
+    # x_plot = linspace[0]
+    # probs_plot_projx = np.sum(probs_plot, axis=0)
+    # plt.plot(x_plot, probs_np)
+    # probs_plot = np.reshape(probs_np, (n_points, n_points))
+    # plt.imshow(probs_plot)
     # plt.show()
     # assert len(conv.get_dependents(only_floating=False)) == 2  # TODO: activate again with fixed params

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -82,7 +82,7 @@ def test_onedim_sampling():
     sample_nosample = conv_nosample.sample(npoints_sample)
     x = z.unstack_x(sample)
     xns = z.unstack_x(sample_nosample)
-    assert scipy.stats.ks_2samp(x, xns).pvalue > 1e-5  # can vary a lot, but still means close
+    assert scipy.stats.ks_2samp(x, xns).pvalue > 1e-10  # can vary a lot, but still means close
 
     # import matplotlib.pyplot as plt
     # plt.figure()

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -68,7 +68,6 @@ def test_conv_simple(interpolation):
 
 
 def test_onedim_sampling():
-    zfit.run.set_graph_mode(False)
     obs_kernel = zfit.Space("obs1", limits=(-3, 3))
     obs = zfit.Space("obs1", limits=(5, 15))
     param2 = zfit.Parameter('param2', 0.3)
@@ -109,18 +108,30 @@ def true_conv_np(func, gauss1, obs, x):
     true_conv /= np.mean(true_conv) * obs.rect_area()
     return true_conv
 
+def true_conv_2d_np(func, gauss1, obs, x):
+    # n_points = x.shape[0]
+    # y_kernel = gauss1.pdf(x[n_points // 4:-n_points // 4])
+    y_kernel = gauss1.pdf(x)
+    y_func = func.pdf(x)
+    n = int(np.sqrt(x.shape[0]))
+    y_kernel = tf.reshape(y_kernel, (n, n))
+    y_func = tf.reshape(y_func, (n, n))
+    true_conv = scipy.signal.convolve(y_func, y_kernel, mode='same')
+    # true_conv = true_conv[n_points // 4:  n_points * 5 // 4]
+    true_conv /= np.mean(true_conv) * obs.rect_area()
+    return true_conv
 
-@pytest.mark.skip  # not yet implemented
+
+# @pytest.mark.skip  # not yet implemented
 def test_conv_2D_simple():
     zfit.run.set_graph_mode(False)  # TODO: remove, just for debugging
     n_points = 200
     obs1 = zfit.Space("obs1", limits=(-5, 5))
-    obs2 = zfit.Space("obs2", limits=(-6, 4))
+    obs2 = zfit.Space("obs2", limits=(-6, 6))
 
-    param1 = zfit.Parameter('param1', -3)
     param2 = zfit.Parameter('param2', 0.4)
     gauss1 = zfit.pdf.Gauss(0., 0.5, obs=obs1)
-    gauss22 = zfit.pdf.CrystalBall(0.3, param2, -0.2, 3, obs=obs2)
+    gauss22 = zfit.pdf.CrystalBall(0.0, param2, -0.2, 3, obs=obs2)
 
     obs1func = zfit.Space("obs1", limits=(4, 10))
     obs2func = zfit.Space("obs2", limits=(-6, 4))
@@ -148,8 +159,8 @@ def test_conv_2D_simple():
     probs = conv.pdf(x=linspace_data)
 
     # Numpy doesn't support ndim convolution?
-    true_probs = true_conv_np(func, gauss, obs=obs2d, x=linspace)
-    np.testing.assert_allclose(probs, true_probs, rtol=0.2, atol=0.1)
+    true_probs = true_conv_2d_np(func, gauss, obs=obs2d, x=linspace)
+    # np.testing.assert_allclose(probs, true_probs, rtol=0.2, atol=0.1)
     integral = conv.integrate(limits=obs_func)
     assert pytest.approx(1, rel=1e-3) == integral.numpy()
     probs_np = probs_rnd.numpy()
@@ -170,9 +181,10 @@ def test_conv_2D_simple():
     sample_nosample = conv_nosample.sample(npoints_sample)
     x, y = z.unstack_x(sample)
     xns, yns = z.unstack_x(sample_nosample)
-    assert True
-    # import matplotlib.pyplot as plt
-    # plt.figure()
+    import matplotlib.pyplot as plt
+    true_probsr = tf.reshape(true_probs, (n_points, n_points))
+    probsr = tf.reshape(probs, (n_points, n_points))
+    plt.figure()
     # plt.hist(x, bins=50, label='custom', alpha=0.5)
     # plt.hist(xns, bins=50, label='fallback', alpha=0.5)
     # plt.legend()

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -150,9 +150,9 @@ def test_conv_2D_simple():
     x, y = z.unstack_x(sample)
     xns, yns = z.unstack_x(sample_nosample)
 
-    import matplotlib.pyplot as plt
-    plt.figure()
-    plt.hist(x, bins=50, label='custom', alpha=0.5)
-    plt.hist(xns, bins=50, label='fallback', alpha=0.5)
-    plt.legend()
-    plt.show()
+    # import matplotlib.pyplot as plt
+    # plt.figure()
+    # plt.hist(x, bins=50, label='custom', alpha=0.5)
+    # plt.hist(xns, bins=50, label='fallback', alpha=0.5)
+    # plt.legend()
+    # plt.show()

--- a/tests/test_pdf_kde.py
+++ b/tests/test_pdf_kde.py
@@ -8,6 +8,9 @@ import zfit.models.dist_tfp
 import zfit.models.kde
 
 
+# noinspection PyUnresolvedReferences
+from zfit.core.testing import setup_function, teardown_function, tester
+
 @pytest.mark.skip()  # copy not yet implemented
 def test_copy_kde():
     size = 500

--- a/tests/test_pdf_polynomials.py
+++ b/tests/test_pdf_polynomials.py
@@ -8,9 +8,8 @@ import tensorflow_probability as tfp
 
 import zfit
 # noinspection PyUnresolvedReferences
-from zfit import z
+from zfit.core.testing import setup_function, teardown_function, tester
 
-# obs1_random = zfit.Space(obs="obs1", limits=(-1.05, 1.05))
 obs1_random = zfit.Space(obs="obs1", limits=(-1.5, 1.2))
 obs1 = zfit.Space(obs="obs1", limits=(-1, 1))
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -105,6 +105,20 @@ def create_test_pdf_overriden_gauss1():
 gaussian_dists = [create_gauss1, create_test_gauss1]
 
 
+def test_mutlidim_sampling():
+    zfit.run.set_graph_mode(False)
+    spaces = [zfit.Space(f'obs{i}', (i * 10, i * 10 + 6)) for i in range(4)]
+    pdfs = [GaussNoAnalyticSampling(obs=spaces[0], mu=3, sigma=1),
+            GaussNoAnalyticSampling(obs=spaces[2], mu=23, sigma=1),
+            UniformNoAnalyticSampling(obs=spaces[1], low=12, high=14),
+            UniformNoAnalyticSampling(obs=spaces[3], low=32, high=34),
+            ]
+    prod = zfit.pdf.ProductPDF(pdfs)
+    sample = prod.sample(n=20000)
+    for i, space in enumerate([p.space for p in pdfs]):
+        assert all(space.inside(sample.value()[:, i]))
+
+
 @pytest.mark.flaky(2)  # sampling
 @pytest.mark.parametrize('gauss_factory', gaussian_dists)
 def test_multiple_limits_sampling(gauss_factory):

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -834,7 +834,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         return sample
 
     @_BaseModel_register_check_support(True)
-    def _sample(self, n, limits):
+    def _sample(self, n, limits: ZfitSpace):
         raise SpecificFunctionNotImplementedError
 
     def sample(self, n: ztyping.nSamplingTypeIn = None,

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -27,8 +27,9 @@ from ..util import ztyping
 from ..util.cache import GraphCachable, invalidate_graph
 from ..util.container import convert_to_container
 from ..util.exception import LogicalUndefinedOperationError, ShapeIncompatibleError, \
-    ObsIncompatibleError, DataIsBatchedError
+    ObsIncompatibleError
 from ..util.temporary import TemporarilySet
+
 
 # TODO: make cut only once, then remember
 class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
@@ -154,7 +155,6 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
     def space(self) -> "ZfitSpace":
         return self._space
 
-
     # constructors
     @classmethod
     def from_root_iter(cls, path, treepath, branches=None, entrysteps=None, name=None, **kwargs):
@@ -172,7 +172,6 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
         dataset = tf.data.Dataset.from_generator(uproot_generator, output_types=ztypes.float)
         dataset.prefetch(1)
         return Data(dataset=dataset, name=name)
-
 
     @classmethod
     def from_root(cls, path: str, treepath: str, branches: List[str] = None, branches_alias: Dict = None,

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -27,7 +27,7 @@ from ..util import ztyping
 from ..util.cache import GraphCachable, invalidate_graph
 from ..util.container import convert_to_container
 from ..util.exception import LogicalUndefinedOperationError, ShapeIncompatibleError, \
-    ObsIncompatibleError
+    ObsIncompatibleError, WorkInProgressError
 from ..util.temporary import TemporarilySet
 
 
@@ -516,7 +516,7 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
 class SampleData(Data):
     _cache_counting = 0
 
-    def __init__(self, dataset: Union[tf.data.Dataset, "LightDataset"], sample_holder: tf.Tensor,
+    def __init__(self, dataset: Union[tf.data.Dataset, "LightDataset"],
                  obs: ztyping.ObsTypeInput = None, weights=None, name: str = None,
                  dtype: tf.DType = ztypes.float):
         super().__init__(dataset, obs, name=name, weights=weights, iterator_feed_dict=None, dtype=dtype)
@@ -531,7 +531,7 @@ class SampleData(Data):
     def from_sample(cls, sample: tf.Tensor, obs: ztyping.ObsTypeInput, name: str = None,
                     weights=None):
         dataset = LightDataset.from_tensor(sample)
-        return SampleData(dataset=dataset, sample_holder=sample, obs=obs, name=name, weights=weights)
+        return SampleData(dataset=dataset, obs=obs, name=name, weights=weights)
 
 
 class Sampler(Data):
@@ -637,26 +637,6 @@ class Sampler(Data):
         return f'<Sampler: {self.name} obs={self.obs}>'
 
 
-# def _dense_var_to_tensor(var, dtype=None, name=None, as_ref=False):
-#     return var._dense_var_to_tensor(dtype=dtype, name=name, as_ref=as_ref)
-
-
-# ops.register_tensor_conversion_function(Data, _dense_var_to_tensor)
-# fetch_function = lambda data: ([data.value()],
-#                                lambda val: val[0])
-# feed_function = lambda data, feed_val: [(data.value(), feed_val)]
-# feed_function_for_partial_run = lambda data: [data.value()]
-#
-# from tensorflow.python.client.session import register_session_run_conversion_functions
-#
-# # ops.register_dense_tensor_like_type()
-#
-# register_session_run_conversion_functions(tensor_type=Data, fetch_function=fetch_function,
-#                                           feed_function=feed_function,
-#                                           feed_function_for_partial_run=feed_function_for_partial_run)
-#
-# Data._OverloadAllOperators()
-
 register_tensor_conversion(Data, name='Data', overload_operators=True)
 
 
@@ -679,3 +659,16 @@ class LightDataset:
 
     def value(self):
         return self.tensor
+
+
+def add_samples(sample1, sample2, obs):
+    samples = [sample1, sample2]
+    if obs is None:
+        raise WorkInProgressError
+    # tensor = tf.math.accumulate_n([sample.value(obs.obs) for sample in samples])
+    tensor = sample1.value(obs=obs) + sample2.value(obs=obs)
+    if any([s.weights is not None for s in samples]):
+        raise WorkInProgressError("Cannot combine weights currently")
+    weights = None
+
+    return SampleData.from_sample(sample=tensor, obs=obs, weights=weights)

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 import tensorflow as tf
 import uproot
-from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 
 # from ..settings import types as ztypes
@@ -661,12 +660,14 @@ class LightDataset:
         return self.tensor
 
 
-def add_samples(sample1, sample2, obs):
+def add_samples(sample1: ZfitData, sample2: ZfitData, obs: ZfitSpace, shuffle: bool = False):
     samples = [sample1, sample2]
     if obs is None:
         raise WorkInProgressError
-    # tensor = tf.math.accumulate_n([sample.value(obs.obs) for sample in samples])
-    tensor = sample1.value(obs=obs) + sample2.value(obs=obs)
+    sample2 = sample2.value(obs=obs)
+    if shuffle:
+        sample2 = tf.random.shuffle(sample2)
+    tensor = sample1.value(obs=obs) + sample2
     if any([s.weights is not None for s in samples]):
         raise WorkInProgressError("Cannot combine weights currently")
     weights = None

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -248,7 +248,7 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
             limits=new_limits,
             dtype=dtype)
 
-        rnd_sample = Data.from_tensor(obs=limits, tensor=rnd_sample)
+        rnd_sample = Data.from_tensor(obs=new_limits, tensor=rnd_sample)
         n_drawn = tf.cast(n_drawn, dtype=tf.int32)
         if run.numeric_checks: tf.debugging.assert_non_negative(n_drawn)
         n_total_drawn += n_drawn

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -231,7 +231,7 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
             # TODO: remove below? was there due to overflow in tf?
             # safe_to_produce = tf.maximum(max_produce_cap, n_to_produce)  # protect against overflow, n_to_prod -> neg.
             n_to_produce = tf.minimum(n_to_produce, max_produce_cap)  # introduce a cap to force serial
-            new_limits = limits
+            new_limits = limits  # because limits in the vector space case can change
         else:
             # TODO(Mayou36): add cap for n_to_produce here as well
             if multiple_limits:

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -5,24 +5,21 @@ from typing import Callable, Union, Iterable, List, Optional, Tuple
 import tensorflow as tf
 from tensorflow_probability import distributions as tfd
 
-import zfit
-from zfit import z
-
-ztf = z
-from zfit.core.interfaces import ZfitPDF
-from zfit.util import ztyping
-from zfit.util.exception import WorkInProgressError
-from .. import settings
-from ..util.container import convert_to_container
+from .data import Data
+from .interfaces import ZfitPDF
 from .space import Space
+from .. import z, settings
 from ..settings import ztypes, run
+from ..util import ztyping
+from ..util.container import convert_to_container
+from ..util.exception import WorkInProgressError
 
 
 class UniformSampleAndWeights:
     def __call__(self, n_to_produce: Union[int, tf.Tensor], limits: Space, dtype):
         rnd_samples = []
         thresholds_unscaled_list = []
-        weights = tf.broadcast_to(ztf.constant(1., shape=(1,)), shape=(n_to_produce,))
+        weights = tf.broadcast_to(z.constant(1., shape=(1,)), shape=(n_to_produce,))
         n_produced = tf.constant(0)
         for i, space in enumerate(limits):
             lower, upper = space.rect_limits  # TODO: remove new space
@@ -35,7 +32,7 @@ class UniformSampleAndWeights:
                     tot_area = limits.rect_area()
                     frac = (space.rect_area() / tot_area)[0]
                 n_partial_to_produce = tf.cast(
-                    ztf.to_real(n_to_produce) * ztf.to_real(frac), dtype=tf.int32)  # TODO(Mayou36): split right!
+                    z.to_real(n_to_produce) * z.to_real(frac), dtype=tf.int32)  # TODO(Mayou36): split right!
 
             sample_drawn = tf.random.uniform(shape=(n_partial_to_produce, limits.n_obs + 1),
                                              # + 1 dim for the function value
@@ -210,7 +207,7 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
     @z.function(wraps='tensor')
     def sample_body(n, sample, n_produced=0, n_total_drawn=0, eff=1.0, is_sampled=None, weights_scaling=0.,
                     weights_maximum=0., prob_maximum=0., n_min_to_produce=10000):
-        eff = tf.reduce_max(input_tensor=[eff, ztf.to_real(1e-6)])
+        eff = tf.reduce_max(input_tensor=[eff, z.to_real(1e-6)])
 
         n_to_produce = n - n_produced
 
@@ -225,7 +222,7 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
 
         if dynamic_array_shape:
             # TODO: move all this fixed numbers out into settings
-            n_to_produce = tf.cast(ztf.to_real(n_to_produce) / eff * 1.1, dtype=tf.int32) + 3  # just to make sure
+            n_to_produce = tf.cast(z.to_real(n_to_produce) / eff * 1.1, dtype=tf.int32) + 3  # just to make sure
             n_to_produce = tf.maximum(n_to_produce, n_min_to_produce)
             n_min_to_produce -= tf.maximum(n_to_produce, 0)  # reduce to minimum of 0
             # TODO: adjustable efficiency cap for memory efficiency (prevent too many samples at once produced)
@@ -251,6 +248,7 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
             limits=new_limits,
             dtype=dtype)
 
+        rnd_sample = Data.from_tensor(obs=limits, tensor=rnd_sample)
         n_drawn = tf.cast(n_drawn, dtype=tf.int32)
         if run.numeric_checks: tf.debugging.assert_non_negative(n_drawn)
         n_total_drawn += n_drawn
@@ -360,17 +358,17 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
         sample_new = sample.scatter(indices=tf.cast(indices, dtype=tf.int32), value=filtered_sample)
 
         # efficiency (estimate) of how many samples we get
-        eff = tf.reduce_max(input_tensor=[ztf.to_real(n_produced_new), ztf.to_real(1.)]) / tf.reduce_max(
-            input_tensor=[ztf.to_real(n_total_drawn), ztf.to_real(1.)])
+        eff = tf.reduce_max(input_tensor=[z.to_real(n_produced_new), z.to_real(1.)]) / tf.reduce_max(
+            input_tensor=[z.to_real(n_total_drawn), z.to_real(1.)])
         return (
             n, sample_new, n_produced_new, n_total_drawn, eff, is_sampled, weights_scaling, weights_maximum,
             prob_maximum, n_min_to_produce
         )
 
-    efficiency_estimation = ztf.to_real(efficiency_estimation)
-    weights_scaling = ztf.constant(0.)
-    weights_maximum = ztf.constant(0.)
-    prob_maximum = ztf.constant(0.)
+    efficiency_estimation = z.to_real(efficiency_estimation)
+    weights_scaling = z.constant(0.)
+    weights_maximum = z.constant(0.)
+    prob_maximum = z.constant(0.)
     loop_vars = (
         n, sample, inital_n_produced, initial_n_drawn, efficiency_estimation, initial_is_sampled, weights_scaling,
         weights_maximum, prob_maximum, n_min_to_produce)

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -222,7 +222,7 @@ def accept_reject_sample(prob: Callable, n: int, limits: Space,
 
         if dynamic_array_shape:
             # TODO: move all this fixed numbers out into settings
-            n_to_produce = tf.cast(z.to_real(n_to_produce) / eff * 1.1, dtype=tf.int32) + 3  # just to make sure
+            n_to_produce = tf.cast(z.to_real(n_to_produce) / eff * 1.01, dtype=tf.int32) + 3  # just to make sure
             n_to_produce = tf.maximum(n_to_produce, n_min_to_produce)
             n_min_to_produce -= tf.maximum(n_to_produce, 0)  # reduce to minimum of 0
             # TODO: adjustable efficiency cap for memory efficiency (prevent too many samples at once produced)

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -1,44 +1,80 @@
 #  Copyright (c) 2020 zfit
-from typing import Optional
+from typing import Optional, Union
 
 import tensorflow as tf
 import tensorflow_addons as tfa
 import tensorflow_probability as tfp
 
 from .functor import BaseFunctor
-from ..core.basepdf import BasePDF
+from ..core.interfaces import ZfitPDF
 from ..util import exception, ztyping
 from ..util.exception import WorkInProgressError, ShapeIncompatibleError
 
 
 class FFTConvV1(BaseFunctor):
-    def __init__(self, func: BasePDF, kernel: BasePDF,
-                 limits_func: ztyping.ObsTypeInput = None, limits_kernel: ztyping.ObsTypeInput = None,
-                 obs: ztyping.ObsTypeInput = None, interpolation: Optional[str] = None,
-                 npoints: int = None, name: str = "FFTConv1DV1"):
-        """Numerical Convolution pdf of *func* convoluted with *kernel*.
+
+    def __init__(self,
+                 func: ZfitPDF,
+                 kernel: ZfitPDF,
+                 n: int = None,
+                 limits_func: Union[ztyping.LimitsType, float] = None,
+                 limits_kernel: ztyping.LimitsType = None,
+                 interpolation: Optional[str] = None,
+                 obs: ztyping.ObsTypeInput = None,
+                 name: str = "FFTConvV1"):
+        """*EXPERIMENTAL* Numerical Convolution pdf of `func` convoluted with `kernel` using FFT
+
+
 
         Args:
-            func (:py:class:`zfit.pdf.BasePDF`): PDF  with `pdf` method that takes x and returns the function value.
+            func: PDF  with `pdf` method that takes x and returns the function value.
                 Here x is a `Data` with the obs and limits of *limits*.
-            kernel (:py:class:`zfit.pdf.BasePDF`): PDF with `pdf` method that takes x acting as the kernel.
+            kernel: PDF with `pdf` method that takes x acting as the kernel.
                 Here x is a `Data` with the obs and limits of *limits*.
-            limits_func (:py:class:`zfit.Space`): Limits for the numerical integration.
-            obs (:py:class:`zfit.Space`): Observables of the class
-            npoints (int): Number of points to evaluate the kernel and pdf at
-            name (str): Human readable name of the pdf
+            n: Number of points _per dimension_ to evaluate the kernel and pdf at.
+                The higher the number of points, the more accurate the convolution at the cost
+                of computing time. If `None`, a heuristic is used (default to 100 in 1 dimension).
+            limits_func: Specify in which limits the `func` should
+                be evaluated for the convolution:
+                - If `None`, the limits from the `func` are used and extended by a
+                 default value (relative 0.2).
+                - If float: the fraction of the limit do be extended. 0 means no extension,
+                  1 would extend the limits to each side by the same size resulting in
+                  a tripled size (for 1 dimension).
+                  As an example, the limits (1, 5) with a `limits_func` of 0.5 would result in
+                  effective limits of (-1, 7), as 0.5 * (5 - 1) = 2 has been added to each side.
+                - If a space with limits is used, this is taken as the range.
+            limits_kernel: the limits of the kernel. Usually not needed to change and automatically
+                taken from the kernel.
+            interpolation: Specify the method that is used for interpolation. Available methods are:
+                - 'linear': this is the default for any convolution > 1 dimensional. It is a
+                  fast, linear interpolation between the evaluated points and approximates the
+                  function reasonably well in case of high number of points and a smooth response.
+                - 'spline' or `f'spline{order}'`: a spline interpolation with polynomials. If
+                  the order is not specified, a default is used. To specify the order, an integer
+                  should be followed the word 'spline' as e.g. in 'spline3' to use a spline of
+                  order three.
+                  This method is considerably more computationally intensive as it requires to solve
+                  a system of equations. When using 1000+ points this can affect the runtime critical.
+                  However, it provides better solutions that are smooth even with less points
+                  than for a linear interpolation.
+            obs: Observables of the class. If not specified, automatically taken from `func`
+            name: Human readable name of the PDF
         """
         valid_interpolations = ('spline', 'linear')
 
         obs = func.space if obs is None else obs
         super().__init__(obs=obs, pdfs=[func, kernel], params={}, name=name)
-        stretch_limits_func = False
-        # stretch_limits_kernel = False
+
+        buffer = False  # extra zone to avoid boundary effects
         if limits_func is None:
+            buffer = 0.2
             limits_func = func.space
-            stretch_limits_func = True
+        elif isinstance(limits_func, (float, int)):
+            buffer = limits_func
+            limits_func = func.space
+
         if limits_kernel is None:
-            # stretch_limits_kernel = True
             limits_kernel = kernel.space
         limits_func = self._check_input_limits(limits=limits_func)
         limits_kernel = self._check_input_limits(limits=limits_kernel)
@@ -61,69 +97,53 @@ class FFTConvV1(BaseFunctor):
         if interpolation is None:
             interpolation = 'spline' if self.n_obs == 1 else 'linear'
 
+        spline_order = 3  # default
+        if ':' in interpolation:
+            interpolation, spline_order = interpolation.split(':')
+            spline_order = int(spline_order)
         if interpolation not in valid_interpolations:
             raise ValueError(f"`interpolation` {interpolation} not known. Has to be one "
                              f"of the following: {valid_interpolations}")
         self._interpolation = interpolation
+        self._spline_order = spline_order
 
-        if npoints is None:
+        if n is None:
             npoints_scaling = 100
-            npoints = tf.cast(limits_kernel.rect_area() / limits_func.rect_area() * npoints_scaling, tf.int32)[0]
-            npoints = max(npoints, npoints_scaling)
-            tf.assert_less(npoints, tf.cast(1e6, tf.int32),
+            n = tf.cast(limits_kernel.rect_area() / limits_func.rect_area() * npoints_scaling, tf.int32)[0]
+            n = max(n, npoints_scaling)
+            tf.assert_less(n - 1.,  # so that for three dimension it's 999'999, not 10^6
+                           tf.cast(1e6, tf.int32),
                            message="Number of points automatically calculated to be used for the FFT"
                                    " based convolution exceeds 1e6. If you want to use this number - "
-                                   "or an even higher value - use explicitly the `npoints` argument.")
-        x_kernels = []
-        x_funcs = []
+                                   "or an even higher value - use explicitly the `n` argument.")
 
         limit_func = limits_func.with_obs(obs)
         lower, upper = limit_func.rect_limits
-        if stretch_limits_func:
+        if buffer:
             areas = upper - lower
-            areas *= 0.2  # add to limits this fraction
+            areas *= buffer  # add to limits this fraction
             lower -= areas
             upper += areas
-        x_funcs = tf.linspace(lower, upper, npoints)
-        x_kernels = x_funcs - (lower + upper) / 2
 
-        # for ob in self.obs:
-        #     limit_func = limits_func.with_obs(ob)
-        #     x_func_min, x_func_max = limit_func.limit1d
-        #     if stretch_limits_func:
-        #         add_to_limit = limit_func.rect_area()[0] * 0.2
-        #         x_func_min -= add_to_limit
-        #         x_func_max += add_to_limit
-        #     x_func = tf.linspace(x_func_min, x_func_max, npoints)
-        #     x_shifted = x_func - (x_func_max + x_func_min) / 2
-        #     # x_kernel = limits_kernel.filter(x_shifted)
-        #     x_kernel = x_shifted
-        #     x_kernels.append(x_kernel)
-        #     x_funcs.append(x_func)
+        self._npoints = n
+        self._xfunc_lower = lower
+        self._xfunc_upper = upper
+        self._npoints = n
+
+    # @z.function
+    def _unnormalized_pdf(self, x):
+        lower, upper = self._xfunc_lower, self._xfunc_upper
+        x_funcs = tf.linspace(lower, upper, self._npoints)
+        x_kernels = x_funcs - (lower + upper) / 2
 
         x_kernel = - tf.transpose(tf.meshgrid(*tf.unstack(x_kernels, axis=-1),
                                               indexing='ij'))
         x_func = - tf.transpose(tf.meshgrid(*tf.unstack(x_funcs, axis=-1),
                                             indexing='ij'))
-        self._xfunc_lower = lower
-        self._xfunc_upper = upper
-        self._npoints = npoints
-        self._xfunc = x_func
-        self._xkernel = x_kernel
 
-    # @z.function
-    def _unnormalized_pdf(self, x):
-        # x = z.unstack_x(x)
-        y_func = self.pdfs[0].pdf(self._xfunc)
-        y_kernel = self.pdfs[1].pdf(self._xkernel)
+        y_func = self.pdfs[0].pdf(x_func)
+        y_kernel = self.pdfs[1].pdf(x_kernel)
 
-        # conv = tf.nn.conv1d(
-        #     input=tf.reshape(y_func, (1, -1, 1)),
-        #     filters=tf.reshape(y_kernel, (-1, 1, 1)),
-        #     stride=1,
-        #     padding='SAME',
-        #     data_format='NWC'
-        # )
         npoints = self._npoints
         obs_dims = [npoints] * self.n_obs
         new_shape = (1, *obs_dims, 1)
@@ -132,22 +152,16 @@ class FFTConvV1(BaseFunctor):
             filters=tf.reshape(y_kernel, (*obs_dims, 1, 1)),
             strides=1,
             padding='SAME',
-            # data_format='NWC'
         )
 
-        # conv = tf.reshape(conv, (-1,))
-        # prob = tfp.math.interp_regular_1d_grid(x=x,
-        #                                        x_ref_min=self._x_func_min,
-        #                                        x_ref_max=self._x_func_max,
-        #                                        y_ref=conv)
-        train_points = tf.reshape(self._xfunc, (1, -1, self.n_obs))
+        train_points = tf.reshape(x_func, (1, -1, self.n_obs))
         query_points = tf.expand_dims(x.value(), axis=0)
         if self.interpolation == 'spline':
             conv_points = tf.reshape(conv, (1, -1, 1))
             prob = tfa.image.interpolate_spline(train_points=train_points,
                                                 train_values=conv_points,
                                                 query_points=query_points,
-                                                order=3)
+                                                order=self._spline_order)
             prob = prob[0, ..., 0]
         elif self.interpolation == 'linear':
             prob = tfp.math.batch_interp_regular_nd_grid(x=query_points[0],  # they are inverted due to the convolution

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -11,7 +11,7 @@ from ..util import exception, ztyping
 from ..util.exception import WorkInProgressError, ShapeIncompatibleError
 
 
-class FFTConv1DV1(BaseFunctor):
+class FFTConvV1(BaseFunctor):
     def __init__(self, func: BasePDF, kernel: BasePDF,
                  limits_func: ztyping.ObsTypeInput = None, limits_kernel: ztyping.ObsTypeInput = None,
                  obs: ztyping.ObsTypeInput = None, interpolation: Optional[str] = None,

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -206,6 +206,8 @@ class FFTConvPDFV1(BaseFunctor):
         y_kernel = tf.reverse(y_kernel, axis=range(self.n_obs))
         y_func_rect = tf.reshape(y_func, func_dims)
         y_kernel_rect = tf.reshape(y_kernel, kernel_dims)
+
+        # needed for multi dims?
         # if self.n_obs == 2:
         #     y_kernel_rect = tf.linalg.adjoint(y_kernel_rect)
         y_func_rect_conv = tf.reshape(y_func_rect, (1, *func_dims, 1))
@@ -218,14 +220,14 @@ class FFTConvPDFV1(BaseFunctor):
             padding='SAME',
         )
 
-        if self.n_obs == 2:
-            conv = tf.linalg.adjoint(conv[0, ..., 0])[None, ..., None]
+        # needed for multidims?
+        # if self.n_obs == 2:
+        #     conv = tf.linalg.adjoint(conv[0, ..., 0])[None, ..., None]
         # conv = scipy.signal.convolve(
         #     y_func_rect,
         #     y_kernel_rect,
         #     mode='same'
         # )[None, ..., None]
-        # train_points = tf.reshape(x_func, (1, -1, self.n_obs))
         train_points = tf.expand_dims(x_func, axis=0)
         query_points = tf.expand_dims(x.value(), axis=0)
         if self.conv_interpolation == 'spline':

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -1,6 +1,7 @@
 #  Copyright (c) 2020 zfit
 import tensorflow as tf
 import tensorflow_probability as tfp
+import tensorflow_addons as tfa
 
 from .functor import BaseFunctor
 from .. import z
@@ -78,9 +79,15 @@ class FFTConv1DV1(BaseFunctor):
             padding='SAME',
             data_format='NWC'
         )
-        conv = tf.reshape(conv, (-1,))
-        prob = tfp.math.interp_regular_1d_grid(x=x,
-                                               x_ref_min=self._x_func_min,
-                                               x_ref_max=self._x_func_max,
-                                               y_ref=conv)
+        # conv = tf.reshape(conv, (-1,))
+        # prob = tfp.math.interp_regular_1d_grid(x=x,
+        #                                        x_ref_min=self._x_func_min,
+        #                                        x_ref_max=self._x_func_max,
+        #                                        y_ref=conv)
+        prob = tfa.image.interpolate_spline(train_points=tf.reshape(self._x_func, (1, -1, 1)),
+                                            train_values=conv,
+                                            query_points=tf.reshape(x, (1, -1, 1)),
+                                            order=4)
+        prob = tf.reshape(prob, (-1,))
+
         return prob

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -59,7 +59,7 @@ class FFTConv1DV1(BaseFunctor):
                            message="Number of points automatically calculated to be used for the FFT"
                                    " based convolution exceeds 1e6. If you want to use this number - "
                                    "or an even higher value, use explicitly the `npoints` argument.")
-        x_func_min, x_func_max = limits_func.rect_limits
+        x_func_min, x_func_max = limits_func.limit1d
         if stretch_limits_func:
             add_to_limit = limits_func.rect_area()[0] * 0.2
             x_func_min -= add_to_limit

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -58,7 +58,7 @@ class FFTConv1DV1(BaseFunctor):
             tf.assert_less(npoints, tf.cast(1e6, tf.int32),
                            message="Number of points automatically calculated to be used for the FFT"
                                    " based convolution exceeds 1e6. If you want to use this number - "
-                                   "or an even higher value, use explicitly the `npoints` argument.")
+                                   "or an even higher value - use explicitly the `npoints` argument.")
         x_func_min, x_func_max = limits_func.limit1d
         if stretch_limits_func:
             add_to_limit = limits_func.rect_area()[0] * 0.2

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -1,0 +1,86 @@
+#  Copyright (c) 2020 zfit
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+from .functor import BaseFunctor
+from .. import z
+from ..core.basepdf import BasePDF
+from ..util import exception, ztyping
+from ..util.exception import WorkInProgressError
+
+
+class FFTConv1DV1(BaseFunctor):
+    def __init__(self, func: BasePDF, kernel: BasePDF,
+                 limits_func: ztyping.ObsTypeInput = None, limits_kernel: ztyping.ObsTypeInput = None,
+                 obs: ztyping.ObsTypeInput = None,
+                 npoints: int = None, name: str = "FFTConv1DV1"):
+        """Numerical Convolution pdf of *func* convoluted with *kernel*.
+
+        Args:
+            func (:py:class:`zfit.pdf.BasePDF`): PDF  with `pdf` method that takes x and returns the function value.
+                Here x is a `Data` with the obs and limits of *limits*.
+            kernel (:py:class:`zfit.pdf.BasePDF`): PDF with `pdf` method that takes x acting as the kernel.
+                Here x is a `Data` with the obs and limits of *limits*.
+            limits_func (:py:class:`zfit.Space`): Limits for the numerical integration.
+            obs (:py:class:`zfit.Space`): Observables of the class
+            npoints (int): Number of points to evaluate the kernel and pdf at
+            name (str): Human readable name of the pdf
+        """
+        obs = func.space if obs is None else obs
+        super().__init__(obs=obs, pdfs=[func, kernel], params={}, name=name)
+        stretch_limits_func = False
+        # stretch_limits_kernel = False
+        if limits_func is None:
+            limits_func = func.space
+            stretch_limits_func = True
+        if limits_kernel is None:
+            # stretch_limits_kernel = True
+            limits_kernel = kernel.space
+        limits_func = self._check_input_limits(limits=limits_func)
+        limits_kernel = self._check_input_limits(limits=limits_kernel)
+        if limits_func.n_limits == 0:
+            raise exception.LimitsNotSpecifiedError("obs have to have limits to define where to integrate over.")
+        if limits_func.n_limits > 1:
+            raise WorkInProgressError("Multiple Limits not implemented")
+
+        if npoints is None:
+            npoints_scaling = 100
+            npoints = tf.cast(limits_kernel.rect_area() / limits_func.rect_area() * npoints_scaling, tf.int32)[0]
+            npoints = max(npoints, npoints_scaling)
+            tf.assert_less(npoints, tf.cast(1e6, tf.int32),
+                           message="Number of points automatically calculated to be used for the FFT"
+                                   " based convolution exceeds 1e6. If you want to use this number - "
+                                   "or an even higher value, use explicitly the `npoints` argument.")
+        x_func_min, x_func_max = limits_func.limit1d
+        if stretch_limits_func:
+            add_to_limit = limits_func.rect_area()[0] * 0.2
+            x_func_min -= add_to_limit
+            x_func_max += add_to_limit
+        x_func = tf.linspace(x_func_min, x_func_max, npoints)
+        x_shifted = x_func - (x_func_max + x_func_min) / 2
+        x_kernel = limits_kernel.filter(x_shifted)
+        self._x_func_min = x_func_min
+        self._x_func_max = x_func_max
+        self._x_func = x_func
+        self._x_kernel = -x_kernel
+        # self._npoints = npoints
+
+    # @z.function
+    def _unnormalized_pdf(self, x):
+        x = z.unstack_x(x)
+        y_func = self.pdfs[0].pdf(self._x_func)
+        y_kernel = self.pdfs[1].pdf(self._x_kernel)
+
+        conv = tf.nn.conv1d(
+            input=tf.reshape(y_func, (1, -1, 1)),
+            filters=tf.reshape(y_kernel, (-1, 1, 1)),
+            stride=1,
+            padding='SAME',
+            data_format='NWC'
+        )
+        conv = tf.reshape(conv, (-1,))
+        prob = tfp.math.interp_regular_1d_grid(x=x,
+                                               x_ref_min=self._x_func_min,
+                                               x_ref_max=self._x_func_max,
+                                               y_ref=conv)
+        return prob

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -75,7 +75,6 @@ class FFTConv1DV1(BaseFunctor):
             x_kernels.append(x_kernel)
             x_funcs.append(x_func)
 
-        from zfit import Data
         obs_kernel = limits_kernel.with_obs(self.obs)
         x_kernel = - tf.reshape(tf.meshgrid(*x_kernels, indexing='ij'), (-1, self.n_obs))
         # x_kernel = Data.from_tensor(obs=obs_kernel, tensor=-x_kernel)

--- a/zfit/models/functor.py
+++ b/zfit/models/functor.py
@@ -295,7 +295,7 @@ class ProductPDF(BaseFunctor):  # TODO: compose of smaller Product PDF by disass
 
     def _pdf(self, x, norm_range):
         equal_norm_ranges = len(set([pdf.norm_range for pdf in self.pdfs] + [norm_range])) == 1
-        if all(not dep for dep in self._model_same_obs) and equal_norm_ranges:
+        if not any(self._model_same_obs) and equal_norm_ranges:
 
             probs = [pdf.pdf(x=x) for pdf in self.pdfs]
             return z.convert_to_tensor(functools.reduce(operator.mul, probs))

--- a/zfit/models/functor.py
+++ b/zfit/models/functor.py
@@ -294,7 +294,7 @@ class ProductPDF(BaseFunctor):  # TODO: compose of smaller Product PDF by disass
         # return tf.math.reduce_prod(probs, axis=0)
 
     def _pdf(self, x, norm_range):
-        equal_norm_ranges = len(set([pdf.norm_range for pdf in self.pdfs] + [norm_range])) == 1
+        equal_norm_ranges = len(set([pdf.norm_range for pdf in self.pdfs] + [norm_range])) == 1  # all equal
         if not any(self._model_same_obs) and equal_norm_ranges:
 
             probs = [pdf.pdf(x=x) for pdf in self.pdfs]

--- a/zfit/pdf.py
+++ b/zfit/pdf.py
@@ -8,7 +8,7 @@ from .models.kde import GaussianKDE1DimV1
 from .models.physics import CrystalBall, DoubleCB
 from .models.polynomials import Chebyshev, Legendre, Chebyshev2, Hermite, Laguerre, RecursivePolynomial
 from .models.special import ZPDF, SimplePDF, SimpleFunctorPDF
-from .models.convolution import FFTConv1DV1
+from .models.convolution import FFTConvV1
 
 __all__ = ['BasePDF', 'BaseFunctor',
            'Exponential',
@@ -17,6 +17,6 @@ __all__ = ['BasePDF', 'BaseFunctor',
            "Chebyshev", "Legendre", "Chebyshev2", "Hermite", "Laguerre", "RecursivePolynomial",
            'ProductPDF', 'SumPDF',
            'GaussianKDE1DimV1',
-           'FFTConv1DV1',
+           'FFTConvV1',
            'ZPDF', 'SimplePDF', 'SimpleFunctorPDF'
            ]

--- a/zfit/pdf.py
+++ b/zfit/pdf.py
@@ -8,6 +8,7 @@ from .models.kde import GaussianKDE1DimV1
 from .models.physics import CrystalBall, DoubleCB
 from .models.polynomials import Chebyshev, Legendre, Chebyshev2, Hermite, Laguerre, RecursivePolynomial
 from .models.special import ZPDF, SimplePDF, SimpleFunctorPDF
+from .models.convolution import FFTConv1DV1
 
 __all__ = ['BasePDF', 'BaseFunctor',
            'Exponential',
@@ -16,5 +17,6 @@ __all__ = ['BasePDF', 'BaseFunctor',
            "Chebyshev", "Legendre", "Chebyshev2", "Hermite", "Laguerre", "RecursivePolynomial",
            'ProductPDF', 'SumPDF',
            'GaussianKDE1DimV1',
+           'FFTConv1DV1',
            'ZPDF', 'SimplePDF', 'SimpleFunctorPDF'
            ]

--- a/zfit/pdf.py
+++ b/zfit/pdf.py
@@ -8,7 +8,7 @@ from .models.kde import GaussianKDE1DimV1
 from .models.physics import CrystalBall, DoubleCB
 from .models.polynomials import Chebyshev, Legendre, Chebyshev2, Hermite, Laguerre, RecursivePolynomial
 from .models.special import ZPDF, SimplePDF, SimpleFunctorPDF
-from .models.convolution import FFTConvV1
+from .models.convolution import FFTConvPDFV1
 
 __all__ = ['BasePDF', 'BaseFunctor',
            'Exponential',
@@ -17,6 +17,6 @@ __all__ = ['BasePDF', 'BaseFunctor',
            "Chebyshev", "Legendre", "Chebyshev2", "Hermite", "Laguerre", "RecursivePolynomial",
            'ProductPDF', 'SumPDF',
            'GaussianKDE1DimV1',
-           'FFTConvV1',
+           'FFTConvPDFV1',
            'ZPDF', 'SimplePDF', 'SimpleFunctorPDF'
            ]


### PR DESCRIPTION
Adds a one dimensional convolution PDF


## Proposed Changes

  - add a discrete/FFT convolution (using `tf.nn.convolution`) and interpolate (linear/splines)

## Tests added

  - multiple to check for sampling (special, just adding the dataset) and shape against `scipy.signal.convolve`
  
## Checklist

 - [x] change approved
 - [x] implementation finished
 - [x] correct namespace imported
 - [x] tests added
 - [x] CHANGELOG updated

