### PR TITLE
Tensorflow numpy api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ ordered-set
 pandas
 scipy>=1.2
 tabulate
-tensorflow~=2.4
+tensorflow~=2.5.0rc0
 tensorflow-addons
 tensorflow_probability~=0.12
 texttable

--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -186,7 +186,7 @@ def test_normalization(obs1, pdf_factory):
         probs = dist.pdf(samples)
         probs_small = dist.pdf(small_samples)
         log_probs = dist.log_pdf(small_samples)
-        probs, log_probs = probs.numpy(), log_probs.numpy()
+        probs, log_probs = zfit.run(probs, log_probs)
         probs = np.average(probs) * (high - low)
         assert probs == pytest.approx(1., rel=0.05)
         assert log_probs == pytest.approx(tf.math.log(probs_small).numpy(), rel=0.05)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -56,6 +56,9 @@ def test_complex_param():
     for dep in deps_param4:
         assert dep.floating
 
+    # Test complex conjugate
+    param5 = param2.conj
+
     # Test properties (1e-8 is too precise)
     assert zfit.run(param1.real) == pytest.approx(real_part, rel=1e-6)
     assert zfit.run(param1.imag) == pytest.approx(imag_part, rel=1e-6)
@@ -67,6 +70,8 @@ def test_complex_param():
     assert zfit.run(param3.arg) == pytest.approx(arg_val, rel=1e-6)
     assert zfit.run(param3.real) == pytest.approx(mod_val * np.cos(arg_val), rel=1e-6)
     assert zfit.run(param3.imag) == pytest.approx(mod_val * np.sin(arg_val), rel=1e-6)
+    assert zfit.run(param5.real) == pytest.approx(real_part)
+    assert zfit.run(param5.imag) == pytest.approx(-imag_part)
 
 
 def test_repr():

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,6 +1,4 @@
 #  Copyright (c) 2021 zfit
-from math import cos, pi
-
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -38,7 +36,7 @@ def test_complex_param():
 
     # Polar complex
     mod_val = 2
-    arg_val = pi / 4.0
+    arg_val = np.pi / 4.0
     mod_part_param = Parameter("mod_part_param", mod_val)
     arg_part_param = Parameter("arg_part_param", arg_val)
     param3 = ComplexParameter.from_polar("param3_compl", mod_part_param, arg_part_param)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -59,16 +59,16 @@ def test_complex_param():
         assert dep.floating
 
     # Test properties (1e-8 is too precise)
-    assert param1.real == pytest.approx(real_part, rel=1e-6)
-    assert param1.imag == pytest.approx(imag_part, rel=1e-6)
-    assert param2.real == pytest.approx(real_part, rel=1e-6)
-    assert param2.imag == pytest.approx(imag_part, rel=1e-6)
-    assert param2.mod == pytest.approx(np.abs(complex_value))
-    assert param2.arg == pytest.approx(np.angle(complex_value))
-    assert param3.mod == pytest.approx(mod_val, rel=1e-6)
-    assert param3.arg == pytest.approx(arg_val, rel=1e-6)
-    assert param3.real == pytest.approx(mod_val * np.cos(arg_val), rel=1e-6)
-    assert param3.imag == pytest.approx(mod_val * np.sin(arg_val), rel=1e-6)
+    assert zfit.run(param1.real) == pytest.approx(real_part, rel=1e-6)
+    assert zfit.run(param1.imag) == pytest.approx(imag_part, rel=1e-6)
+    assert zfit.run(param2.real) == pytest.approx(real_part, rel=1e-6)
+    assert zfit.run(param2.imag) == pytest.approx(imag_part, rel=1e-6)
+    assert zfit.run(param2.mod) == pytest.approx(np.abs(complex_value))
+    assert zfit.run(param2.arg) == pytest.approx(np.angle(complex_value))
+    assert zfit.run(param3.mod) == pytest.approx(mod_val, rel=1e-6)
+    assert zfit.run(param3.arg) == pytest.approx(arg_val, rel=1e-6)
+    assert zfit.run(param3.real) == pytest.approx(mod_val * np.cos(arg_val), rel=1e-6)
+    assert zfit.run(param3.imag) == pytest.approx(mod_val * np.sin(arg_val), rel=1e-6)
 
 
 def test_repr():

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -15,21 +15,19 @@ from zfit.util.exception import NameAlreadyTakenError
 def test_complex_param():
     real_part = 1.3
     imag_part = 0.3
+    complex_value = real_part + 1j * imag_part
 
-    # Constant complex
-    def complex_value():
-        return real_part + imag_part * 1.j
-
-    param1 = ComplexParameter("param1_compl", complex_value, params=None)
+    param1 = ComplexParameter("param1_compl", lambda: complex_value, params=None)
     some_value = 3. * param1 ** 2 - 1.2j
-    true_value = 3. * complex_value() ** 2 - 1.2j
+    true_value = 3. * complex_value ** 2 - 1.2j
     assert true_value == pytest.approx(some_value.numpy(), rel=1e-8)
-    assert not param1.get_cache_deps()
+    assert not param1.get_params()
+
     # Cartesian complex
     real_part_param = Parameter("real_part_param", real_part)
     imag_part_param = Parameter("imag_part_param", imag_part)
     param2 = ComplexParameter.from_cartesian("param2_compl", real_part_param, imag_part_param)
-    part1, part2 = param2.get_cache_deps()
+    part1, part2 = param2.get_params()
     part1_val, part2_val = [part1.value().numpy(), part2.value().numpy()]
     if part1_val == pytest.approx(real_part):
         assert part2_val == pytest.approx(imag_part)
@@ -37,8 +35,9 @@ def test_complex_param():
         assert part1_val == pytest.approx(imag_part)
     else:
         assert False, "one of the if or elif should be the case"
+
     # Polar complex
-    mod_val = 1.0
+    mod_val = 2
     arg_val = pi / 4.0
     mod_part_param = Parameter("mod_part_param", mod_val)
     arg_part_param = Parameter("arg_part_param", arg_val)
@@ -58,15 +57,18 @@ def test_complex_param():
     assert len(deps_param4) == 2
     for dep in deps_param4:
         assert dep.floating
-    assert param4.mod.name == param4_name + "_mod"
-    assert param4.arg.name == param4_name + "_arg"
 
     # Test properties (1e-8 is too precise)
-    assert real_part == pytest.approx(param1.real.numpy(), rel=1e-6)
-    assert imag_part == pytest.approx(param2.imag.numpy(), rel=1e-6)
-    assert mod_val == pytest.approx(param3.mod.numpy(), rel=1e-6)
-    assert arg_val == pytest.approx(param3.arg.numpy(), rel=1e-6)
-    assert cos(arg_val) == pytest.approx(param3.real.numpy(), rel=1e-6)
+    assert param1.real == pytest.approx(real_part, rel=1e-6)
+    assert param1.imag == pytest.approx(imag_part, rel=1e-6)
+    assert param2.real == pytest.approx(real_part, rel=1e-6)
+    assert param2.imag == pytest.approx(imag_part, rel=1e-6)
+    assert param2.mod == pytest.approx(np.abs(complex_value))
+    assert param2.arg == pytest.approx(np.angle(complex_value))
+    assert param3.mod == pytest.approx(mod_val, rel=1e-6)
+    assert param3.arg == pytest.approx(arg_val, rel=1e-6)
+    assert param3.real == pytest.approx(mod_val * np.cos(arg_val), rel=1e-6)
+    assert param3.imag == pytest.approx(mod_val * np.sin(arg_val), rel=1e-6)
 
 
 def test_repr():

--- a/tests/test_simple_subclass.py
+++ b/tests/test_simple_subclass.py
@@ -48,7 +48,6 @@ def test_func_simple_subclass():
     gauss1 = SimpleGaussFunc(obs='obs1', mu=3, sigma=5)
 
     value = gauss1.func(np.random.random(size=(10, 1)))
-    value.numpy()
 
     with pytest.raises(ValueError):
         gauss2 = SimpleGaussFunc('obs1', 1., sigma=5.)

--- a/tests/test_z_numpy.py
+++ b/tests/test_z_numpy.py
@@ -1,0 +1,17 @@
+#  Copyright (c) 2021 zfit
+import tensorflow as tf
+
+import zfit.z.numpy as znp
+
+
+def test_z_numpy_ndarray_is_tensorflow_tensor():
+    """In tensorflow 2.4.1 tf.experimental.numpy.ndarray was a wrapper around tf.Tensor.
+
+    Now this concept seems to
+    have been scratched and tf.experimental.numpy.ndarray is just an alias for tf.Tensor.
+    See the commit history of
+    https://github.com/tensorflow/tensorflow/commits/master/tensorflow/python/ops/numpy_ops/np_arrays.py
+    """
+    assert znp.ndarray is tf.Tensor
+    assert isinstance(znp.array(1), tf.Tensor)
+    assert isinstance(znp.sum(znp.array(0)), tf.Tensor)

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -213,9 +213,9 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
     def _add_dim_to_x(self, x):  # TODO(Mayou36): remove function? unnecessary? dealt with in `Data`?
         if self.n_obs == 1:
             if len(x.shape.as_list()) == 0:
-                x = tf.expand_dims(x, -1)
+                x = znp.expand_dims(x, -1)
             if len(x.shape.as_list()) == 1:
-                x = tf.expand_dims(x, -1)
+                x = znp.expand_dims(x, -1)
         return x
 
     def update_integration_options(self, draws_per_dim=None, mc_sampler=None):

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -925,7 +925,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         except MultipleLimitsNotImplemented as error:
             try:
                 total_integral = self.analytic_integrate(limits, norm_range=False)
-                sub_integrals = tf.concat([self.analytic_integrate(limit, norm_range=False) for limit in limits],
+                sub_integrals = znp.concatenate([self.analytic_integrate(limit, norm_range=False) for limit in limits],
                                           axis=0)
             except AnalyticIntegralNotImplemented:
                 raise MultipleLimitsNotImplemented("Cannot autohandle multiple limits as the analytic"
@@ -939,7 +939,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
                 if isinstance(sub_sample, ZfitData):
                     sub_sample = sub_sample.value()
                 samples.append(sub_sample)
-            sample = tf.concat(samples, axis=0)
+            sample = znp.concatenate(samples, axis=0)
 
         return sample
 

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -18,6 +18,8 @@ import tensorflow as tf
 from dotmap import DotMap
 from tensorflow_probability.python import mcmc as mc
 
+import zfit.z.numpy as znp
+
 from .. import z
 from ..core.integration import Integration
 from ..settings import ztypes
@@ -350,7 +352,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             integrals = []
             for sub_limits in limits:
                 integrals.append(self._call_integrate(limits=sub_limits, norm_range=norm_range))
-            integral = z.reduce_sum(tf.stack(integrals), axis=0)  # TODO: remove stack?
+            integral = z.reduce_sum(znp.stack(integrals), axis=0)  # TODO: remove stack?
         return integral
 
     def _call_integrate(self, limits, norm_range):
@@ -477,7 +479,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             integrals = []
             for sub_limits in limits:
                 integrals.append(self._call_analytic_integrate(limits=sub_limits, norm_range=norm_range))
-            integral = z.reduce_sum(tf.stack(integrals), axis=0)
+            integral = z.reduce_sum(znp.stack(integrals), axis=0)
         return integral
 
     def _call_analytic_integrate(self, limits, norm_range):
@@ -534,7 +536,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             integrals = []
             for sub_limits in limits:
                 integrals.append(self._call_numeric_integrate(limits=sub_limits, norm_range=norm_range))
-            integral = z.reduce_sum(tf.stack(integrals), axis=0)
+            integral = z.reduce_sum(znp.stack(integrals), axis=0)
 
         return integral
 
@@ -595,7 +597,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             integrals = []
             for sub_limit in limits:
                 integrals.append(self._call_partial_integrate(x=x, limits=sub_limit, norm_range=norm_range))
-            integral = z.reduce_sum(tf.stack(integrals), axis=0)
+            integral = z.reduce_sum(znp.stack(integrals), axis=0)
 
         return integral
 
@@ -690,7 +692,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             integrals = []
             for sub_limits in limits:
                 integrals.append(self._call_partial_analytic_integrate(x=x, limits=sub_limits, norm_range=norm_range))
-            integral = z.reduce_sum(tf.stack(integrals), axis=0)
+            integral = z.reduce_sum(znp.stack(integrals), axis=0)
 
         return integral
 
@@ -754,7 +756,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             integrals = []
             for sub_limits in limits:
                 integrals.append(self._call_partial_numeric_integrate(x=x, limits=sub_limits, norm_range=norm_range))
-            integral = z.reduce_sum(tf.stack(integrals), axis=0)
+            integral = z.reduce_sum(znp.stack(integrals), axis=0)
         return integral
 
     def _call_partial_numeric_integrate(self, x, limits, norm_range):

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -284,7 +284,7 @@ class BasePDF(ZfitPDF, BaseModel):
         """
         if not self.is_extended:
             raise NotExtendedPDFError(f"{self} is not extended, cannot call `ext_pdf`")
-        return self.log_pdf(x=x, norm_range=norm_range) + tf.math.log(self.get_yield())
+        return self.log_pdf(x=x, norm_range=norm_range) + znp.log(self.get_yield())
 
     @_BasePDF_register_check_support(False)
     def _pdf(self, x, norm_range):
@@ -362,11 +362,11 @@ class BasePDF(ZfitPDF, BaseModel):
         with suppress(FunctionNotImplemented):
             return self._log_pdf(x=x, norm_range=norm_range)
         with suppress(FunctionNotImplemented):
-            return tf.math.log(self._pdf(x=x, norm_range=norm_range))
+            return znp.log(self._pdf(x=x, norm_range=norm_range))
         return self._fallback_log_pdf(x=x, norm_range=norm_range)
 
     def _fallback_log_pdf(self, x, norm_range):
-        return tf.math.log(self._hook_pdf(x=x, norm_range=norm_range))
+        return znp.log(self._hook_pdf(x=x, norm_range=norm_range))
 
     def gradient(self, x: ztyping.XType, norm_range: ztyping.LimitsType, params: ztyping.ParamsTypeOpt = None):
         raise BreakingAPIChangeError("Removed with 0.5.x: is this needed?")
@@ -392,7 +392,7 @@ class BasePDF(ZfitPDF, BaseModel):
     def _apply_yield(self, value: float, norm_range: ztyping.LimitsType, log: bool) -> Union[float, tf.Tensor]:
         if self.is_extended and not norm_range.limits_are_false:
             if log:
-                value += tf.math.log(self.get_yield())
+                value += znp.log(self.get_yield())
             else:
                 value *= self.get_yield()
         return value

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -59,8 +59,8 @@ from typing import Dict, Optional, Set, Type, Union
 
 import tensorflow as tf
 
-from zfit import z
 import zfit.z.numpy as znp
+from zfit import z
 
 from ..settings import run, ztypes
 from ..util import ztyping

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -7,12 +7,15 @@ Defining your own pdf
 ---------------------
 
 A simple example:
+>>> import zfit
+>>> import zfit.z.numpy as znp
+>>>
 >>> class MyGauss(BasePDF):
 >>>     def __init__(self, mean, stddev, name="MyGauss"):
 >>>         super().__init__(mean=mean, stddev=stddev, name=name)
 >>>
 >>>     def _unnormalized_pdf(self, x):
->>>         return tf.exp((x - mean) ** 2 / (2 * stddev**2))
+>>>         return znp.exp((x - mean) ** 2 / (2 * stddev**2))
 
 Notice that *here* we only specify the *function* and no normalization. This
 **No** attempt to **explicitly** normalize the function should be done inside `_unnormalized_pdf`.
@@ -57,6 +60,7 @@ from typing import Dict, Optional, Set, Type, Union
 import tensorflow as tf
 
 from zfit import z
+import zfit.z.numpy as znp
 
 from ..settings import run, ztypes
 from ..util import ztyping
@@ -317,7 +321,7 @@ class BasePDF(ZfitPDF, BaseModel):
         with suppress(FunctionNotImplemented):
             return self._pdf(x, norm_range=norm_range)
         with suppress(FunctionNotImplemented):
-            return tf.exp(self._log_pdf(x=x, norm_range=norm_range))
+            return znp.exp(self._log_pdf(x=x, norm_range=norm_range))
         return self._fallback_pdf(x=x, norm_range=norm_range)
 
     def _fallback_pdf(self, x, norm_range):

--- a/zfit/core/constraint.py
+++ b/zfit/core/constraint.py
@@ -8,6 +8,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 from ordered_set import OrderedSet
 
+import zfit.z.numpy as znp
 from zfit import z
 
 from ..settings import ztypes
@@ -212,7 +213,7 @@ class GaussianConstraint(TFProbabilityConstraint):
             elif sigma.shape.ndims == 1:
                 covariance = tf.linalg.tensor_diag(z.pow(sigma, 2.))
             else:
-                sigma = tf.reshape(sigma, [1])
+                sigma = znp.reshape(sigma, [1])
                 covariance = tf.linalg.tensor_diag(z.pow(sigma, 2.))
 
             if not params_tensor.shape[0] == mu.shape[0] == covariance.shape[0] == covariance.shape[1]:

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -12,6 +12,7 @@ from tensorflow.python.ops import array_ops
 
 # from ..settings import types as ztypes
 import zfit
+import zfit.z.numpy as znp
 
 from .. import z
 from ..settings import ztypes
@@ -285,9 +286,9 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
             dtype = ztypes.float
         tensor = tf.cast(tensor, dtype=dtype)
         if len(tensor.shape) == 0:
-            tensor = tf.expand_dims(tensor, -1)
+            tensor = znp.expand_dims(tensor, -1)
         if len(tensor.shape) == 1:
-            tensor = tf.expand_dims(tensor, -1)
+            tensor = znp.expand_dims(tensor, -1)
         # dataset = tf.data.Dataset.from_tensor_slices(tensor)
         dataset = LightDataset.from_tensor(tensor)
 
@@ -359,9 +360,9 @@ class Data(GraphCachable, ZfitData, BaseDimensional, BaseObject):
     def _check_convert_value(self, value):
         # TODO(Mayou36): add conversion to right dimension? (n_events, n_obs)? # check if 1-D?
         if len(value.shape.as_list()) == 0:
-            value = tf.expand_dims(value, -1)
+            value = znp.expand_dims(value, -1)
         if len(value.shape.as_list()) == 1:
-            value = tf.expand_dims(value, -1)
+            value = znp.expand_dims(value, -1)
 
         # cast data to right type
         if value.dtype != self.dtype:

--- a/zfit/core/integration.py
+++ b/zfit/core/integration.py
@@ -247,7 +247,7 @@ def chunked_average(func, x, num_batches, batch_size, space, mc_sampler):
                 sample = mc_sampler(shape=(batch_size, space.n_obs), dtype=ztypes.float)
             sample = tf.guarantee_const(sample)
             sample = (np.array(upper[0]) - np.array(lower[0])) * sample + lower[0]
-            sample = tf.transpose(a=sample)
+            sample = znp.transpose(a=sample)
             sample = func(sample)
             sample = tf.guarantee_const(sample)
 

--- a/zfit/core/integration.py
+++ b/zfit/core/integration.py
@@ -16,11 +16,12 @@ from zfit.core.dimension import BaseDimensional
 from zfit.core.interfaces import ZfitData, ZfitModel, ZfitSpace
 from zfit.util.container import convert_to_container
 from zfit.util.temporary import TemporarilySet
-from .space import Space, convert_to_space, supports
+
 from ..settings import ztypes
 from ..util import ztyping
 from ..util.exception import (AnalyticIntegralNotImplemented,
                               WorkInProgressError)
+from .space import Space, convert_to_space, supports
 
 
 @supports()

--- a/zfit/core/integration.py
+++ b/zfit/core/integration.py
@@ -214,11 +214,6 @@ def normalization_chunked(func, n_axes, batch_size, num_batches, dtype, space, x
                                              dtype=dtype,
                                              space=space, x=x, shape_after=shape_after)
 
-            # normed_grad = normalization_nograd(func=lambda x: tf.stack(tf.gradients(ys=func(x), xs=variables)),
-            #                                    n_axes=n_axes, batch_size=batch_size, num_batches=num_batches,
-            #                                    dtype=dtype,
-            #                                    space=space,
-            #                                    x=x, shape_after=(len(variables),))
 
             return dy, tape.gradient(value, variables)
 

--- a/zfit/core/integration.py
+++ b/zfit/core/integration.py
@@ -120,7 +120,7 @@ def mc_integrate(func: Callable, limits: ztyping.LimitsType, axes: Optional[ztyp
                 index_samples = 0
                 index_values = 0
                 if len(x.shape) == 1:
-                    x = tf.expand_dims(x, axis=1)
+                    x = znp.expand_dims(x, axis=1)
                 for i in range(n_axes + x.shape[-1]):
                     if i in axes:
                         new_obs.append(space.obs[index_samples])
@@ -128,7 +128,7 @@ def mc_integrate(func: Callable, limits: ztyping.LimitsType, axes: Optional[ztyp
                         index_samples += 1
                     else:
                         new_obs.append(data_obs[index_values])
-                        value_list.append(tf.expand_dims(x[:, index_values], axis=1))
+                        value_list.append(znp.expand_dims(x[:, index_values], axis=1))
                         index_values += 1
                 value_list = [tf.cast(val, dtype=dtype) for val in value_list]
                 x = PartialIntegralSampleData(sample=value_list,
@@ -166,7 +166,7 @@ def normalization_nograd(func, n_axes, batch_size, num_batches, dtype, space, x=
                                                          randomized=False)
         # halton_sample = tf.random_uniform(shape=(n_axes, batch_size), dtype=dtype)
         samples_normed.set_shape((batch_size, n_axes))
-        samples_normed = tf.expand_dims(samples_normed, axis=0)
+        samples_normed = znp.expand_dims(samples_normed, axis=0)
         samples = samples_normed * (upper - lower) + lower
         func_vals = func(samples)
         if shape_after == ():
@@ -174,7 +174,7 @@ def normalization_nograd(func, n_axes, batch_size, num_batches, dtype, space, x=
         else:
             reduce_axis = 1
             if len(func_vals.shape) == 1:
-                func_vals = tf.expand_dims(func_vals, -1)
+                func_vals = znp.expand_dims(func_vals, -1)
         batch_mean = znp.mean(func_vals, axis=reduce_axis)  # if there are gradients
         err_weight = 1 / tf.cast(batch_num + 1, dtype=tf.float64)
 

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -51,10 +51,10 @@ def _unbinned_nll_tf(model: ztyping.PDFInputType, data: ztyping.DataInputType, f
                 for p, d, r in zip(model, data, fit_range)]
         # nlls_total = [nll.total for nll in nlls]
         # nlls_correction = [nll.correction for nll in nlls]
-        # nlls_total_summed = tf.reduce_sum(input_tensor=nlls_total, axis=0)
-        nlls_summed = tf.reduce_sum(input_tensor=nlls, axis=0)
+        # nlls_total_summed = znp.sum(input_tensor=nlls_total, axis=0)
+        nlls_summed = znp.sum(nlls, axis=0)
 
-        # nlls_correction_summed = tf.reduce_sum(input_tensor=nlls_correction, axis=0)
+        # nlls_correction_summed = znp.sum(input_tensor=nlls_correction, axis=0)
         # nll_finished = (nlls_total_summed, nlls_correction_summed)
         nll_finished = nlls_summed
     else:
@@ -77,7 +77,7 @@ def _nll_calc_unbinned_tf(log_probs, weights=None, log_offset=None):
         log_probs *= weights  # because it's prob ** weights
     if log_offset is not None:
         log_probs -= log_offset
-    nll = -tf.reduce_sum(input_tensor=log_probs, axis=0)
+    nll = -znp.sum(log_probs, axis=0)
     # nll = -tfp.math.reduce_kahan_sum(input_tensor=log_probs, axis=0)
     return nll
 
@@ -633,7 +633,7 @@ class ExtendedUnbinnedNLL(UnbinnedNLL):
         term_new = tf.nn.log_poisson_loss(nevents_collected, znp.log(yields))
         if log_offset is not None:
             term_new += log_offset
-        nll += tf.reduce_sum(term_new, axis=0)
+        nll += znp.sum(term_new, axis=0)
         return nll
 
     @property

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -670,20 +670,26 @@ class SimpleLoss(BaseLoss):
         .. code:: python
 
             import zfit
-            from zfit import z
+            import zfit.z.numpy as znp
+
+            import tensorflow as tf
 
             param1 = zfit.Parameter('param1', 5, 1, 10)
             # we can build a model here if we want, but in principle, it's not necessary
 
-            x = z.random.uniform(shape=(100,))
-            y = x * z.random.normal(mean=4, stddev=0.1, shape=x.shape)
+            x = znp.random.uniform(size=(100,))
+            # Todo: change to znp.random.normal when introduced into tensorflow.experimental.numpy.
+            y = x*tf.random.normal(mean=4, stddev=0.1, shape=x.shape, dtype=tf.double)
+
 
             def squared_loss():
-                y_pred = x * param1  # this is very simple, but we can of course use any
-                                     # zfit PDF or Func inside
-                squared = (y_pred - y) ** 2
-                mse = tf.reduce_mean(squared)
+                y_pred = x*param1  # this is very simple, but we can of course use any
+                # zfit PDF or Func inside
+                squared = (y_pred - y)**2
+                mse = znp.mean(squared)
                 return mse
+
+            squared_loss.errordef = 1
 
             loss = zfit.loss.SimpleLoss(squared_loss, param1)
 
@@ -691,7 +697,7 @@ class SimpleLoss(BaseLoss):
 
         .. code:: python
 
-            minimizer = zfit.minize.Minuit()
+            minimizer = zfit.minimize.Minuit()
             result = minimizer.minimize(loss)
         """
         super().__init__(model=[], data=[], options={'subtr_const': False})

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -10,9 +10,8 @@ import tensorflow as tf
 from ordered_set import OrderedSet
 
 import zfit.z.numpy as znp
-from .. import settings, z
-from .interfaces import ZfitPDF
 
+from .. import settings, z
 from ..util import ztyping
 from ..util.checks import NONE
 from ..util.container import convert_to_container, is_container
@@ -27,7 +26,7 @@ from ..z.math import (autodiff_gradient, autodiff_value_gradients,
 from .baseobject import BaseNumeric, extract_filter_params
 from .constraint import BaseConstraint
 from .dependents import _extract_dependencies
-from .interfaces import ZfitData, ZfitLoss, ZfitSpace
+from .interfaces import ZfitData, ZfitLoss, ZfitPDF, ZfitSpace
 from .parameter import convert_to_parameters
 
 

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -627,8 +627,8 @@ class ExtendedUnbinnedNLL(UnbinnedNLL):
             nevents = tf.cast(nevents, tf.float64)
             nevents_collected.append(nevents)
             yields.append(mod.get_yield())
-        yields = tf.stack(yields, axis=0)
-        nevents_collected = tf.stack(nevents_collected, axis=0)
+        yields = znp.stack(yields, axis=0)
+        nevents_collected = znp.stack(nevents_collected, axis=0)
 
         term_new = tf.nn.log_poisson_loss(nevents_collected, znp.log(yields))
         if log_offset is not None:

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -9,10 +9,10 @@ from typing import (Callable, Iterable, List, Mapping, Optional, Set, Tuple,
 import tensorflow as tf
 from ordered_set import OrderedSet
 
+import zfit.z.numpy as znp
 from .. import settings, z
 from .interfaces import ZfitPDF
 
-znp = z.numpy
 from ..util import ztyping
 from ..util.checks import NONE
 from ..util.container import convert_to_container, is_container
@@ -64,7 +64,7 @@ def _unbinned_nll_tf(model: ztyping.PDFInputType, data: ztyping.DataInputType, f
                 probs = model.pdf(data, norm_range=fit_range)
         else:
             probs = model.pdf(data)
-        log_probs = tf.math.log(probs)
+        log_probs = znp.log(probs)
         nll = _nll_calc_unbinned_tf(log_probs=log_probs,
                                     weights=data.weights if data.weights is not None else None,
                                     log_offset=log_offset)
@@ -631,7 +631,7 @@ class ExtendedUnbinnedNLL(UnbinnedNLL):
         yields = tf.stack(yields, axis=0)
         nevents_collected = tf.stack(nevents_collected, axis=0)
 
-        term_new = tf.nn.log_poisson_loss(nevents_collected, tf.math.log(yields))
+        term_new = tf.nn.log_poisson_loss(nevents_collected, znp.log(yields))
         if log_offset is not None:
             term_new += log_offset
         nll += tf.reduce_sum(term_new, axis=0)

--- a/zfit/core/operations.py
+++ b/zfit/core/operations.py
@@ -4,6 +4,8 @@ from typing import Callable, Union
 
 import tensorflow as tf
 
+import zfit.z.numpy as znp
+
 from ..util import ztyping
 from ..util.exception import (BreakingAPIChangeError, IntentionAmbiguousError,
                               ModelIncompatibleError)
@@ -111,7 +113,7 @@ def multiply_param_func(param: ZfitParameter, func: ZfitFunc) -> ZfitFunc:
 def multiply_param_param(param1: ZfitParameter, param2: ZfitParameter) -> ZfitParameter:
     if not (isinstance(param1, ZfitParameter) and isinstance(param2, ZfitParameter)):
         raise TypeError(f"`param1` and `param2` need to be `ZfitParameter` and not {param1}, {param2}")
-    param = tf.multiply(param1, param2)
+    param = znp.multiply(param1, param2)
     return param
 
 
@@ -201,7 +203,7 @@ def add_param_param(param1: ZfitParameter, param2: ZfitParameter) -> ZfitParamet
     if not (isinstance(param1, ZfitParameter) and isinstance(param2, ZfitParameter)):
         raise TypeError(f"`param1` and `param2` need to be `ZfitParameter` and not {param1}, {param2}")
     # use the default behavior of variables
-    return tf.add(param1, param2)
+    return znp.add(param1, param2)
 
 
 # Conversions

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -21,6 +21,7 @@ from tensorflow.python.ops.resource_variable_ops import \
 from tensorflow.python.ops.variables import Variable
 from tensorflow.python.types.core import Tensor as TensorType
 
+import zfit.z.numpy as znp
 from .. import z
 from . import interfaces as zinterfaces
 from .dependents import _extract_dependencies
@@ -824,7 +825,7 @@ class ComplexParameter(ComposedParameter):  # TODO: change to real, imag as inpu
         arg = convert_to_parameter(arg, name=name + "_arg", prefer_constant=not floating)
         param = cls(name=name,
                     value_fn=lambda: tf.cast(
-                        tf.complex(mod * tf.math.cos(arg), mod * tf.math.sin(arg)),
+                        tf.complex(mod * znp.cos(arg), mod * znp.sin(arg)),
                         dtype=dtype),
                     params=[mod, arg])
         param._mod = mod

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -22,9 +22,7 @@ from tensorflow.python.ops.variables import Variable
 from tensorflow.python.types.core import Tensor as TensorType
 
 import zfit.z.numpy as znp
-from . import interfaces as zinterfaces
-from .dependents import _extract_dependencies
-from .interfaces import ZfitIndependentParameter, ZfitModel, ZfitParameter
+
 from .. import z
 from ..core.baseobject import BaseNumeric, extract_filter_params
 from ..minimizers.interface import ZfitResult
@@ -40,7 +38,9 @@ from ..util.exception import (BreakingAPIChangeError, FunctionNotImplemented,
                               NameAlreadyTakenError,
                               ParameterNotIndependentError)
 from ..util.temporary import TemporarilySet
-
+from . import interfaces as zinterfaces
+from .dependents import _extract_dependencies
+from .interfaces import ZfitIndependentParameter, ZfitModel, ZfitParameter
 
 # todo add type hints in this module for api
 

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -795,7 +795,7 @@ class ComplexParameter(ComposedParameter):  # TODO: change to real, imag as inpu
 
     @classmethod
     def from_cartesian(cls, name, real, imag, dtype=ztypes.complex,
-                       floating=True):  # TODO: correct dtype handling, also below
+                       floating=True) -> 'ComplexParameter':  # TODO: correct dtype handling, also below
         """Create a complex parameter from cartesian coordinates.
 
         Args:
@@ -813,7 +813,7 @@ class ComplexParameter(ComposedParameter):  # TODO: change to real, imag as inpu
         return param
 
     @classmethod
-    def from_polar(cls, name, mod, arg, dtype=ztypes.complex, floating=True, **kwargs):
+    def from_polar(cls, name, mod, arg, dtype=ztypes.complex, floating=True, **kwargs) -> 'ComplexParameter':
         """Create a complex parameter from polar coordinates.
 
         Args:
@@ -842,36 +842,24 @@ class ComplexParameter(ComposedParameter):  # TODO: change to real, imag as inpu
         return self._conj
 
     @property
-    def real(self):
+    def real(self) -> znp.ndarray:
         """Real part of the complex parameter."""
-        real = self._real
-        if real is None:
-            real = z.to_real(self)
-        return real
+        return znp.real(self)
 
     @property
-    def imag(self):
+    def imag(self) -> znp.ndarray:
         """Imaginary part of the complex parameter."""
-        imag = self._imag
-        if imag is None:
-            imag = tf.math.imag(tf.convert_to_tensor(value=self, dtype_hint=self.dtype))  # HACK tf bug #30029
-        return imag
+        return znp.imag(self)
 
     @property
-    def mod(self):
+    def mod(self) -> znp.ndarray:
         """Modulus (r) of the complex parameter."""
-        mod = self._mod
-        if mod is None:
-            mod = znp.abs(self)
-        return mod
+        return znp.abs(self)
 
     @property
-    def arg(self):
+    def arg(self) -> znp.ndarray:
         """Argument (phi) of the complex parameter."""
-        arg = self._arg
-        if arg is None:
-            arg = znp.arctan(self.imag / self.real)
-        return arg
+        return znp.angle(self)
 
 
 # register_tensor_conversion(ConstantParameter, "ConstantParameter", True)

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -862,7 +862,7 @@ class ComplexParameter(ComposedParameter):  # TODO: change to real, imag as inpu
         """Modulus (r) of the complex parameter."""
         mod = self._mod
         if mod is None:
-            mod = tf.math.abs(self)
+            mod = znp.abs(self)
         return mod
 
     @property

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -806,7 +806,7 @@ class ComplexParameter(ComposedParameter):  # TODO: change to real, imag as inpu
         real = convert_to_parameter(real, name=name + "_real", prefer_constant=not floating)
         imag = convert_to_parameter(imag, name=name + "_imag", prefer_constant=not floating)
         param = cls(name=name,
-                    value_fn=lambda: tf.cast(tf.complex(real, imag), dtype=dtype),
+                    value_fn=lambda _real, _imag: tf.cast(tf.complex(_real, _imag), dtype=dtype),
                     params=[real, imag])
         param._real = real
         param._imag = imag
@@ -824,8 +824,8 @@ class ComplexParameter(ComposedParameter):  # TODO: change to real, imag as inpu
         mod = convert_to_parameter(mod, name=name + "_mod", prefer_constant=not floating)
         arg = convert_to_parameter(arg, name=name + "_arg", prefer_constant=not floating)
         param = cls(name=name,
-                    value_fn=lambda: tf.cast(
-                        tf.complex(mod * znp.cos(arg), mod * znp.sin(arg)),
+                    value_fn=lambda _mod, _arg: tf.cast(
+                        tf.complex(_mod * znp.cos(_arg), _mod * znp.sin(_arg)),
                         dtype=dtype),
                     params=[mod, arg])
         param._mod = mod

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -22,6 +22,7 @@ from tensorflow.python.ops.variables import Variable
 from tensorflow.python.types.core import Tensor as TensorType
 
 import zfit.z.numpy as znp
+
 from .. import z
 from . import interfaces as zinterfaces
 from .dependents import _extract_dependencies

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -842,6 +842,10 @@ class ComplexParameter(ComposedParameter):  # TODO: change to real, imag as inpu
                                           dtype=self.dtype)
         return self._conj
 
+    # Todo: Fix return values of the properties real/imag/mod/arg.
+    # Since update to tf 2.5.0rc0 the tensorflow.experimental.numpy operations tend to return
+    # tf.Tensor instead of ndarray<tf.Tensor>. Correct behaviour seems to be up for debate.
+    # See issue on github https://github.com/tensorflow/tensorflow/issues/48376
     @property
     def real(self) -> znp.ndarray:
         """Real part of the complex parameter."""

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -870,7 +870,7 @@ class ComplexParameter(ComposedParameter):  # TODO: change to real, imag as inpu
         """Argument (phi) of the complex parameter."""
         arg = self._arg
         if arg is None:
-            arg = tf.math.atan(self.imag / self.real)
+            arg = znp.arctan(self.imag / self.real)
         return arg
 
 

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -840,27 +840,23 @@ class ComplexParameter(ComposedParameter):  # TODO: change to real, imag as inpu
                                           dtype=self.dtype)
         return self._conj
 
-    # Todo: Fix return values of the properties real/imag/mod/arg.
-    # Since update to tf 2.5.0rc0 the tensorflow.experimental.numpy operations tend to return
-    # tf.Tensor instead of ndarray<tf.Tensor>. Correct behaviour seems to be up for debate.
-    # See issue on github https://github.com/tensorflow/tensorflow/issues/48376
     @property
-    def real(self) -> znp.ndarray:
+    def real(self) -> tf.Tensor:
         """Real part of the complex parameter."""
         return znp.real(self)
 
     @property
-    def imag(self) -> znp.ndarray:
+    def imag(self) -> tf.Tensor:
         """Imaginary part of the complex parameter."""
         return znp.imag(self)
 
     @property
-    def mod(self) -> znp.ndarray:
+    def mod(self) -> tf.Tensor:
         """Modulus (r) of the complex parameter."""
         return znp.abs(self)
 
     @property
-    def arg(self) -> znp.ndarray:
+    def arg(self) -> tf.Tensor:
         """Argument (phi) of the complex parameter."""
         return znp.angle(self)
 

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -41,6 +41,7 @@ from ..util.exception import (BreakingAPIChangeError, FunctionNotImplemented,
                               ParameterNotIndependentError)
 from ..util.temporary import TemporarilySet
 
+
 # todo add type hints in this module for api
 
 
@@ -834,7 +835,7 @@ class ComplexParameter(ComposedParameter):  # TODO: change to real, imag as inpu
     def conj(self):
         """Returns a complex conjugated copy of the complex parameter."""
         if self._conj is None:
-            self._conj = ComplexParameter(name=f'{self.name}_conj', value_fn=lambda: tf.math.conj(self),
+            self._conj = ComplexParameter(name=f'{self.name}_conj', value_fn=lambda: znp.conj(self),
                                           params=self.get_cache_deps(),
                                           dtype=self.dtype)
         return self._conj

--- a/zfit/core/parameter.py
+++ b/zfit/core/parameter.py
@@ -22,13 +22,10 @@ from tensorflow.python.ops.variables import Variable
 from tensorflow.python.types.core import Tensor as TensorType
 
 import zfit.z.numpy as znp
-
-from .. import z
 from . import interfaces as zinterfaces
 from .dependents import _extract_dependencies
 from .interfaces import ZfitIndependentParameter, ZfitModel, ZfitParameter
-
-znp = z.numpy
+from .. import z
 from ..core.baseobject import BaseNumeric, extract_filter_params
 from ..minimizers.interface import ZfitResult
 from ..settings import run, ztypes

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -208,7 +208,7 @@ def accept_reject_sample(prob: Callable, n: int, limits: ZfitSpace,
     @z.function(wraps='tensor')
     def sample_body(n, sample, n_produced=0, n_total_drawn=0, eff=1.0, is_sampled=None, weights_scaling=0.,
                     weights_maximum=0., prob_maximum=0., n_min_to_produce=10000):
-        eff = tf.reduce_max(input_tensor=[eff, z.to_real(1e-6)])
+        eff = znp.max([eff, z.to_real(1e-6)])
         n_to_produce = n - n_produced
 
         if isinstance(limits, EventSpace):  # EXPERIMENTAL(Mayou36): added to test EventSpace
@@ -268,16 +268,16 @@ def accept_reject_sample(prob: Callable, n: int, limits: ZfitSpace,
         if prob_max_init is None or weights_max is None:  # TODO(performance): estimate prob_max, after enough estimations -> fix it?
 
             # safety margin, predicting future, improve for small samples?
-            weights_maximum_new = tf.reduce_max(input_tensor=weights)
+            weights_maximum_new = znp.max(weights)
             weights_maximum = znp.maximum(weights_maximum, weights_maximum_new)
             # if run.numeric_checks:
             #     tf.debugging.assert_greater_equal(weights, weights_maximum * 1e-5, message="The ")
             weights_clipped = znp.maximum(weights, weights_maximum * 1e-5)
             # prob_weights_ratio = probabilities / weights
-            prob_maximum_new = tf.reduce_max(probabilities)
+            prob_maximum_new = znp.max(probabilities)
             prob_maximum = znp.maximum(prob_maximum, prob_maximum_new)
             # prob_weights_ratio = probabilities / weights_clipped
-            prob_weights_ratio_max = tf.reduce_max(probabilities / weights_clipped)
+            prob_weights_ratio_max = znp.max(probabilities / weights_clipped)
             max_prob_weights_ratio = znp.maximum(prob_maximum / weights_maximum, prob_weights_ratio_max)
             # clipping means that we don't scale more for a certain threshold
             # to properly account for very small numbers, the thresholds should be scaled to match the ratio
@@ -366,8 +366,8 @@ def accept_reject_sample(prob: Callable, n: int, limits: ZfitSpace,
         sample_new = sample.scatter(indices=tf.cast(indices, dtype=tf.int32), value=filtered_sample)
 
         # efficiency (estimate) of how many samples we get
-        eff = tf.reduce_max(input_tensor=[z.to_real(n_produced_new), z.to_real(1.)]) / tf.reduce_max(
-            input_tensor=[z.to_real(n_total_drawn), z.to_real(1.)])
+        eff = znp.max([z.to_real(n_produced_new), z.to_real(1.)]) / znp.max(
+            [z.to_real(n_total_drawn), z.to_real(1.)])
         return (
             n, sample_new, n_produced_new, n_total_drawn, eff, is_sampled, weights_scaling, weights_maximum,
             prob_maximum, n_min_to_produce

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -5,6 +5,8 @@ from typing import Callable, Iterable, List, Optional, Tuple, Union
 import tensorflow as tf
 from tensorflow_probability import distributions as tfd
 
+import zfit.z.numpy as znp
+
 from .. import settings, z
 from ..settings import run, ztypes
 from ..util import ztyping
@@ -228,7 +230,7 @@ def accept_reject_sample(prob: Callable, n: int, limits: ZfitSpace,
             eff_precision: int = 100
             one_over_eff_int = tf.cast(1 / eff * 1.01 * eff_precision, dtype=tf.int64)
             n_to_produce *= one_over_eff_int
-            n_to_produce = tf.math.floordiv(n_to_produce, eff_precision)
+            n_to_produce = znp.floor_divide(n_to_produce, eff_precision)
             # tf.debugging.assert_positive(n_to_produce_float, "n_to_produce went negative, overflow?")
             # n_to_produce = tf.cast(n_to_produce_float, dtype=tf.int64) + 3  # just to make sure
             n_to_produce = tf.maximum(n_to_produce, n_min_to_produce)

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -6,14 +6,15 @@ import tensorflow as tf
 from tensorflow_probability import distributions as tfd
 
 import zfit.z.numpy as znp
-from .data import Data
-from .interfaces import ZfitPDF, ZfitSpace
-from .space import Space
+
 from .. import settings, z
 from ..settings import run, ztypes
 from ..util import ztyping
 from ..util.container import convert_to_container
 from ..util.exception import WorkInProgressError
+from .data import Data
+from .interfaces import ZfitPDF, ZfitSpace
+from .space import Space
 
 
 class UniformSampleAndWeights:

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -48,8 +48,8 @@ class UniformSampleAndWeights:
             thresholds_unscaled_list.append(thresholds_unscaled)
             n_produced += n_partial_to_produce
 
-        rnd_sample = tf.concat(rnd_samples, axis=0)
-        thresholds_unscaled = tf.concat(thresholds_unscaled_list, axis=0)
+        rnd_sample = znp.concatenate(rnd_samples, axis=0)
+        thresholds_unscaled = znp.concatenate(thresholds_unscaled_list, axis=0)
 
         n_drawn = n_to_produce
         return rnd_sample, thresholds_unscaled, weights, weights, n_drawn
@@ -456,5 +456,5 @@ def extended_sampling(pdfs: Union[Iterable[ZfitPDF], ZfitPDF], limits: Space) ->
         # sample.set_shape((n, limits.n_obs))
         samples.append(sample)
 
-    samples = tf.concat(samples, axis=0)
+    samples = znp.concatenate(samples, axis=0)
     return samples

--- a/zfit/core/space.py
+++ b/zfit/core/space.py
@@ -17,11 +17,7 @@ from tensorflow.python.util.deprecation import deprecated
 
 import zfit
 import zfit.z.numpy as znp
-from .baseobject import BaseObject
-from .coordinates import (Coordinates, _convert_obs_to_str, convert_to_axes,
-                          convert_to_obs_str)
-from .dimension import common_axes, common_obs, limits_overlap
-from .interfaces import ZfitLimit, ZfitOrderableDimensional, ZfitSpace
+
 from .. import z
 from ..settings import ztypes
 from ..util import ztyping
@@ -41,6 +37,11 @@ from ..util.exception import (AxesIncompatibleError, AxesNotSpecifiedError,
                               ObsIncompatibleError, ObsNotSpecifiedError,
                               OverdefinedError, ShapeIncompatibleError,
                               SpaceIncompatibleError)
+from .baseobject import BaseObject
+from .coordinates import (Coordinates, _convert_obs_to_str, convert_to_axes,
+                          convert_to_obs_str)
+from .dimension import common_axes, common_obs, limits_overlap
+from .interfaces import ZfitLimit, ZfitOrderableDimensional, ZfitSpace
 
 
 class LimitRangeDefinition:

--- a/zfit/core/space.py
+++ b/zfit/core/space.py
@@ -188,7 +188,7 @@ def _sanitize_x_input(x, n_obs):
         if x.shape.ndims == 0:
             x = tf.broadcast_to(x, (1, 1))
         else:
-            x = tf.expand_dims(x, axis=-1)
+            x = znp.expand_dims(x, axis=-1)
     if tf.get_static_value(x.shape[-1]) != n_obs:
         raise ShapeIncompatibleError("n_obs and the last dim of x do not agree. Assuming x has shape (..., n_obs)")
     return x

--- a/zfit/minimizers/errors.py
+++ b/zfit/minimizers/errors.py
@@ -9,6 +9,8 @@ import scipy.stats
 import tensorflow as tf
 from scipy import optimize
 
+import zfit.z.numpy as znp
+
 from .. import settings, z
 from ..core.interfaces import ZfitIndependentParameter
 from ..core.parameter import assign_values
@@ -220,7 +222,7 @@ def covariance_with_weights(method, result, params):
             if d.weights is not None:
                 v *= d.weights
             values.append(v)
-        return tf.concat(values, axis=0)
+        return znp.concatenate(values, axis=0)
 
     if settings.options['numerical_grad']:
         def wrapped_func(values):

--- a/zfit/minimizers/minimizer_tfp.py
+++ b/zfit/minimizers/minimizer_tfp.py
@@ -6,10 +6,8 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 
-from .. import z
-from ..core.parameter import set_values
 from .baseminimizer import BaseMinimizer, minimize_supports
-from .evaluation import print_gradient, print_params
+from .evaluation import print_gradient
 from .fitresult import FitResult
 from .strategy import ZfitStrategy
 

--- a/zfit/minimizers/minimizer_tfp.py
+++ b/zfit/minimizers/minimizer_tfp.py
@@ -6,6 +6,8 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 
+import zfit.z.numpy as znp
+
 from .baseminimizer import BaseMinimizer, minimize_supports
 from .evaluation import print_gradient
 from .fitresult import FitResult
@@ -86,13 +88,13 @@ class BFGS(BaseMinimizer):
                 nan_counter = 0
                 current_loss = value
 
-            gradient = tf.stack(gradient)
+            gradient = znp.stack(gradient)
             return value, gradient
 
         initial_inv_hessian_est = tf.linalg.tensor_diag([p.step_size for p in params])
 
         minimizer_kwargs = dict(
-            initial_position=tf.stack(params),
+            initial_position=znp.stack(params),
             x_tol=self.tol,
             # f_relative_tolerance=self.tolerance * 1e-5,  # TODO: use edm for stopping criteria
             initial_inverse_hessian_estimate=initial_inv_hessian_est,

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -11,8 +11,8 @@ import numpy as np
 import tensorflow as tf
 
 import zfit.z.math
-from zfit import z
 import zfit.z.numpy as znp
+from zfit import z
 
 from ..core.basepdf import BasePDF
 from ..core.space import ANY_LOWER, ANY_UPPER, Space

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -5,7 +5,6 @@ Gauss, exponential... that can be used together with Functors to build larger mo
 
 #  Copyright (c) 2021 zfit
 import contextlib
-import math as mt
 
 import numpy as np
 import tensorflow as tf
@@ -13,37 +12,12 @@ import tensorflow as tf
 import zfit.z.math
 import zfit.z.numpy as znp
 from zfit import z
-
 from ..core.basepdf import BasePDF
 from ..core.space import ANY_LOWER, ANY_UPPER, Space
 from ..util import ztyping
 from ..util.exception import (AnalyticIntegralNotImplemented,
                               BreakingAPIChangeError)
 from ..util.warnings import warn_advanced_feature
-
-infinity = mt.inf
-
-
-class CustomGaussOLD(BasePDF):
-
-    def __init__(self, mu, sigma, obs, name="Gauss"):
-        super().__init__(name=name, obs=obs, params=dict(mu=mu, sigma=sigma))
-
-    def _unnormalized_pdf(self, x):
-        x = x.unstack_x()
-        mu = self.params['mu']
-        sigma = self.params['sigma']
-        gauss = znp.exp(- 0.5 * tf.square((x - mu) / sigma))
-
-        return gauss
-
-
-def _gauss_integral_from_inf_to_inf(limits, params, model):
-    return tf.sqrt(2 * z.pi) * params['sigma']
-
-
-CustomGaussOLD.register_analytic_integral(func=_gauss_integral_from_inf_to_inf,
-                                          limits=Space(limits=(-infinity, infinity), axes=(0,)))
 
 
 class Exponential(BasePDF):

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -12,6 +12,7 @@ import tensorflow as tf
 
 import zfit.z.math
 from zfit import z
+import zfit.z.numpy as znp
 
 from ..core.basepdf import BasePDF
 from ..core.space import ANY_LOWER, ANY_UPPER, Space
@@ -32,7 +33,7 @@ class CustomGaussOLD(BasePDF):
         x = x.unstack_x()
         mu = self.params['mu']
         sigma = self.params['sigma']
-        gauss = tf.exp(- 0.5 * tf.square((x - mu) / sigma))
+        gauss = znp.exp(- 0.5 * tf.square((x - mu) / sigma))
 
         return gauss
 

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -107,8 +107,8 @@ class Exponential(BasePDF):
                     upper.append(z.convert_to_tensor(up[:, 0]))
                 lower = z.convert_to_tensor(lower)
                 upper = z.convert_to_tensor(upper)
-                lower_val = tf.math.reduce_min(lower, axis=0)
-                upper_val = tf.math.reduce_max(upper, axis=0)
+                lower_val = znp.min(lower, axis=0)
+                upper_val = znp.max(upper, axis=0)
 
                 return (upper_val + lower_val) / 2
 

--- a/zfit/models/basic.py
+++ b/zfit/models/basic.py
@@ -12,6 +12,7 @@ import tensorflow as tf
 import zfit.z.math
 import zfit.z.numpy as znp
 from zfit import z
+
 from ..core.basepdf import BasePDF
 from ..core.space import ANY_LOWER, ANY_UPPER, Space
 from ..util import ztyping

--- a/zfit/models/conditional.py
+++ b/zfit/models/conditional.py
@@ -4,6 +4,8 @@ from typing import Mapping, Optional, Set
 
 import tensorflow as tf
 
+import zfit.z.numpy as znp
+
 from .. import z
 from ..core.interfaces import ZfitIndependentParameter, ZfitPDF, ZfitSpace
 from ..core.parameter import set_values
@@ -136,7 +138,7 @@ class ConditionalPDFV1(BaseFunctor):
             return pdf.sample(n=1, limits=limits).value()
 
         sample_rnd = tf_map(eval_sample, x_values)[..., 0]
-        sample = tf.concat([sample_rnd, x_values], axis=-1)
+        sample = znp.concatenate([sample_rnd, x_values], axis=-1)
         return sample
 
     def copy(self, **override_parameters) -> 'BasePDF':

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -6,15 +6,15 @@ import tensorflow_addons as tfa
 import tensorflow_probability as tfp
 
 import zfit.z.numpy as znp
-from .functor import BaseFunctor
+
 from .. import exception, z
 from ..core.data import Data, sum_samples
 from ..core.interfaces import ZfitPDF
 from ..core.sample import accept_reject_sample
 from ..core.space import supports
 from ..util import ztyping
-from ..util.exception import (ShapeIncompatibleError,
-                              WorkInProgressError)
+from ..util.exception import ShapeIncompatibleError, WorkInProgressError
+from .functor import BaseFunctor
 
 
 class FFTConvPDFV1(BaseFunctor):

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -6,7 +6,7 @@ import tensorflow_addons as tfa
 import tensorflow_probability as tfp
 
 import zfit.z.numpy as znp
-
+from .functor import BaseFunctor
 from .. import exception, z
 from ..core.data import Data, sum_samples
 from ..core.interfaces import ZfitPDF
@@ -14,9 +14,7 @@ from ..core.sample import accept_reject_sample
 from ..core.space import supports
 from ..util import ztyping
 from ..util.exception import (ShapeIncompatibleError,
-                              SpecificFunctionNotImplemented,
                               WorkInProgressError)
-from .functor import BaseFunctor
 
 
 class FFTConvPDFV1(BaseFunctor):
@@ -192,7 +190,7 @@ class FFTConvPDFV1(BaseFunctor):
         # the function as well
         area_ratios = (upper_sample - lower_sample) / (
                 limits_kernel.rect_upper - limits_kernel.rect_lower)
-        nbins_func_exact_max = tf.reduce_max(area_ratios * n)
+        nbins_func_exact_max = znp.max(area_ratios * n)
         nbins_func = znp.ceil(nbins_func_exact_max)  # plus one and floor is like ceiling (we want more bins) with the
         # guarantee that we add one bin (e.g. if we hit exactly the boundaries, we add one.
         nbins_kernel = n

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -229,12 +229,12 @@ class FFTConvPDFV1(BaseFunctor):
         x_kernels = tf.linspace(lower_kernel, upper_kernel, tf.cast(nbins_kernel, tf.int32))
 
         x_func = tf.meshgrid(*tf.unstack(x_funcs, axis=-1), indexing='ij')
-        x_func = tf.transpose(x_func)
+        x_func = znp.transpose(x_func)
         x_func_flatish = tf.reshape(x_func, (-1, self.n_obs))
         data_func = Data.from_tensor(tensor=x_func_flatish, obs=self.obs)
 
         x_kernel = tf.meshgrid(*tf.unstack(x_kernels, axis=-1), indexing='ij')
-        x_kernel = tf.transpose(x_kernel)
+        x_kernel = znp.transpose(x_kernel)
         x_kernel_flatish = tf.reshape(x_kernel, (-1, self.n_obs))
         data_kernel = Data.from_tensor(tensor=x_kernel_flatish, obs=self.obs)
 

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -285,8 +285,8 @@ class FFTConvPDFV1(BaseFunctor):
         #     y_kernel_rect,
         #     mode='same'
         # )[None, ..., None]
-        train_points = tf.expand_dims(x_func, axis=0)
-        query_points = tf.expand_dims(x.value(), axis=0)
+        train_points = znp.expand_dims(x_func, axis=0)
+        query_points = znp.expand_dims(x.value(), axis=0)
         if self.conv_interpolation == 'spline':
             conv_points = tf.reshape(conv, (1, -1, 1))
             prob = tfa.image.interpolate_spline(train_points=train_points,

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 import tensorflow_addons as tfa
 import tensorflow_probability as tfp
 
+import zfit.z.numpy as znp
 from .. import exception, z
 from ..core.data import Data, sum_samples
 from ..core.interfaces import ZfitPDF
@@ -191,8 +192,7 @@ class FFTConvPDFV1(BaseFunctor):
         area_ratios = (upper_sample - lower_sample) / (
                 limits_kernel.rect_upper - limits_kernel.rect_lower)
         nbins_func_exact_max = tf.reduce_max(area_ratios * n)
-        nbins_func = tf.math.ceil(
-            nbins_func_exact_max)  # plus one and floor is like ceiling (we want more bins) with the
+        nbins_func = znp.ceil(nbins_func_exact_max)  # plus one and floor is like ceiling (we want more bins) with the
         # guarantee that we add one bin (e.g. if we hit exactly the boundaries, we add one.
         nbins_kernel = n
         # n = max(n, npoints_scaling)

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -6,6 +6,7 @@ import tensorflow_addons as tfa
 import tensorflow_probability as tfp
 
 import zfit.z.numpy as znp
+
 from .. import exception, z
 from ..core.data import Data, sum_samples
 from ..core.interfaces import ZfitPDF

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -230,12 +230,12 @@ class FFTConvPDFV1(BaseFunctor):
 
         x_func = tf.meshgrid(*tf.unstack(x_funcs, axis=-1), indexing='ij')
         x_func = znp.transpose(x_func)
-        x_func_flatish = tf.reshape(x_func, (-1, self.n_obs))
+        x_func_flatish = znp.reshape(x_func, (-1, self.n_obs))
         data_func = Data.from_tensor(tensor=x_func_flatish, obs=self.obs)
 
         x_kernel = tf.meshgrid(*tf.unstack(x_kernels, axis=-1), indexing='ij')
         x_kernel = znp.transpose(x_kernel)
-        x_kernel_flatish = tf.reshape(x_kernel, (-1, self.n_obs))
+        x_kernel_flatish = znp.reshape(x_kernel, (-1, self.n_obs))
         data_kernel = Data.from_tensor(tensor=x_kernel_flatish, obs=self.obs)
 
         y_func = self.pdfs[0].pdf(data_func, norm_range=False)
@@ -244,8 +244,8 @@ class FFTConvPDFV1(BaseFunctor):
         func_dims = [nbins_func] * self.n_obs
         kernel_dims = [nbins_kernel] * self.n_obs
 
-        y_func = tf.reshape(y_func, func_dims)
-        y_kernel = tf.reshape(y_kernel, kernel_dims)
+        y_func = znp.reshape(y_func, func_dims)
+        y_kernel = znp.reshape(y_kernel, kernel_dims)
 
         # flip the kernel to use the cross-correlation called `convolution function from TF
         # convolution = cross-correlation with flipped kernel
@@ -259,16 +259,16 @@ class FFTConvPDFV1(BaseFunctor):
         upper_func += kernel_shift
 
         # make rectangular grid
-        y_func_rect = tf.reshape(y_func, func_dims)
-        y_kernel_rect = tf.reshape(y_kernel, kernel_dims)
+        y_func_rect = znp.reshape(y_func, func_dims)
+        y_kernel_rect = znp.reshape(y_kernel, kernel_dims)
 
         # needed for multi dims?
         # if self.n_obs == 2:
         #     y_kernel_rect = tf.linalg.adjoint(y_kernel_rect)
 
         # get correct shape for tf.nn.convolution
-        y_func_rect_conv = tf.reshape(y_func_rect, (1, *func_dims, 1))
-        y_kernel_rect_conv = tf.reshape(y_kernel_rect, (*kernel_dims, 1, 1))
+        y_func_rect_conv = znp.reshape(y_func_rect, (1, *func_dims, 1))
+        y_kernel_rect_conv = znp.reshape(y_kernel_rect, (*kernel_dims, 1, 1))
 
         conv = tf.nn.convolution(
             input=y_func_rect_conv,
@@ -288,7 +288,7 @@ class FFTConvPDFV1(BaseFunctor):
         train_points = znp.expand_dims(x_func, axis=0)
         query_points = znp.expand_dims(x.value(), axis=0)
         if self.conv_interpolation == 'spline':
-            conv_points = tf.reshape(conv, (1, -1, 1))
+            conv_points = znp.reshape(conv, (1, -1, 1))
             prob = tfa.image.interpolate_spline(train_points=train_points,
                                                 train_values=conv_points,
                                                 query_points=query_points,

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -145,7 +145,7 @@ class WrapDistribution(BasePDF):  # TODO: extend functionality of wrapper, like 
 #
 #     def _unnormalized_pdf(self, x: "zfit.Data", norm_range=False):
 #         value = znp.expand_dims(x.value(), -2)
-#         new_shape = tf.concat([tf.shape(value)[:2], [tf.shape(self._latent_loc)[0], 4]], axis=0)
+#         new_shape = znp.concatenate([tf.shape(value)[:2], [tf.shape(self._latent_loc)[0], 4]], axis=0)
 #         value = tf.broadcast_to(value, new_shape)
 #         probs = self.distribution.prob(value=value, name="unnormalized_pdf")
 #         # weights = znp.expand_dims(self._weights_loc, axis=-1)

--- a/zfit/models/dist_tfp.py
+++ b/zfit/models/dist_tfp.py
@@ -144,11 +144,11 @@ class WrapDistribution(BasePDF):  # TODO: extend functionality of wrapper, like 
 #                          name=name)
 #
 #     def _unnormalized_pdf(self, x: "zfit.Data", norm_range=False):
-#         value = tf.expand_dims(x.value(), -2)
+#         value = znp.expand_dims(x.value(), -2)
 #         new_shape = tf.concat([tf.shape(value)[:2], [tf.shape(self._latent_loc)[0], 4]], axis=0)
 #         value = tf.broadcast_to(value, new_shape)
 #         probs = self.distribution.prob(value=value, name="unnormalized_pdf")
-#         # weights = tf.expand_dims(self._weights_loc, axis=-1)
+#         # weights = znp.expand_dims(self._weights_loc, axis=-1)
 #         weights = self._weights_loc
 #         probs = z.reduce_sum(probs * weights, axis=-1) / self._weights_sum
 #         return probs

--- a/zfit/models/functions.py
+++ b/zfit/models/functions.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict, Iterable, Union
 import tensorflow as tf
 
 import zfit.z.numpy as znp
+
 from ..core.basefunc import BaseFunc
 from ..core.basemodel import SimpleModelSubclassMixin
 from ..core.dependents import _extract_dependencies

--- a/zfit/models/functions.py
+++ b/zfit/models/functions.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, Iterable, Union
 
 import tensorflow as tf
 
+import zfit.z.numpy as znp
 from ..core.basefunc import BaseFunc
 from ..core.basemodel import SimpleModelSubclassMixin
 from ..core.dependents import _extract_dependencies
@@ -79,7 +80,7 @@ class ProdFunc(BaseFunctorFunc):
 
     def _func(self, x):
         funcs = [func.func(x) for func in self.funcs]
-        product = tf.reduce_prod(funcs, axis=0)
+        product = znp.prod(funcs, axis=0)
         return product
 
 

--- a/zfit/models/functor.py
+++ b/zfit/models/functor.py
@@ -13,6 +13,7 @@ from typing import List, Optional
 import tensorflow as tf
 
 import zfit.z.numpy as znp
+
 from .. import z
 from ..core.basepdf import BasePDF
 from ..core.coordinates import convert_to_obs_str

--- a/zfit/models/functor.py
+++ b/zfit/models/functor.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 
 import tensorflow as tf
 
+import zfit.z.numpy as znp
 from .. import z
 from ..core.basepdf import BasePDF
 from ..core.coordinates import convert_to_obs_str
@@ -153,8 +154,8 @@ class SumPDF(BaseFunctor):
             yields = [pdf.get_yield() for pdf in pdfs]
 
             def sum_yields_func():
-                return tf.reduce_sum(
-                    input_tensor=[tf.convert_to_tensor(value=y, dtype_hint=ztypes.float) for y in yields])
+                return znp.sum(
+                    [tf.convert_to_tensor(value=y, dtype_hint=ztypes.float) for y in yields])
 
             sum_yields = convert_to_parameter(sum_yields_func, params=yields)
             yield_fracs = [convert_to_parameter(lambda sum_yields, yield_: yield_ / sum_yields,

--- a/zfit/models/functor.py
+++ b/zfit/models/functor.py
@@ -271,7 +271,7 @@ class SumPDF(BaseFunctor):
             if isinstance(sub_sample, ZfitData):
                 sub_sample = sub_sample.value()
             samples.append(sub_sample)
-        sample = tf.concat(samples, axis=0)
+        sample = znp.concatenate(samples, axis=0)
         sample = tf.random.shuffle(sample)
         return sample
 

--- a/zfit/models/kde.py
+++ b/zfit/models/kde.py
@@ -7,6 +7,7 @@ import tensorflow_probability as tfp
 from tensorflow_probability.python import distributions as tfd
 
 import zfit.z.numpy as znp
+
 from .. import z
 from ..core.interfaces import ZfitData, ZfitSpace
 from ..settings import ztypes

--- a/zfit/models/kde.py
+++ b/zfit/models/kde.py
@@ -7,13 +7,12 @@ import tensorflow_probability as tfp
 from tensorflow_probability.python import distributions as tfd
 
 import zfit.z.numpy as znp
-
+from .dist_tfp import WrapDistribution
 from .. import z
 from ..core.interfaces import ZfitData, ZfitSpace
 from ..settings import ztypes
 from ..util import ztyping
 from ..util.exception import OverdefinedError, ShapeIncompatibleError
-from .dist_tfp import WrapDistribution
 
 
 def bandwidth_rule_of_thumb(data, factor=0.9):
@@ -145,7 +144,7 @@ class GaussianKDE1DimV1(WrapDistribution):
         shape_data = tf.shape(data)
         size = tf.cast(shape_data[0], dtype=ztypes.float)
         if weights is not None:
-            probs = weights / tf.reduce_sum(weights)
+            probs = weights / znp.sum(weights)
         else:
             probs = tf.broadcast_to(1 / size, shape=(tf.cast(size, tf.int32),))
         categorical = tfd.Categorical(probs=probs)  # no grad -> no need to recreate

--- a/zfit/models/kde.py
+++ b/zfit/models/kde.py
@@ -52,7 +52,7 @@ def _bandwidth_silverman_KDEV1(data, *_, **__):
 
 @z.function(wraps='tensor')
 def min_std_or_iqr(x):
-    return znp.minimum(tf.math.reduce_std(x), (tfp.stats.percentile(x, 75) - tfp.stats.percentile(x, 25)))
+    return znp.minimum(znp.std(x), (tfp.stats.percentile(x, 75) - tfp.stats.percentile(x, 25)))
 
 
 class GaussianKDE1DimV1(WrapDistribution):

--- a/zfit/models/kde.py
+++ b/zfit/models/kde.py
@@ -169,7 +169,7 @@ class GaussianKDE1DimV1(WrapDistribution):
             if not isinstance(obs, ZfitSpace):
                 raise ValueError(f"`obs` has to be a `ZfitSpace` if `truncated` is True.")
             inside = obs.inside(data)
-            all_inside = tf.reduce_all(inside)
+            all_inside = znp.all(inside)
             tf.debugging.assert_equal(all_inside, True, message="Not all data points are inside the limits but"
                                                                 " a truncate kernel was chosen.")
 

--- a/zfit/models/kde.py
+++ b/zfit/models/kde.py
@@ -6,6 +6,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 from tensorflow_probability.python import distributions as tfd
 
+import zfit.z.numpy as znp
 from .. import z
 from ..core.interfaces import ZfitData, ZfitSpace
 from ..settings import ztypes
@@ -51,7 +52,7 @@ def _bandwidth_silverman_KDEV1(data, *_, **__):
 
 @z.function(wraps='tensor')
 def min_std_or_iqr(x):
-    return tf.minimum(tf.math.reduce_std(x), (tfp.stats.percentile(x, 75) - tfp.stats.percentile(x, 25)))
+    return znp.minimum(tf.math.reduce_std(x), (tfp.stats.percentile(x, 75) - tfp.stats.percentile(x, 25)))
 
 
 class GaussianKDE1DimV1(WrapDistribution):

--- a/zfit/models/kde.py
+++ b/zfit/models/kde.py
@@ -7,12 +7,13 @@ import tensorflow_probability as tfp
 from tensorflow_probability.python import distributions as tfd
 
 import zfit.z.numpy as znp
-from .dist_tfp import WrapDistribution
+
 from .. import z
 from ..core.interfaces import ZfitData, ZfitSpace
 from ..settings import ztypes
 from ..util import ztyping
 from ..util.exception import OverdefinedError, ShapeIncompatibleError
+from .dist_tfp import WrapDistribution
 
 
 def bandwidth_rule_of_thumb(data, factor=0.9):

--- a/zfit/models/physics.py
+++ b/zfit/models/physics.py
@@ -5,10 +5,8 @@ from typing import Type
 import numpy as np
 import tensorflow as tf
 
-import zfit
 import zfit.z.numpy as znp
 from zfit import z
-
 from ..core.basepdf import BasePDF
 from ..core.space import ANY_LOWER, ANY_UPPER, Space
 from ..settings import ztypes
@@ -16,14 +14,14 @@ from ..util import ztyping
 
 
 def _powerlaw(x, a, k):
-    return a * tf.pow(x, k)
+    return a * znp.power(x, k)
 
 
 @z.function(wraps='zfit_tensor')
 def crystalball_func(x, mu, sigma, alpha, n):
     t = (x - mu) / sigma * tf.sign(alpha)
     abs_alpha = znp.abs(alpha)
-    a = tf.pow((n / abs_alpha), n) * znp.exp(-0.5 * tf.square(alpha))
+    a = znp.power((n / abs_alpha), n) * znp.exp(-0.5 * tf.square(alpha))
     b = (n / abs_alpha) - abs_alpha
     cond = tf.less(t, -abs_alpha)
     func = z.safe_where(cond,
@@ -85,7 +83,7 @@ def crystalball_integral_func(mu, sigma, alpha, n, lower, upper):
 
         def if_true_3():
             result_3 = result_6
-            a = tf.pow(n / abs_alpha, n) * znp.exp(-0.5 * tf.square(abs_alpha))
+            a = znp.power(n / abs_alpha, n) * znp.exp(-0.5 * tf.square(abs_alpha))
             b = n / abs_alpha - abs_alpha
 
             def if_true_1():
@@ -96,7 +94,7 @@ def crystalball_integral_func(mu, sigma, alpha, n, lower, upper):
             def if_false_1():
                 result_2, = result_3,
                 result_2 += a * abs_sigma / (1.0 - n) * (
-                    1.0 / tf.pow(b - tmin, n - 1.0) - 1.0 / tf.pow(b - tmax, n - 1.0))
+                    1.0 / znp.power(b - tmin, n - 1.0) - 1.0 / znp.power(b - tmax, n - 1.0))
                 return result_2
 
             result_3 = tf.cond(pred=use_log, true_fn=if_true_1, false_fn=if_false_1)
@@ -104,7 +102,7 @@ def crystalball_integral_func(mu, sigma, alpha, n, lower, upper):
 
         def if_false_3():
             result_4, = result_6,
-            a = tf.pow(n / abs_alpha, n) * znp.exp(-0.5 * tf.square(abs_alpha))
+            a = znp.power(n / abs_alpha, n) * znp.exp(-0.5 * tf.square(abs_alpha))
             b = n / abs_alpha - abs_alpha
 
             def if_true_2():
@@ -113,7 +111,7 @@ def crystalball_integral_func(mu, sigma, alpha, n, lower, upper):
 
             def if_false_2():
                 term1 = a * abs_sigma / (1.0 - n) * (
-                    1.0 / tf.pow(b - tmin, n - 1.0) - 1.0 / tf.pow(n / abs_alpha, n - 1.0))
+                    1.0 / znp.power(b - tmin, n - 1.0) - 1.0 / znp.power(n / abs_alpha, n - 1.0))
                 return term1
 
             term1 = tf.cond(pred=use_log, true_fn=if_true_2, false_fn=if_false_2)

--- a/zfit/models/physics.py
+++ b/zfit/models/physics.py
@@ -90,7 +90,7 @@ def crystalball_integral_func(mu, sigma, alpha, n, lower, upper):
 
             def if_true_1():
                 result_1, = result_3,
-                result_1 += a * abs_sigma * (tf.math.log(b - tmin) - tf.math.log(b - tmax))
+                result_1 += a * abs_sigma * (znp.log(b - tmin) - znp.log(b - tmax))
                 return result_1
 
             def if_false_1():
@@ -108,7 +108,7 @@ def crystalball_integral_func(mu, sigma, alpha, n, lower, upper):
             b = n / abs_alpha - abs_alpha
 
             def if_true_2():
-                term1 = a * abs_sigma * (tf.math.log(b - tmin) - tf.math.log(n / abs_alpha))
+                term1 = a * abs_sigma * (znp.log(b - tmin) - znp.log(n / abs_alpha))
                 return term1
 
             def if_false_2():

--- a/zfit/models/physics.py
+++ b/zfit/models/physics.py
@@ -7,6 +7,7 @@ import tensorflow as tf
 
 import zfit
 from zfit import z
+import zfit.z.numpy as znp
 
 from ..core.basepdf import BasePDF
 from ..core.space import ANY_LOWER, ANY_UPPER, Space
@@ -22,12 +23,12 @@ def _powerlaw(x, a, k):
 def crystalball_func(x, mu, sigma, alpha, n):
     t = (x - mu) / sigma * tf.sign(alpha)
     abs_alpha = tf.abs(alpha)
-    a = tf.pow((n / abs_alpha), n) * tf.exp(-0.5 * tf.square(alpha))
+    a = tf.pow((n / abs_alpha), n) * znp.exp(-0.5 * tf.square(alpha))
     b = (n / abs_alpha) - abs_alpha
     cond = tf.less(t, -abs_alpha)
     func = z.safe_where(cond,
                         lambda t: _powerlaw(b - t, a, -n),
-                        lambda t: tf.exp(-0.5 * tf.square(t)),
+                        lambda t: znp.exp(-0.5 * tf.square(t)),
                         values=t, value_safer=lambda t: tf.ones_like(t) * (b - 2))
     func = tf.maximum(func, tf.zeros_like(func))
     return func
@@ -84,7 +85,7 @@ def crystalball_integral_func(mu, sigma, alpha, n, lower, upper):
 
         def if_true_3():
             result_3 = result_6
-            a = tf.pow(n / abs_alpha, n) * tf.exp(-0.5 * tf.square(abs_alpha))
+            a = tf.pow(n / abs_alpha, n) * znp.exp(-0.5 * tf.square(abs_alpha))
             b = n / abs_alpha - abs_alpha
 
             def if_true_1():
@@ -103,7 +104,7 @@ def crystalball_integral_func(mu, sigma, alpha, n, lower, upper):
 
         def if_false_3():
             result_4, = result_6,
-            a = tf.pow(n / abs_alpha, n) * tf.exp(-0.5 * tf.square(abs_alpha))
+            a = tf.pow(n / abs_alpha, n) * znp.exp(-0.5 * tf.square(abs_alpha))
             b = n / abs_alpha - abs_alpha
 
             def if_true_2():

--- a/zfit/models/physics.py
+++ b/zfit/models/physics.py
@@ -7,6 +7,7 @@ import tensorflow as tf
 
 import zfit.z.numpy as znp
 from zfit import z
+
 from ..core.basepdf import BasePDF
 from ..core.space import ANY_LOWER, ANY_UPPER, Space
 from ..settings import ztypes

--- a/zfit/models/physics.py
+++ b/zfit/models/physics.py
@@ -30,7 +30,7 @@ def crystalball_func(x, mu, sigma, alpha, n):
                         lambda t: _powerlaw(b - t, a, -n),
                         lambda t: znp.exp(-0.5 * tf.square(t)),
                         values=t, value_safer=lambda t: tf.ones_like(t) * (b - 2))
-    func = tf.maximum(func, tf.zeros_like(func))
+    func = znp.maximum(func, tf.zeros_like(func))
     return func
 
 

--- a/zfit/models/physics.py
+++ b/zfit/models/physics.py
@@ -6,8 +6,8 @@ import numpy as np
 import tensorflow as tf
 
 import zfit
-from zfit import z
 import zfit.z.numpy as znp
+from zfit import z
 
 from ..core.basepdf import BasePDF
 from ..core.space import ANY_LOWER, ANY_UPPER, Space

--- a/zfit/models/physics.py
+++ b/zfit/models/physics.py
@@ -22,7 +22,7 @@ def _powerlaw(x, a, k):
 @z.function(wraps='zfit_tensor')
 def crystalball_func(x, mu, sigma, alpha, n):
     t = (x - mu) / sigma * tf.sign(alpha)
-    abs_alpha = tf.abs(alpha)
+    abs_alpha = znp.abs(alpha)
     a = tf.pow((n / abs_alpha), n) * znp.exp(-0.5 * tf.square(alpha))
     b = (n / abs_alpha) - abs_alpha
     cond = tf.less(t, -abs_alpha)
@@ -63,9 +63,9 @@ def crystalball_integral_func(mu, sigma, alpha, n, lower, upper):
     sqrt_pi_over_two = np.sqrt(np.pi / 2)
     sqrt2 = np.sqrt(2)
 
-    use_log = tf.less(tf.abs(n - 1.0), 1e-05)
-    abs_sigma = tf.abs(sigma)
-    abs_alpha = tf.abs(alpha)
+    use_log = tf.less(znp.abs(n - 1.0), 1e-05)
+    abs_sigma = znp.abs(sigma)
+    abs_alpha = znp.abs(alpha)
     tmin = (lower - mu) / abs_sigma
     tmax = (upper - mu) / abs_sigma
 

--- a/zfit/models/polynomials.py
+++ b/zfit/models/polynomials.py
@@ -101,7 +101,7 @@ def legendre_recurrence(p1, p2, n, x):
     .. math::
          (n+1) P_{n+1}(x) = (2n + 1) x P_{n}(x) - n P_{n-1}(x)
     """
-    return ((2 * n + 1) * tf.multiply(x, p1) - n * p2) / (n + 1)
+    return ((2 * n + 1) * znp.multiply(x, p1) - n * p2) / (n + 1)
 
 
 def legendre_shape(x, coeffs):
@@ -194,7 +194,7 @@ def chebyshev_recurrence(p1, p2, _, x):
 
     T_{n+1}(x) = 2 x T_{n}(x) - T_{n-1}(x)
     """
-    return 2 * tf.multiply(x, p1) - p2
+    return 2 * znp.multiply(x, p1) - p2
 
 
 def chebyshev_shape(x, coeffs):
@@ -370,7 +370,7 @@ def generalized_laguerre_recurrence_factory(alpha=0.):
 
         :math:`(n+1) L_{n+1}(x) = (2n + 1 + \alpha - x) L_{n}(x) - (n + \alpha) L_{n-1}(x)`
         """
-        return (tf.multiply(2 * n + 1 + alpha - x, p1) - (n + alpha) * p2) / (n + 1)
+        return (znp.multiply(2 * n + 1 + alpha - x, p1) - (n + alpha) * p2) / (n + 1)
 
     return generalized_laguerre_recurrence
 
@@ -478,7 +478,7 @@ def hermite_recurrence(p1, p2, n, x):
 
     :math:`H_{n+1}(x) = 2x H_{n}(x) - 2n H_{n-1}(x)`
     """
-    return 2 * (tf.multiply(x, p1) - n * p2)
+    return 2 * (znp.multiply(x, p1) - n * p2)
 
 
 def hermite_shape(x, coeffs):

--- a/zfit/models/polynomials.py
+++ b/zfit/models/polynomials.py
@@ -7,6 +7,7 @@ import tensorflow as tf
 
 import zfit.z.numpy as znp
 from zfit import z
+
 from ..core.basepdf import BasePDF
 from ..core.space import Space
 from ..settings import ztypes

--- a/zfit/models/polynomials.py
+++ b/zfit/models/polynomials.py
@@ -5,8 +5,8 @@ from typing import Dict, List, Mapping, Optional
 
 import tensorflow as tf
 
+import zfit.z.numpy as znp
 from zfit import z
-
 from ..core.basepdf import BasePDF
 from ..core.space import Space
 from ..settings import ztypes
@@ -79,7 +79,7 @@ class RecursivePolynomial(BasePDF):
 def create_poly(x, polys, coeffs, recurrence):
     degree = len(coeffs) - 1
     polys = do_recurrence(x, polys=polys, degree=degree, recurrence=recurrence)
-    sum_polys = tf.reduce_sum(input_tensor=[coeff * poly for coeff, poly in zip(coeffs, polys)], axis=0)
+    sum_polys = znp.sum([coeff * poly for coeff, poly in zip(coeffs, polys)], axis=0)
     return sum_polys
 
 

--- a/zfit/models/polynomials.py
+++ b/zfit/models/polynomials.py
@@ -137,7 +137,7 @@ def legendre_integral(limits: ztyping.SpaceType, norm_range: ztyping.SpaceType,
             return z.reduce_sum(one_limit_integrals, axis=0)
 
         integral = indefinite_integral(upper) - indefinite_integral(lower) + integral_0
-        integral = tf.reshape(integral, shape=())
+        integral = znp.reshape(integral, newshape=())
     integral *= 0.5 * model.space.area()  # rescale back to whole width
 
     return integral
@@ -268,7 +268,7 @@ def func_integral_chebyshev1(limits, norm_range, params, model):
             return z.reduce_sum(one_limit_integrals, axis=0)
 
         integral += indefinite_integral(upper) - indefinite_integral(lower)
-        integral = tf.reshape(integral, shape=())
+        integral = znp.reshape(integral, newshape=())
     integral *= 0.5 * model.space.area()  # rescale back to whole width
     integral = tf.gather(integral, indices=0, axis=-1)
     return integral
@@ -346,7 +346,7 @@ def func_integral_chebyshev2(limits, norm_range, params, model):
         return chebyshev_shape(x=limits, coeffs=coeffs_cheby1)
 
     integral = indefinite_integral(upper) - indefinite_integral(lower)
-    integral = tf.reshape(integral, shape=())
+    integral = znp.reshape(integral, newshape=())
     integral *= 0.5 * model.space.area()  # rescale back to whole width
 
     return integral
@@ -461,7 +461,7 @@ def func_integral_laguerre(limits, norm_range, params: Dict, model):
         return -1 * laguerre_shape_alpha_minusone(x=limits, coeffs=coeffs_laguerre_nup)
 
     integral = indefinite_integral(upper) - indefinite_integral(lower)
-    integral = tf.reshape(integral, shape=())
+    integral = znp.reshape(integral, newshape=())
     integral *= 0.5 * model.space.area()  # rescale back to whole width
     return integral
 
@@ -543,7 +543,7 @@ def func_integral_hermite(limits, norm_range, params, model):
         return hermite_shape(x=limits, coeffs=coeffs)
 
     integral = indefinite_integral(upper) - indefinite_integral(lower)
-    integral = tf.reshape(integral, shape=())
+    integral = znp.reshape(integral, newshape=())
     integral *= 0.5 * model.space.area()  # rescale back to whole width
 
     return integral

--- a/zfit/z/__init__.py
+++ b/zfit/z/__init__.py
@@ -1,4 +1,6 @@
-"""z is a zfit TensorFlow version, that wraps TF while adding some conveniences, basically using a different default
+"""Thin wrapper around tensorflow.
+
+z is a zfit TensorFlow version, that wraps TF while adding some conveniences, basically using a different default
 dtype (`zfit.ztypes`). In addition, it expands TensorFlow by adding a few convenient functions helping to deal with
 `NaN`s and similar.
 

--- a/zfit/z/__init__.py
+++ b/zfit/z/__init__.py
@@ -7,32 +7,6 @@ Some function are already wrapped, others are not. Best practice is to use `z` w
 
 #  Copyright (c) 2021 zfit
 
-# fill the following in to the namespace for (future) wrapping
-
-# doesn't work below because of autoimport... probably anytime in the Future :)
-# from tensorflow import *  # Yes, this is wanted. Yields an equivalent z BUT we COULD wrap it :)
-# _module_dict = tensorflow.__dict__
-# try:
-#     _to_import = tensorflow.__all__
-# except AttributeError:
-#     _to_import = [name for name in _module_dict if not name.startswith('_')]
-#
-# __all__ = _to_import
-# del tensorflow
-# _imported = {}
-# _failed_imports = []
-# for _name in _to_import:
-#     try:
-#         _imported[_name] = _module_dict[_name]
-#     except KeyError as error:
-#         _failed_imports.append(_name)
-# if _failed_imports:
-#     warnings.warn("The following modules/attributes from TensorFlow could NOT be imported:\n{}".format(
-#     _failed_imports))
-# globals().update(_imported)
-#
-# del _imported, _failed_imports, _to_import, _module_dict
-
 from . import math, random, unstable
 from .wrapping_tf import (check_numerics, complex, convert_to_tensor, exp, pow,
                           random_normal, random_uniform, reduce_prod,

--- a/zfit/z/__init__.py
+++ b/zfit/z/__init__.py
@@ -33,12 +33,6 @@ Some function are already wrapped, others are not. Best practice is to use `z` w
 #
 # del _imported, _failed_imports, _to_import, _module_dict
 
-# same as in TensorFlow, wrapped
-
-
-# noinspection PyUnresolvedReferences
-import tensorflow.experimental.numpy as numpy
-
 from . import math, random, unstable
 from .wrapping_tf import (check_numerics, complex, convert_to_tensor, exp, pow,
                           random_normal, random_uniform, reduce_prod,

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -65,7 +65,7 @@ def numerical_gradient(func: Callable, params: Iterable["zfit.Parameter"]) -> tf
         gradient = tf.numpy_function(grad_func, inp=[param_vals],
                                      Tout=tf.float64)
     if gradient.shape == ():
-        gradient = tf.reshape(gradient, shape=(1,))
+        gradient = znp.reshape(gradient, newshape=(1,))
     gradient.set_shape(param_vals.shape)
     assign_values(params, original_vals)
     return gradient

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -6,11 +6,10 @@ import numdifftools
 import tensorflow as tf
 
 import zfit.z.numpy as znp
-
-from ..util.container import convert_to_container
-from ..util.deprecation import deprecated
 from .tools import _auto_upcast
 from .zextension import convert_to_tensor
+from ..util.container import convert_to_container
+from ..util.deprecation import deprecated
 
 
 def poly_complex(*args, real_x=False):
@@ -291,7 +290,7 @@ def automatic_value_gradients_hessian(*args, **kwargs):
 
 @tf.function(autograph=False)
 def reduce_geometric_mean(input_tensor, axis=None, keepdims=False):
-    log_mean = tf.reduce_mean(znp.log(input_tensor), axis=axis, keepdims=keepdims)
+    log_mean = znp.mean(znp.log(input_tensor), axis=axis, keepdims=keepdims)
     return znp.exp(log_mean)
 
 

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -6,10 +6,11 @@ import numdifftools
 import tensorflow as tf
 
 import zfit.z.numpy as znp
-from .tools import _auto_upcast
-from .zextension import convert_to_tensor
+
 from ..util.container import convert_to_container
 from ..util.deprecation import deprecated
+from .tools import _auto_upcast
+from .zextension import convert_to_tensor
 
 
 def poly_complex(*args, real_x=False):

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -26,7 +26,7 @@ def poly_complex(*args, real_x=False):
     args = list(args)
     x = args.pop()
     if real_x is not None:
-        pow_func = tf.pow
+        pow_func = znp.power
     else:
         pow_func = z.nth_pow
     return tf.add_n([coef * z.to_complex(pow_func(x, p)) for p, coef in enumerate(args)])

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -291,10 +291,10 @@ def automatic_value_gradients_hessian(*args, **kwargs):
 
 @tf.function(autograph=False)
 def reduce_geometric_mean(input_tensor, axis=None, keepdims=False):
-    log_mean = tf.reduce_mean(tf.math.log(input_tensor), axis=axis, keepdims=keepdims)
+    log_mean = tf.reduce_mean(znp.log(input_tensor), axis=axis, keepdims=keepdims)
     return znp.exp(log_mean)
 
 
-def log(x, name=None):
+def log(x):
     x = _auto_upcast(x)
-    return _auto_upcast(tf.math.log(x=x, name=name))
+    return _auto_upcast(znp.log(x=x))

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -5,6 +5,8 @@ from typing import Callable, Iterable, Optional
 import numdifftools
 import tensorflow as tf
 
+import zfit.z.numpy as znp
+
 from ..util.container import convert_to_container
 from ..util.deprecation import deprecated
 from .tools import _auto_upcast
@@ -290,7 +292,7 @@ def automatic_value_gradients_hessian(*args, **kwargs):
 @tf.function(autograph=False)
 def reduce_geometric_mean(input_tensor, axis=None, keepdims=False):
     log_mean = tf.reduce_mean(tf.math.log(input_tensor), axis=axis, keepdims=keepdims)
-    return tf.math.exp(log_mean)
+    return znp.exp(log_mean)
 
 
 def log(x, name=None):

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -55,7 +55,7 @@ def numerical_gradient(func: Callable, params: Iterable["zfit.Parameter"]) -> tf
             value = value.numpy()
         return value
 
-    param_vals = tf.stack(params)
+    param_vals = znp.stack(params)
     original_vals = [param.value() for param in params]
     grad_func = numdifftools.Gradient(wrapped_func, order=2, base_step=1e-4)
     if tf.executing_eagerly():
@@ -116,7 +116,7 @@ def numerical_hessian(func: Optional[Callable],
             value = value.numpy()
         return value
 
-    param_vals = tf.stack(params)
+    param_vals = znp.stack(params)
     original_vals = [param.value() for param in params]
 
     if hessian == 'diag':
@@ -270,11 +270,9 @@ def automatic_value_gradient_hessian(func: Callable = None, params: Iterable["zf
         else:
             loss, gradients = autodiff_value_gradients(func=func, params=params)
         if hessian != 'diag':
-            gradients_tf = tf.stack(gradients)
+            gradients_tf = znp.stack(gradients)
     if hessian == 'diag':
-        computed_hessian = tf.stack(
-            # tape.gradient(gradients_tf, sources=params)
-            # computed_hessian = tf.stack(tf.vectorized_map(lambda grad: tape.gradient(grad, sources=params), gradients))
+        computed_hessian = znp.stack(
             [tape.gradient(grad, sources=param) for param, grad in zip(params, gradients)]
         )
     else:

--- a/zfit/z/numpy.py
+++ b/zfit/z/numpy.py
@@ -1,0 +1,14 @@
+"""Numpy like interface for math functions and arrays.
+
+This module is intended to replace tensorflow specific methods and datastructures with equivalent or similar versions
+in the numpy api. This should help make zfit as a project portable to alternatives of tensorflow should it be
+necessary in the future.
+At the moment it is simply an alias for the numpy api of tensorflow.
+See https://www.tensorflow.org/guide/tf_numpy for more a guide to numpy api in tensorflow.
+See https://www.tensorflow.org/api_docs/python/tf/experimental/numpy for the complete numpy api in tensorflow.
+
+Recommended way of importing:
+>>> Import zfit.z.numpy as znp
+"""
+
+from tensorflow.experimental.numpy import *

--- a/zfit/z/unstable.py
+++ b/zfit/z/unstable.py
@@ -30,7 +30,7 @@ def allclose_anyaware(x, y, rtol=1e-5, atol=1e-8):
     Returns:
     """
     if not SWITCH_ON or has_tensor([x, y]):
-        return tf.reduce_all(tf.less_equal(znp.abs(x - y), znp.abs(y) * rtol + atol))
+        return znp.all(tf.less_equal(znp.abs(x - y), znp.abs(y) * rtol + atol))
     else:
         x = np.array(x)
         y = np.array(y)
@@ -82,14 +82,14 @@ def equal(x, y):
 
 def reduce_all(input_tensor, axis=None):
     if not SWITCH_ON or has_tensor(input_tensor):
-        return tf.reduce_all(input_tensor, axis)
+        return znp.all(input_tensor, axis)
     else:
         return np.all(input_tensor, axis)
 
 
 def reduce_any(input_tensor, axis=None):
     if not SWITCH_ON or has_tensor(input_tensor):
-        return tf.reduce_any(input_tensor, axis)
+        return znp.any(input_tensor, axis)
     else:
         return np.any(input_tensor, axis)
 

--- a/zfit/z/unstable.py
+++ b/zfit/z/unstable.py
@@ -58,7 +58,7 @@ def broadcast_to(input, shape):
 
 def expand_dims(input, axis):
     if not SWITCH_ON or has_tensor(input):
-        return tf.expand_dims(input, axis)
+        return znp.expand_dims(input, axis)
     else:
         return np.expand_dims(input, axis)
 

--- a/zfit/z/unstable.py
+++ b/zfit/z/unstable.py
@@ -65,7 +65,7 @@ def expand_dims(input, axis):
 
 def reduce_prod(input_tensor, axis=None, keepdims=None):
     if not SWITCH_ON or has_tensor(input_tensor):
-        return tf.reduce_prod(input_tensor, axis, keepdims=keepdims)
+        return znp.prod(input_tensor, axis, keepdims=keepdims)
     else:
         if keepdims is None:
             return np.prod(input_tensor, axis)

--- a/zfit/z/unstable.py
+++ b/zfit/z/unstable.py
@@ -131,7 +131,7 @@ def gather(x, indices=None, axis=None):
 
 def concat(values, axis, name=None):
     if not SWITCH_ON or has_tensor(values):
-        return tf.concat(values=values, axis=axis, name=name)
+        return znp.concatenate(values, axis=axis)
     else:
         return np.concatenate(values, axis=axis)
 

--- a/zfit/z/unstable.py
+++ b/zfit/z/unstable.py
@@ -2,6 +2,8 @@
 import numpy as np
 import tensorflow as tf
 
+import zfit.z.numpy as znp
+
 SWITCH_ON = True
 
 
@@ -28,7 +30,7 @@ def allclose_anyaware(x, y, rtol=1e-5, atol=1e-8):
     Returns:
     """
     if not SWITCH_ON or has_tensor([x, y]):
-        return tf.reduce_all(tf.less_equal(tf.abs(x - y), tf.abs(y) * rtol + atol))
+        return tf.reduce_all(tf.less_equal(znp.abs(x - y), znp.abs(y) * rtol + atol))
     else:
         x = np.array(x)
         y = np.array(y)

--- a/zfit/z/wrapping_tf.py
+++ b/zfit/z/wrapping_tf.py
@@ -65,8 +65,8 @@ def check_numerics(tensor: Any, message: Any, name: Any = None):
     Returns:
     """
     if tf.as_dtype(tensor.dtype).is_complex:
-        real_check = tf.debugging.check_numerics(tensor=tf.math.real(tensor), message=message, name=name)
-        imag_check = tf.debugging.check_numerics(tensor=tf.math.imag(tensor), message=message, name=name)
+        real_check = tf.debugging.check_numerics(tensor=znp.real(tensor), message=message, name=name)
+        imag_check = tf.debugging.check_numerics(tensor=znp.imag(tensor), message=message, name=name)
         check_op = tf.group(real_check, imag_check)
     else:
         check_op = tf.debugging.check_numerics(tensor=tensor, message=message, name=name)

--- a/zfit/z/wrapping_tf.py
+++ b/zfit/z/wrapping_tf.py
@@ -5,13 +5,14 @@ from typing import Any
 
 import tensorflow as tf
 
+import zfit.z.numpy as znp
 from ..settings import ztypes
 from ..util.deprecation import deprecated
 from .tools import _auto_upcast
 
 
-def exp(x, name=None):
-    return _auto_upcast(tf.exp(x=x, name=name))
+def exp(x):
+    return _auto_upcast(znp.exp(x=x))
 
 
 @functools.wraps(tf.convert_to_tensor)

--- a/zfit/z/wrapping_tf.py
+++ b/zfit/z/wrapping_tf.py
@@ -6,9 +6,10 @@ from typing import Any
 import tensorflow as tf
 
 import zfit.z.numpy as znp
-from .tools import _auto_upcast
+
 from ..settings import ztypes
 from ..util.deprecation import deprecated
+from .tools import _auto_upcast
 
 
 def exp(x):

--- a/zfit/z/wrapping_tf.py
+++ b/zfit/z/wrapping_tf.py
@@ -6,10 +6,9 @@ from typing import Any
 import tensorflow as tf
 
 import zfit.z.numpy as znp
-
+from .tools import _auto_upcast
 from ..settings import ztypes
 from ..util.deprecation import deprecated
-from .tools import _auto_upcast
 
 
 def exp(x):
@@ -74,6 +73,6 @@ def check_numerics(tensor: Any, message: Any, name: Any = None):
     return check_op
 
 
-reduce_sum = tf.reduce_sum
+reduce_sum = znp.sum
 
 reduce_prod = tf.reduce_prod

--- a/zfit/z/wrapping_tf.py
+++ b/zfit/z/wrapping_tf.py
@@ -6,6 +6,7 @@ from typing import Any
 import tensorflow as tf
 
 import zfit.z.numpy as znp
+
 from ..settings import ztypes
 from ..util.deprecation import deprecated
 from .tools import _auto_upcast

--- a/zfit/z/wrapping_tf.py
+++ b/zfit/z/wrapping_tf.py
@@ -75,4 +75,4 @@ def check_numerics(tensor: Any, message: Any, name: Any = None):
 
 reduce_sum = znp.sum
 
-reduce_prod = tf.reduce_prod
+reduce_prod = znp.prod

--- a/zfit/z/zextension.py
+++ b/zfit/z/zextension.py
@@ -1,14 +1,13 @@
 #  Copyright (c) 2021 zfit
 import functools
-import math as _mt
 from collections import defaultdict
 from typing import Any, Callable
 
+import math as _mt
 import numpy as np
 import tensorflow as tf
 
 import zfit.z.numpy as znp
-
 from ..settings import ztypes
 from ..util.exception import BreakingAPIChangeError
 from ..util.warnings import warn_advanced_feature
@@ -120,7 +119,7 @@ def run_no_nan(func, x):
     value_with_nans = func(x=x)
     if value_with_nans.dtype in (tf.complex128, tf.complex64):
         value_with_nans = znp.real(value_with_nans) + znp.imag(value_with_nans)  # we care only about NaN or not
-    finite_bools = tf.math.is_finite(tf.cast(value_with_nans, dtype=tf.float64))
+    finite_bools = znp.isfinite(tf.cast(value_with_nans, dtype=tf.float64))
     finite_indices = tf.where(finite_bools)
     new_x = tf.gather_nd(params=x, indices=finite_indices)
     new_x = Data.from_tensor(obs=x.obs, tensor=new_x)

--- a/zfit/z/zextension.py
+++ b/zfit/z/zextension.py
@@ -8,6 +8,7 @@ import numpy as np
 import tensorflow as tf
 
 import zfit.z.numpy as znp
+
 from ..settings import ztypes
 from ..util.exception import BreakingAPIChangeError
 from ..util.warnings import warn_advanced_feature

--- a/zfit/z/zextension.py
+++ b/zfit/z/zextension.py
@@ -1,13 +1,14 @@
 #  Copyright (c) 2021 zfit
 import functools
+import math as _mt
 from collections import defaultdict
 from typing import Any, Callable
 
-import math as _mt
 import numpy as np
 import tensorflow as tf
 
 import zfit.z.numpy as znp
+
 from ..settings import ztypes
 from ..util.exception import BreakingAPIChangeError
 from ..util.warnings import warn_advanced_feature

--- a/zfit/z/zextension.py
+++ b/zfit/z/zextension.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 import numpy as np
 import tensorflow as tf
 
+import zfit.z.numpy as znp
 from ..settings import ztypes
 from ..util.exception import BreakingAPIChangeError
 from ..util.warnings import warn_advanced_feature
@@ -31,7 +32,7 @@ def to_real(x, dtype=ztypes.float):
 
 
 def abs_square(x):
-    return tf.math.real(x * tf.math.conj(x))
+    return znp.real(x * znp.conj(x))
 
 
 def nth_pow(x, n, name=None):
@@ -117,7 +118,7 @@ def run_no_nan(func, x):
 
     value_with_nans = func(x=x)
     if value_with_nans.dtype in (tf.complex128, tf.complex64):
-        value_with_nans = tf.math.real(value_with_nans) + tf.math.imag(value_with_nans)  # we care only about NaN or not
+        value_with_nans = znp.real(value_with_nans) + znp.imag(value_with_nans)  # we care only about NaN or not
     finite_bools = tf.math.is_finite(tf.cast(value_with_nans, dtype=tf.float64))
     finite_indices = tf.where(finite_bools)
     new_x = tf.gather_nd(params=x, indices=finite_indices)


### PR DESCRIPTION
## Proposed Changes

- Replace part of the tensorflow namespace with the `tensorflow.experimental.numpy` namespace.
- **Update to tensorflow~=2.5.0rc0**
- Change behaviour of `ComplexParameter` properties `imag`, `real`, `arg`, `mod`. They now always return a `tf.Tensor` and not a `Parameter`.

### Replaced functions
Roughly two types of functions were changed:
- Functions from the `tensorflow.math` namespace.
- Functions that construct new Tensors based on existing tensors like `tf.concat`, `tf.stack` or `tf.transpose`.

### Skipped functions
- All functions that create a `tf.Tensor` from scratch like `tf.constant`, `tf.variable`, `tf.range` or `tf.convert_to_tensor`.
- Functions that don't have an equivalent in tensorflow NumPy. This are mainly one of the following:
    + Function exists in numpy but has not yet been implemented in tensorflow NumPy.
    + Function does not exist in numpy but would make sense to be there. :wink: (e.g. `tf.unstack`).
    + Everything under `tf.debbuging.assert_*`.
    + Flow control functions like `while_loop`.
    + Logical functions like `tf.greater`.

### Skipped regions
- Everything under `test`, as to not change what is actually tested. This does not mean, that there are no changes to the tests but that there are no replacements of tensorflow functions with `tensorflow.experimental.numpy` functions.
- Examples, docs and docstrings, e.g. everything that appears to the user on the website.

## Notes

- The modules `z.unstable`, `z.wrapping_tf` and `z.zextension` now both use tensorflow NumPy and pure tensorflow functions in an inconsistent manner. The purpose of these three modules seems overlapping at times and I think it would make sense to harmonize them at a later point when tensorflow NumPy has proven to be stable enough. I.e. remove parts of it in favour of tensorflow numpy and consolidate the parts that are still necessary. This is also connected to the next point.
- `tf.experimental.numpy.experimental_enable_numpy_behavior()` is not called yet. It does the following things
    + Enables type promotion in TensorFlow
    + Changes type inference, when converting literals to tensors, to more strictly follow the NumPy standard.
    + Adds methods and properties to `tf.Tensor` like `astype()` and `T` to make it compatible with the numpy ndarray. This last behaviour is not documented yet, as it seems to be new in `tensorflow~=2.5.0rc0`. This is probably due to the decision to scrap the separate `tf.experimental.numpy.ndarray` class and just make it an alias of `tf.tensor` (See commit `Add test for zfit/z/numpy.py.` 7656cba7faf6ff74cfa5701e993514b28fb3dc8d)

## Tests added

- Tests for checking that `ComplexParamter.imag/real/arg/mod` always return a `tf.Tensor`.

## Checklist

-   [ ] change approved
-   [ ] implementation finished
-   [ ] correct namespace imported
-   [ ] tests added
-   [ ] CHANGELOG updated
