### PR TITLE
add create_new method to loss

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,10 @@ Depreceations
 Bug fixes and small changes
 ---------------------------
 
-- add `loss` to callback signature that gives full access to the model
+- add ``loss`` to callback signature that gives full access to the model
+- add :meth:`~zfit.loss.UnbinnedNLL.create_new` to losses in order to re-instantiate
+  them with new models and data
+  preserving their current (and future) options and other arguments
 
 Experimental
 ------------

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -294,3 +294,63 @@ def test_simple_loss():
     assert true_a == pytest.approx(result2.params[params[0]]['value'], rel=0.03)
     assert true_b == pytest.approx(result2.params[params[1]]['value'], rel=0.06)
     assert true_c == pytest.approx(result2.params[params[2]]['value'], rel=0.5)
+
+
+def test_create_new_nll():
+    gaussian1, mu1, sigma1 = create_gauss1()
+    gaussian2, mu2, sigma2 = create_gauss2()
+
+    test_values = tf.constant(test_values_np)
+    test_values = zfit.Data.from_tensor(obs=obs1, tensor=test_values)
+    nll = zfit.loss.UnbinnedNLL(model=gaussian1, data=test_values)
+
+    nll2 = nll.create_new(model=gaussian2)
+    assert nll2.data[0] is nll.data[0]
+    assert nll2.constraints == nll.constraints
+    assert nll2._options == nll._options
+
+    nll3 = nll.create_new()
+    assert nll3.data[0] is nll.data[0]
+    assert nll3.constraints == nll.constraints
+    assert nll3._options == nll._options
+
+    nll4 = nll.create_new(options={})
+    assert nll4.data[0] is nll.data[0]
+    assert nll4.constraints == nll.constraints
+    assert nll4._options != nll._constraints
+
+
+def test_create_new_extnll():
+    gaussian1, mu1, sigma1, yield1 = create_gauss3ext()
+
+    test_values = tf.constant(test_values_np)
+    test_values = zfit.Data.from_tensor(obs=obs1, tensor=test_values)
+    nll = zfit.loss.ExtendedUnbinnedNLL(model=gaussian1, data=test_values,
+                                        constraints=zfit.constraint.GaussianConstraint(mu1, 1., 0.1))
+
+    nll2 = nll.create_new(model=gaussian1)
+    assert nll2.data[0] is nll.data[0]
+    assert nll2.constraints == nll.constraints
+    assert nll2._options == nll._options
+
+    nll3 = nll.create_new()
+    assert nll3.data[0] is nll.data[0]
+    assert nll3.constraints == nll.constraints
+    assert nll3._options == nll._options
+
+    nll4 = nll.create_new(options={})
+    assert nll4.data[0] is nll.data[0]
+    assert nll4.constraints == nll.constraints
+    assert nll4._options != nll._constraints
+
+
+def test_create_new_simple():
+    _, mu1, sigma1 = create_gauss1()
+
+    loss = zfit.loss.SimpleLoss(lambda x, y: x * y,
+                                params=[mu1, sigma1],
+                                errordef=0.5)
+
+    loss1 = loss.create_new()
+    assert loss1._simple_func is loss._simple_func
+    assert loss1.errordef == loss.errordef

--- a/utils/api/argdocs.yaml
+++ b/utils/api/argdocs.yaml
@@ -146,6 +146,52 @@ minimizer.nlopt.info: |1+
          original implementations of various other algorithms.
 
 
+
+
+loss.init.model: |1+
+   PDFs that return the normalized probability for
+                *data* under the given parameters.
+                If multiple model and data are given, they will be used
+                in the same order to do a simultaneous fit.
+
+loss.init.data: |1+
+   Dataset that will be given to the *model*.
+                If multiple model and data are given, they will be used
+                in the same order to do a simultaneous fit.
+
+loss.init.constraints: |1+
+   Auxiliary measurements that add a term to the loss
+                or terms that restrict the loss in an other way such as penalties.
+loss.init.options: |1+
+   Additional options (as a dict) for the loss.
+                Current possibilities include:
+
+                - 'subtr_const' (default True): subtract from each points
+                  log probability density a constant that
+                  is approximately equal to the average log probability
+                  density in the very first evaluation before
+                  the summation. This brings the initial loss value closer to 0 and increases,
+                  especially for large datasets, the numerical stability.
+
+                  The value will be stored ith 'subtr_const_value' and can also be given
+                  directly.
+
+                  The subtraction should not affect the minimum as the absolute
+                  value of the NLL is meaningless. However,
+                  with this switch on, one cannot directly compare
+                  different likelihoods ablolute value as the constant
+                  may differs! Use `create_new` in order to have a comparable likelihood
+                  between different losses
+
+
+                These settings may extend over time. In order to make sure that a loss is the
+                same under the same data, make sure to use `create_new` instead of instantiating
+                a new loss as the former will automatically overtake any relevant constants
+                and behavior.
+
+
+
+
 result.init.loss: |1+
     The loss function that was minimized.
                 Usually, but not necessary, contains

--- a/zfit/core/interfaces.py
+++ b/zfit/core/interfaces.py
@@ -783,6 +783,10 @@ class ZfitLoss(ZfitObject, metaclass=ABCMeta):
     def value_gradient_hessian(self, params, hessian=None):
         pass
 
+    @abstractmethod
+    def create_new(self, model, data, fit_range, constraints, options):
+        pass
+
 
 class ZfitModel(ZfitNumericParametrized, ZfitDimensional):
 

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -183,13 +183,9 @@ class BaseLoss(ZfitLoss, BaseNumeric):
         return params
 
     def _input_check(self, pdf, data, fit_range):
-        if is_container(pdf) ^ is_container(data):
-            raise ValueError("`pdf` and `data` either both have to be a list or not.")
-        if not is_container(pdf) and isinstance(fit_range, list):
-            raise TypeError("`pdf` and `data` are not a `list`, `fit_range` can't be a `list` then.")
+
         if isinstance(pdf, tuple):
             raise TypeError("`pdf` has to be a pdf or a list of pdfs, not a tuple.")
-
         if isinstance(data, tuple):
             raise TypeError("`data` has to be a data or a list of data, not a tuple.")
 
@@ -606,8 +602,10 @@ class UnbinnedNLL(BaseLoss):
             fit_range = self.fit_range
         if constraints is NONE:
             constraints = self.constraints
+            if constraints is not None:
+                constraints = constraints.copy()
         if options is NONE:
-            options = self.options
+            options = self._options
             if isinstance(options, dict):
                 options = options.copy()
         return type(self)(model=model, data=data, fit_range=fit_range, constraints=constraints, options=options)


### PR DESCRIPTION
Allows to simply create a new instance of the loss

## Proposed Changes

- `add create_new method to loss`

## Tests added

- for the method

## Checklist

-   [x] change approved
-   [x] implementation finished
-   [x] correct namespace imported
-   [x] tests added
-   [x] CHANGELOG updated
