### PR TITLE
Fixing test flakiness

### DIFF
--- a/tests/test_pdf_sumpdf.py
+++ b/tests/test_pdf_sumpdf.py
@@ -94,7 +94,7 @@ def test_sampling():
     assert true_mu == pytest.approx(np.mean(sample), abs=tolerance)
     assert np.std(sample_true) == pytest.approx(np.std(sample), abs=tolerance)
 
-    assert scipy.stats.ks_2samp(sample_true, sample).pvalue > 0.05
+    assert scipy.stats.ks_2samp(sample_true, sample).pvalue > 0.01
 
 
 @pytest.mark.flaky(2)  # mc integration


### PR DESCRIPTION
The test `test_sampling` is flaky. It sometimes fails when the p-value is below 0.05. i collected the samples of p-value from several executions and computed the tail distribution. The computed percentiles are as follows:

```
0.9 :: 0.096
0.99 :: 0.018
0.9999 :: 0.0114
```

I updated the assertion using the 99.99th percentile. Do you think looks reasonable? I will be happy to incorporate any other suggestions that you may have.

Thanks!