### PR TITLE
Fix css bug

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -7,13 +7,8 @@
     background-color: #2F4858 !important;
 }
 
-/* This is kept for reference, in case the logo needs to be adjusted in the css. */
-/*.navbar-brand>.logo {*/
-/*    filter: drop-shadow(1px 1px 0px #ffffff88);*/
-/*}*/
-
-.nav-link {
-    color: #ffffffff!important;
+.navbar-nav > .nav-item > .nav-link {
+    color: #ffffffff;
 }
 
 .navbar-nav > .active > .nav-link {

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,7 +1,7 @@
-/*This css file is a bit of a hack for changing the look of pydata_sphinx_theme. As soon as */
+/*This css file is a bit of a hack for changing the look of pydata_sphinx_theme. As soon as*/
 /*there will be an official way of doing this, we can change this.*/
-
-@import 'index.css';
+/*An official way for most of these elements seems to be on it's ways.*/
+/*See https://github.com/pydata/pydata-sphinx-theme/issues/339 */
 
 #navbar-main {
     background-color: #2F4858 !important;

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -4,7 +4,7 @@
 @import 'index.css';
 
 #navbar-main {
-    background-color: #2F4858!important;
+    background-color: #2F4858 !important;
 }
 
 /* This is kept for reference, in case the logo needs to be adjusted in the css. */
@@ -16,9 +16,9 @@
     color: #ffffffff!important;
 }
 
-.navbar-nav>.active>.nav-link {
+.navbar-nav > .active > .nav-link {
     font-weight: 600;
-    color: #CB5628!important;
+    color: #CB5628 !important;
 }
 
 i.fa-github-square:before {


### PR DESCRIPTION
White color was applied to all elements with class .nav-link instead of only the ones inside a .navbar-nav element.
This caused the links in the right column to turn white as well, making them invisible on the white background.