### PR TITLE
Construct initial queue as tf.Tensor()

### DIFF
--- a/zfit/minimizers/baseminimizer.py
+++ b/zfit/minimizers/baseminimizer.py
@@ -11,6 +11,7 @@ import warnings
 from abc import abstractmethod
 from collections import OrderedDict
 from typing import List, Union, Iterable, Mapping
+from tensorflow import constant
 
 import numpy as np
 import texttable as tt
@@ -284,7 +285,7 @@ class BaseMinimizer(ZfitMinimizer):
 
     def _minimize_with_step(self, loss, params):  # TODO improve
         n_old_vals = 10
-        changes = collections.deque(np.ones(n_old_vals))
+        changes = collections.deque([constant(1.0, dtype='float64') for i in range(n_old_vals)])
         last_val = -10
         n_steps = 0
 


### PR DESCRIPTION
Issue

I faced the following error.
```
---------------------------------------------------------------------------
MinimizeNotImplementedError               Traceback (most recent call last)
~/zfit_test/zfit/zfit/minimizers/baseminimizer.py in _call_minimize(self, loss, params)
    277         try:
--> 278             return self._minimize(loss=loss, params=params)
    279         except MinimizeNotImplementedError as error:

~/zfit_test/zfit/zfit/minimizers/baseminimizer.py in _minimize(self, loss, params)
    327     def _minimize(self, loss, params):
--> 328         raise MinimizeNotImplementedError
    329 

MinimizeNotImplementedError: 

During handling of the above exception, another exception occurred:

AttributeError                            Traceback (most recent call last)
<ipython-input-8-cbddf78a156f> in <module>
----> 1 zf.fit()
      2 zf.draw()

~/zfit_test/zfitter/zfitter/core.py in fit(self)
    109         self.model = self.model
    110         data = zfit.Data.from_numpy(obs=self.obs, array=self.data)
--> 111         self.result = self.minimizer.minimize(self.loss(model=self.model, data=data))
    112         self.fitted = True
    113         return self.result

~/zfit_test/zfit/zfit/minimizers/baseminimizer.py in minimize(self, loss, params)
    263         params = self._check_input_params(loss=loss, params=params, only_floating=True)
    264         try:
--> 265             return self._hook_minimize(loss=loss, params=params)
    266         except (FailMinimizeNaN, RuntimeError) as error:  # iminuit raises RuntimeError if user raises Error
    267             fail_result = self.strategy.fit_result

~/zfit_test/zfit/zfit/minimizers/baseminimizer.py in _hook_minimize(self, loss, params)
    272 
    273     def _hook_minimize(self, loss, params):
--> 274         return self._call_minimize(loss=loss, params=params)
    275 
    276     def _call_minimize(self, loss, params):

~/zfit_test/zfit/zfit/minimizers/baseminimizer.py in _call_minimize(self, loss, params)
    279         except MinimizeNotImplementedError as error:
    280             try:
--> 281                 return self._minimize_with_step(loss=loss, params=params)
    282             except MinimizeStepNotImplementedError:
    283                 raise error

~/zfit_test/zfit/zfit/minimizers/baseminimizer.py in _minimize_with_step(self, loss, params)
    307         # compose fit result
    308         message = "successful finished"
--> 309         are_unique = len(set([float(change.numpy()) for change in changes])) > 1  # values didn't change...
    310         if not are_unique:
    311             message = "Loss unchanged for last {} steps".format(n_old_vals)

~/zfit_test/zfit/zfit/minimizers/baseminimizer.py in <listcomp>(.0)
    307         # compose fit result
    308         message = "successful finished"
--> 309         are_unique = len(set([float(change.numpy()) for change in changes])) > 1  # values didn't change...
    310         if not are_unique:
    311             message = "Loss unchanged for last {} steps".format(n_old_vals)

AttributeError: 'numpy.float64' object has no attribute 'numpy'
```
The issue seems to be initialization of deque, `changes`.
https://github.com/zfit/zfit/blob/a798f931cdd3d876d1cdaffd4776781b5d1330b4/zfit/minimizers/baseminimizer.py#L287
The deque is initialized as just float, which has not numpy() method.

## Proposed Changes
In
https://github.com/zfit/zfit/blob/a798f931cdd3d876d1cdaffd4776781b5d1330b4/zfit/minimizers/baseminimizer.py#L309 ,
tf.Tensor() object are required as element of `changes`.
I propose to initialize them as tf.Tensor() not numpy.ones().
Is it correct fix?

## Tests added

  -
  
## Checklist

 - [ ] change approved
 - [ ] implementation finished
 - [ ] correct namespace imported
 - [ ] tests added
 - [ ] CHANGELOG updated

