### PR TITLE
Addition of Poisson 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Thanks
 Major Features and Improvements
 -------------------------------
 - completely new doc design
+- new Poisson PDF
 
 Breaking changes
 ------------------

--- a/tests/test_pdf_poisson.py
+++ b/tests/test_pdf_poisson.py
@@ -29,4 +29,4 @@ def test_poisson():
 
     samples = poisson.sample(1000).numpy()
 
-    assert np.std(samples) == pytest.isclose(50**0.5)
+    assert np.std(samples) == pytest.approx(50**0.5, rel=0.05)

--- a/tests/test_pdf_poisson.py
+++ b/tests/test_pdf_poisson.py
@@ -1,0 +1,32 @@
+#  Copyright (c) 2020 zfit
+import numpy as np
+import pytest
+
+import zfit
+from zfit import Parameter
+# noinspection PyUnresolvedReferences
+from zfit.core.testing import setup_function, teardown_function, tester
+from zfit.models.dist_tfp import Poisson
+
+lamb_true = 50
+
+obs = zfit.Space(obs="Nobs", limits=(0, 200))
+
+test_values = np.random.uniform(low=0, high=100, size=100)
+
+
+def create_poisson():
+    N = Parameter("N", lamb_true)
+    poisson = Poisson(obs=obs, lamb=N)
+    return poisson
+
+
+def test_poisson():
+    poisson = create_poisson()
+
+    probs1 = poisson.pdf(x=test_values)
+    probs1 = probs1.numpy()
+
+    samples = poisson.sample(1000).numpy()
+
+    assert np.std(samples) == pytest.isclose(50**0.5)

--- a/tests/test_pdf_poisson.py
+++ b/tests/test_pdf_poisson.py
@@ -27,6 +27,6 @@ def test_poisson():
     probs1 = poisson.pdf(x=test_values)
     probs1 = probs1.numpy()
 
-    samples = poisson.sample(1000).numpy()
+    samples = poisson.sample(10000).numpy()
 
     assert np.std(samples) == pytest.approx(50**0.5, rel=0.05)

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -282,3 +282,30 @@ class Cauchy(WrapDistribution):
         super().__init__(distribution=distribution, dist_params=dist_params,
                          obs=obs, params=params, name=name)
 
+
+class Poisson(WrapDistribution):
+    _N_OBS = 1
+
+    def __init__(self,
+                 lamb: ztyping.ParamTypeInput,
+                 obs: ztyping.ObsTypeInput,
+                 name: str = "Poisson"):
+        """
+        Poisson distribution, parametrized with an event rate parameter (lamb).
+
+        The probability mass function of the Poisson distribution is given by
+
+        .. math::
+            f(x, \\lambda) = \\frac{\\lambda^{x}e^{-\\lambda}}{x!}
+
+        Args:
+            lamb: the event rate
+            obs: Observables and normalization range the pdf is defined in
+            name: Name of the PDF
+        """
+        (lamb,) = self._check_input_params(lamb)
+        params = OrderedDict((('lamb', lamb),))
+        dist_params = dict(rate=lamb)
+        distribution = tfp.distributions.Poisson
+        super().__init__(distribution=distribution, dist_params=dist_params,
+                         obs=obs, params=params, name=name)

--- a/zfit/pdf.py
+++ b/zfit/pdf.py
@@ -2,7 +2,7 @@
 
 from .core.basepdf import BasePDF
 from .models.basic import Exponential
-from .models.dist_tfp import Gauss, Uniform, WrapDistribution, TruncatedGauss, Cauchy
+from .models.dist_tfp import Gauss, Uniform, WrapDistribution, TruncatedGauss, Cauchy, Poisson
 from .models.functor import ProductPDF, SumPDF, BaseFunctor
 from .models.kde import GaussianKDE1DimV1
 from .models.physics import CrystalBall, DoubleCB
@@ -12,7 +12,7 @@ from .models.special import ZPDF, SimplePDF, SimpleFunctorPDF
 __all__ = ['BasePDF', 'BaseFunctor',
            'Exponential',
            'CrystalBall', 'DoubleCB',
-           'Gauss', 'Uniform', 'TruncatedGauss', 'WrapDistribution', 'Cauchy',
+           'Gauss', 'Uniform', 'TruncatedGauss', 'WrapDistribution', 'Cauchy', 'Poisson',
            "Chebyshev", "Legendre", "Chebyshev2", "Hermite", "Laguerre", "RecursivePolynomial",
            'ProductPDF', 'SumPDF',
            'GaussianKDE1DimV1',


### PR DESCRIPTION
## Proposed Changes

  - Add the Poisson PDF, this will be useful for analysts who want to do inferences with `hepstats`  with counting analysis instead of shape analysis (see https://github.com/scikit-hep/hepstats/pull/33). And maybe for other cases ... 🤷🏻‍♂️

## Tests added

  - test_pdf_poisson.py
  
## Checklist

 - [x] change approved
 - [x] implementation finished
 - [x] correct namespace imported
 - [x] tests added
 - [x] CHANGELOG updated

