### PR TITLE
Return the limits of the `obs` instead of directly returning the `obs`

### DIFF
--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -151,7 +151,7 @@ class BasePDF(ZfitPDF, BaseModel):
         """
         norm_range = self._norm_range
         if norm_range is None:
-            norm_range = self.space
+            norm_range = self.space.limits
         return norm_range
 
     @invalidate_graph


### PR DESCRIPTION
## Proposed Changes
Return the limits of the `obs` instead of directly returning the `obs`

This is already mentioned in the docstring of the function
"""Return the current normalization range. If None and the `obs` have limits, they are returned
