### PR TITLE
parameter raises error with `set_value` out of limits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,7 @@ Breaking changes
 - BFGS (from TensorFlow Probability) has been removed as it is not working properly. There are many alternatives
   such as ScipyLBFGSV1 or NLoptLBFGSV1
 - Scipy (the minimizer) has been removed. Use specialized `Scipy*` minimizers instead.
+- ``set_value`` or ``set_values`` now raises a ``ValueError`` if it is outside the limits. Use ``assign`` to ignore it.
 
 Depreceations
 -------------

--- a/tests/test_fitresult.py
+++ b/tests/test_fitresult.py
@@ -79,8 +79,9 @@ def test_set_values():
     val_a = fitresult['a']
     val_b = fitresult['b']
     val_c = fitresult['c']
-    param_b.set_value(999)
-    param_c.set_value(9999)
+    with pytest.raises(ValueError):
+        param_b.set_value(999)
+    param_c.assign(9999)
     zfit.param.set_values([param_c, param_b], values=result)
 
     assert param_a.value() == val_a
@@ -124,14 +125,14 @@ def test_params_at_limit():
     loss, (param_a, param_b, param_c) = create_loss(n=5000)
     old_lower = param_a.lower
     param_a.lower = param_a.upper
-    param_a.upper += 5
-    minimizer = zfit.minimize.Minuit(use_minuit_grad=True, tol=0.1)
+    param_a.assign(param_a.upper + 5)
+    minimizer = zfit.minimize.Minuit(gradient=True, tol=10.)
     result = minimizer.minimize(loss)
+    param_a.assign(100)
     assert param_a.at_limit
     assert result.params_at_limit
     param_a.lower = old_lower
-    assert not param_a.at_limit
-    assert result.params_at_limit
+    assert param_a.at_limit
     assert not result.valid
 
 

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -156,9 +156,7 @@ minimizers = [
 
 ]
 
-# minimizers = [
-#     (zfit.minimize.Minuit, {"tol": 0.0001, "verbosity": verbosity, 'minuit_grad': True},
-#      {'error': True, 'longtests': True})]
+# minimizers = [(zfit.minimize.Minuit, {"verbosity": verbosity, 'gradient': True}, {'error': True, 'longtests': True})]
 # minimizers = [(zfit.minimize.IpyoptV1, {'verbosity': 7}, True)]
 # minimizers = [(zfit.minimize.ScipyLBFGSBV1, {'verbosity': 7}, True)]
 # minimizers = [(zfit.minimize.ScipyPowellV1, {'verbosity': 7}, True)]
@@ -352,9 +350,9 @@ def test_minimizers(minimizer_class_and_kwargs, numgrad, chunksize, spaces,
             profile_methods = ['zfit_error']
             from zfit.minimizers.minimizer_minuit import Minuit
             hesse_methods.append('minuit_hesse')
+            profile_methods.append('minuit_minos')
             if isinstance(minimizer, Minuit):
                 # TODO: Move up for all once https://github.com/scikit-hep/iminuit/issues/631 fixed
-                profile_methods.append('minuit_minos')
                 hesse_methods.append('approx')
 
             rel_error_tol = 0.15

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -110,7 +110,8 @@ def test_composed_param():
     assert param_a.get_cache_deps(only_floating=False) == {param1, param2, param3}
     a_unchanged = value_fn(param1, param2, param3).numpy()
     assert a_unchanged == param_a.numpy()
-    assert param2.assign(3.5).numpy()
+    param2.assign(3.5)
+    assert param2.numpy()
     a_changed = value_fn(param1, param2, param3).numpy()
     assert a_changed == param_a.numpy()
     assert a_changed != a_unchanged
@@ -167,17 +168,21 @@ def test_param_limits():
     assert param1.has_limits
     assert not param2.has_limits
 
-    param1.set_value(upper + 0.5)
+    with pytest.raises(ValueError):
+        param1.set_value(upper + 0.5)
+    param1.assign(upper + 0.5)
     assert upper == param1.value().numpy()
     assert param1.at_limit
-    param1.set_value(lower - 1.1)
+    with pytest.raises(ValueError):
+        param1.set_value(lower - 1.1)
+    param1.assign(lower - 1.1)
     assert lower == param1.value().numpy()
     assert param1.at_limit
     param1.set_value(upper - 0.1)
     assert not param1.at_limit
 
     param2.lower = lower
-    param2.set_value(lower - 1.1)
+    param2.assign(lower - 1.1)
     assert lower == param2.value().numpy()
 
 

--- a/zfit/minimizers/evaluation.py
+++ b/zfit/minimizers/evaluation.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 import texttable as tt
 
 from ..core.interfaces import ZfitLoss
-from ..core.parameter import set_values
+from ..core.parameter import assign_values, set_values
 from ..settings import run
 from ..util import ztyping
 from ..util.exception import MaximumIterationReached
@@ -132,7 +132,7 @@ class LossEval:
             self.nfunc_eval += 1
             self.ngrad_eval += 1
 
-        set_values(self.params, values=values)
+        assign_values(self.params, values=values)
         is_nan = False
 
         try:
@@ -192,7 +192,7 @@ class LossEval:
         """
         if not self._ignoring_maxiter:
             self.nfunc_eval += 1
-        set_values(self.params, values=values)
+        assign_values(self.params, values=values)
         is_nan = False
 
         try:
@@ -246,7 +246,7 @@ class LossEval:
         """
         if not self._ignoring_maxiter:
             self.ngrad_eval += 1
-        set_values(self.params, values=values)
+        assign_values(self.params, values=values)
         is_nan = False
 
         try:
@@ -302,7 +302,7 @@ class LossEval:
         """
         if not self._ignoring_maxiter:
             self.nhess_eval += 1
-        set_values(self.params, values=values)
+        assign_values(self.params, values=values)
         is_nan = False
 
         try:

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -19,7 +19,7 @@ from scipy.optimize import LbfgsInvHessProduct
 from tabulate import tabulate
 
 from ..core.interfaces import ZfitIndependentParameter, ZfitLoss, ZfitParameter
-from ..core.parameter import set_values
+from ..core.parameter import assign_values, set_values
 from ..settings import run
 from ..util.container import convert_to_container
 from ..util.deprecation import deprecated_args
@@ -416,7 +416,7 @@ class FitResult(ZfitResult):
             if isinstance(self.minimizer, Minuit):
                 minuit = self.minimizer._minuit_minimizer
             else:
-                minimizer = Minuit(tol=self.minimizer.tol, verbosity=0, name="ZFIT_TMP_UNCERTAINTY")
+                minimizer = Minuit(tol=self.minimizer.tol, verbosity=0, name="ZFIT_TMP_UNCERTAINITIES")
                 minuit, _, _ = minimizer._make_minuit(loss=self.loss, params=self.params, init=self)
             self._cache_minuit = minuit
         return minuit
@@ -914,7 +914,7 @@ class FitResult(ZfitResult):
                           " used state. If this happens during normal operation, make sure you reset the values.",
                           RuntimeWarning)
             raise
-        set_values(params=params, values=old_values)
+        assign_values(params=params, values=old_values)  # TODO: or set?
 
     def _input_check_params(self, params):
         if params is not None:

--- a/zfit/minimizers/ipopt.py
+++ b/zfit/minimizers/ipopt.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict, Optional, Union
 import ipyopt
 import numpy as np
 
-from ..core.parameter import set_values
+from ..core.parameter import assign_values, set_values
 from ..settings import run
 from ..util.exception import MaximumIterationReached
 from .baseminimizer import (BaseMinimizer, minimize_supports,
@@ -320,7 +320,7 @@ class IpyoptV1(BaseMinimizer):
             else:
                 maxiter_reached = evaluator.maxiter_reached
 
-            set_values(params, xvalues)
+            assign_values(params, xvalues)
             with evaluator.ignore_maxiter():
                 result_prelim = FitResult.from_ipopt(loss=loss,
                                                      params=params,

--- a/zfit/minimizers/minimizer_minuit.py
+++ b/zfit/minimizers/minimizer_minuit.py
@@ -6,7 +6,7 @@ import iminuit
 import numpy as np
 
 from ..core.interfaces import ZfitLoss
-from ..core.parameter import Parameter, set_values
+from ..core.parameter import Parameter, assign_values, set_values
 from ..settings import run
 from ..util.cache import GraphCachable
 from ..util.deprecation import deprecated_args
@@ -207,7 +207,7 @@ class Minuit(BaseMinimizer, GraphCachable):
                                           internal_tol=internal_tol)
 
             if converged or maxiter_reached:
-                set_values(params, minimizer.values)  # make sure it's at the right value
+                assign_values(params, minimizer.values)  # make sure it's at the right value
                 break
 
         fitresult = FitResult.from_minuit(loss=loss,

--- a/zfit/minimizers/minimizer_nlopt.py
+++ b/zfit/minimizers/minimizer_nlopt.py
@@ -7,7 +7,7 @@ from typing import Callable, Mapping, Optional, Union
 import nlopt
 import numpy as np
 
-from ..core.parameter import set_values
+from ..core.parameter import assign_values, set_values
 from ..settings import run
 from ..util.exception import MaximumIterationReached
 from .baseminimizer import (NOT_SUPPORTED, BaseMinimizer, minimize_supports,
@@ -267,7 +267,7 @@ class NLoptBaseMinimizerV1(BaseMinimizer):
             else:
                 maxiter_reached = evaluator.niter > evaluator.maxiter
 
-            set_values(params, xvalues)
+            assign_values(params, xvalues)
             fmin = minimizer.last_optimum_value()  # TODO: what happens if minimization terminated?
             with evaluator.ignore_maxiter():
                 result_prelim = FitResult.from_nlopt(loss,

--- a/zfit/minimizers/minimizer_tfp.py
+++ b/zfit/minimizers/minimizer_tfp.py
@@ -107,7 +107,7 @@ class BFGS(BaseMinimizer):
 
         # save result
         params_result = run(result.position)
-        set_values(params, values=params_result)
+        assign_values(params, values=params_result)
 
         info = {'n_eval'  : run(result.num_objective_evaluations),
                 'n_iter'  : run(result.num_iterations),

--- a/zfit/minimizers/minimizers_scipy.py
+++ b/zfit/minimizers/minimizers_scipy.py
@@ -8,7 +8,7 @@ import numpy as np
 import scipy.optimize
 from scipy.optimize import SR1, HessianUpdateStrategy
 
-from ..core.parameter import set_values
+from ..core.parameter import assign_values, set_values
 from ..settings import run
 from ..util.container import convert_to_container
 from ..util.exception import MaximumIterationReached
@@ -92,7 +92,7 @@ class ScipyBaseMinimizerV1(BaseMinimizer):
         self._minimize_func = scipy.optimize.minimize if minimize_func is None else minimize_func
 
         if initializer is None:
-            initializer = lambda options, init: options
+            initializer = lambda options, init, step_size: options
         if not callable(initializer):
             raise TypeError(f"Initializer has to be callable not {initializer}")
         self._scipy_initializer = initializer
@@ -198,10 +198,15 @@ class ScipyBaseMinimizerV1(BaseMinimizer):
 
             init_scale = 'auto'
             # get possible initial step size from previous minimizer
-            if init:
-                approx_step_sizes = init.hesse(params=params, method='approx')
+        if init:
+            approx_init_hesse = result_prelim.hesse(params=params, method='approx')
+            if approx_init_hesse:
+                approx_step_sizes = [val['error']
+                                     for val in approx_init_hesse.values()] or None
             else:
                 approx_step_sizes = None
+        else:
+            approx_step_sizes = None
 
         maxiter = self.get_maxiter(len(params))
         if maxiter is not None:
@@ -226,7 +231,8 @@ class ScipyBaseMinimizerV1(BaseMinimizer):
         old_edm = -1
         n_paramatlim = 0
         for i in range(self._internal_maxiter):
-            minimizer_options['options'] = self._scipy_initializer(minimizer_options['options'], init=result_prelim)
+            minimizer_options['options'] = self._scipy_initializer(minimizer_options['options'], init=result_prelim,
+                                                                   step_size=approx_step_sizes)
 
             # update from previous run/result
             if use_hessian and is_update_strat:
@@ -255,7 +261,7 @@ class ScipyBaseMinimizerV1(BaseMinimizer):
             values = optim_result['x']
 
             fmin = optim_result.fun
-            set_values(params, values)
+            assign_values(params, values)
 
             optimize_results = combine_optimize_results(
                 [optim_result] if optimize_results is None else [optimize_results, optim_result])
@@ -269,8 +275,10 @@ class ScipyBaseMinimizerV1(BaseMinimizer):
                                                  valid=valid)
             if result_prelim.params_at_limit:
                 n_paramatlim += 1
-            if use_hessian:
-                approx_step_sizes = result_prelim.hesse(params=params, method='approx')
+            approx_init_hesse = result_prelim.hesse(params=params, method='approx')
+            if approx_init_hesse:
+                approx_step_sizes = [val['error']
+                                     for val in approx_init_hesse.values()] or None
             converged = criterion.converged(result_prelim)
             valid = converged
             edm = criterion.last_value
@@ -285,10 +293,12 @@ class ScipyBaseMinimizerV1(BaseMinimizer):
 
             if math.isclose(old_edm, edm, rel_tol=1e-4, abs_tol=1e-12):
                 if nrandom < self._nrandom_max:  # in order not to start too close
-                    if init_scale is None:
-                        init_scale = np.ones_like(values)
-                    init_scale_no_nan = np.nan_to_num(init_scale, nan=1.)
-                    values += np.random.uniform(low=-init_scale_no_nan, high=init_scale_no_nan) / 5
+                    if approx_step_sizes is None:
+                        rnd_range = np.ones_like(values)
+                    else:
+                        rnd_range = approx_step_sizes
+                    rnd_range_no_nan = np.nan_to_num(rnd_range, nan=1.)
+                    values += np.random.uniform(low=-rnd_range_no_nan, high=rnd_range_no_nan) / 5
                     nrandom += 1
                 else:
                     message = f"Stuck (no change in a few iterations) at the edm={edm}"
@@ -698,11 +708,14 @@ class ScipyTrustNCGV1(ScipyBaseMinimizerV1):
         if init_trust_radius is not None:
             options['initial_trust_radius'] = init_trust_radius
 
-        def initializer(options, init):
+        def initializer(options, init, step_size, **_):
+            trust_radius = None
             if init is not None:
                 trust_radius = init.info.get('tr_radius')
-                if trust_radius is not None:
-                    options['initial_trust_radius'] = trust_radius
+            elif step_size is not None:
+                trust_radius = np.mean(step_size)
+            if trust_radius is not None:
+                options['initial_trust_radius'] = trust_radius
             return options
 
         minimizer_options = {}
@@ -841,11 +854,14 @@ class ScipyTrustConstrV1(ScipyBaseMinimizerV1):
         if init_trust_radius is not None:
             options['initial_tr_radius'] = init_trust_radius
 
-        def initializer(options, init):
+        def initializer(options, init, step_size, **_):
+            trust_radius = None
             if init is not None:
                 trust_radius = init.info.get('tr_radius')
-                if trust_radius is not None:
-                    options['initial_tr_radius'] = trust_radius
+            elif step_size is not None:
+                trust_radius = np.mean(step_size)
+            if trust_radius is not None:
+                options['initial_tr_radius'] = trust_radius
             return options
 
         def verbosity_setter(options, verbosity):
@@ -1114,13 +1130,18 @@ class ScipyTruncNCV1(ScipyBaseMinimizerV1):
         if options:
             minimizer_options['options'] = options
 
+        def initializer(options, step_size, **_):
+            if step_size is not None:
+                options['scale'] = step_size
+            return options
+
         scipy_tols = {'xtol': None, 'ftol': None, 'gtol': None}
 
         method = "TNC"
         super().__init__(method=method, tol=tol, verbosity=verbosity,
                          strategy=strategy, gradient=gradient, hessian=NOT_SUPPORTED,
                          criterion=criterion, internal_tol=scipy_tols,
-                         maxiter=maxiter,
+                         maxiter=maxiter, initializer=initializer,
                          minimizer_options=minimizer_options,
                          name=name)
 
@@ -1266,7 +1287,7 @@ class ScipyPowellV1(ScipyBaseMinimizerV1):
 
         scipy_tols = {'xtol': None, 'ftol': None}
 
-        def initializer(options, init):
+        def initializer(options, init, **_):
             if init is not None:
                 direc = init.info['original'].get('direc')
                 if direc is not None:
@@ -1502,7 +1523,7 @@ class ScipyNelderMeadV1(ScipyBaseMinimizerV1):
             options['adaptive'] = adaptive
         minimizer_options['options'] = options
 
-        def initializer(options, init):
+        def initializer(options, init, **_):
             if init is not None:
                 init_simplex = init.info['original'].get('final_simplex')
                 if init_simplex is not None:

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -42,11 +42,12 @@ def numerical_gradient(func: Callable, params: Iterable["zfit.Parameter"]) -> tf
     Returns:
         Gradients
     """
+    from ..core.parameter import assign_values
+
     params = convert_to_container(params)
 
     def wrapped_func(param_values):
-        for param, value in zip(params, param_values):
-            param.assign(value)
+        assign_values(params, param_values)
         value = func()
         if hasattr(value, 'numpy'):
             value = value.numpy()
@@ -63,8 +64,7 @@ def numerical_gradient(func: Callable, params: Iterable["zfit.Parameter"]) -> tf
     if gradient.shape == ():
         gradient = tf.reshape(gradient, shape=(1,))
     gradient.set_shape(param_vals.shape)
-    for param, val in zip(params, original_vals):
-        param.set_value(val)
+    assign_values(params, original_vals)
     return gradient
 
 
@@ -102,12 +102,12 @@ def numerical_hessian(func: Optional[Callable],
     Returns:
         Hessian matrix
     """
+    from ..core.parameter import assign_values
 
     params = convert_to_container(params)
 
     def wrapped_func(param_values):
-        for param, value in zip(params, param_values):
-            param.assign(value)
+        assign_values(params, param_values)
         value = func()
         if hasattr(value, 'numpy'):
             value = value.numpy()
@@ -138,8 +138,7 @@ def numerical_hessian(func: Optional[Callable],
     else:
         computed_hessian.set_shape((n_params, n_params))
 
-    for param, val in zip(params, original_vals):
-        param.set_value(val)
+    assign_values(params, original_vals)
     return computed_hessian
 
 


### PR DESCRIPTION
Fixes #188

## Proposed Changes

- `set_value` now raises an error if out of limits. Added `assign` that does not throw.

## Tests added

-

## Checklist

-   [x] change approved
-   [x] implementation finished
-   [x] correct namespace imported
-   [x] tests added
-   [x] CHANGELOG updated
