### PR TITLE
enh: drop Python 3.6 support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
     dist:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
             - uses: actions/checkout@v1
             - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
             max-parallel: 4
             fail-fast: False
             matrix:
-                python-version: [ 3.6, 3.7, 3.8 ]
+                python-version: [ 3.7, 3.8 ]
         name: JIT compiled tests for Python ${{ matrix.python-version }}
         steps:
             - uses: actions/checkout@v2
@@ -22,13 +22,6 @@ jobs:
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip
-            #            - name: Lint with flake8
-            #              run: |
-            #                  pip install flake8
-            #                  # stop the build if there are Python syntax errors or undefined names
-            #                  # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-            #                  # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-            #                  flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
             - name: Test with pytest
               run: |
                   pip install --use-feature=2020-resolver .[dev]
@@ -47,7 +40,7 @@ jobs:
             max-parallel: 4
             fail-fast: False
             matrix:
-                python-version: [ 3.6, 3.7, 3.8 ]
+                python-version: [ 3.7, 3.8 ]
         name: Eager mode tests for Python ${{ matrix.python-version }}
         steps:
             - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
 
   # Notebook formatting
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.5.9
+    rev: 0.6.0
     hooks:
       - id: nbqa-isort
         additional_dependencies: [ isort==5.6.4 ]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Experimental
 Requirement changes
 -------------------
 
+- remove Python 3.6 support
+
 
 Thanks
 ------

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ keywords = TensorFlow, model, fitting, scalable, HEP
 
 [options]
 packages = find:
-python_requires = >=3.6,<3.9
+python_requires = >=3.7,<3.9
 include_package_data = True
 testpaths = tests
 zip_safe = False

--- a/zfit/__init__.py
+++ b/zfit/__init__.py
@@ -29,17 +29,6 @@ __all__ = ["z", "constraint", "pdf", "minimize", "loss", "core", "data", "func",
 
 #  Copyright (c) 2019 zfit
 
-if sys.version_info < (3, 7):
-    msg = inspect.cleandoc(
-        """zfit is being actively developed and keeps up with the newest versions of other packages.
-        This includes Python itself. Therefore, Python 3.6 will be dropped in the near future (beginning of May 2021)
-        and 3.9 will be added to the supported versions.
-
-        Feel free to contact us in case of problems to upgrade to a more recent version of Python.
-        """
-    )
-    warnings.warn(msg, FutureWarning, stacklevel=2)
-
 
 def _maybe_disable_warnings():
     import os


### PR DESCRIPTION
As title


## Checklist

-   [x] change approved
-   [x] implementation finished
-   [x] correct namespace imported
-   [x] tests added
-   [x] CHANGELOG updated
