### PR TITLE
Modification of Poisson PDF to solve #275

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Depreceations
 
 Bug fixes and small changes
 ---------------------------
+- Fix issue when using a `ComposedParameter` as the `rate` argument of a `Poisson` PDF
 
 
 Experimental

--- a/tests/test_pdf_poisson.py
+++ b/tests/test_pdf_poisson.py
@@ -21,8 +21,22 @@ def create_poisson():
     return poisson
 
 
-def test_poisson():
-    poisson = create_poisson()
+def create_poisson_composed_rate():
+    N1 = Parameter("N1", lamb_true/2)
+    N2 = Parameter("N2", lamb_true/2)
+    N = zfit.param.ComposedParameter("N", lambda n1, n2: n1 + n2, params=[N1, N2])
+
+    poisson = Poisson(obs=obs, lamb=N)
+    return poisson
+
+
+@pytest.mark.parametrize('composed_rate', [False, True])
+def test_poisson(composed_rate):
+
+    if composed_rate:
+        poisson = create_poisson_composed_rate()
+    else:
+        poisson = create_poisson()
 
     probs1 = poisson.pdf(x=test_values)
     probs1 = probs1.numpy()

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -305,7 +305,7 @@ class Poisson(WrapDistribution):
         """
         (lamb,) = self._check_input_params(lamb)
         params = OrderedDict((('lamb', lamb),))
-        dist_params = dict(rate=lamb)
+        dist_params = lambda: dict(rate=lamb.value())
         distribution = tfp.distributions.Poisson
         super().__init__(distribution=distribution, dist_params=dist_params,
                          obs=obs, params=params, name=name)


### PR DESCRIPTION
Fixes #275, at least regarding the `Poisson` PDF side.

`tf.identity` works on a tensor ;).

## Proposed Changes

Replace 

```python3
dist_params = dict(rate=lamb)
```

with

```python3
dist_params = lambda: dict(rate=lamb.value())
```

## Tests added

  - Duplication of the existing test with a `ComposedParameter` as the `rate` argument of `Poisson`.
  
## Checklist

 - [x] change approved
 - [x] implementation finished
 - [x] correct namespace imported
 - [x] tests added
 - [x] CHANGELOG updated

