### PR TITLE
fix: remove ipyopt requirement from macos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 #  Copyright (c) 2021 zfit
 import os
+import platform
 
 from setuptools import setup
 
@@ -9,6 +10,9 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 with open(os.path.join(here, 'requirements.txt'), encoding='utf-8') as requirements_file:
     requirements = requirements_file.read().splitlines()
+    if platform.system() == 'Darwin':  # OSX has no wheels for ipyopt, build fails
+        if 'ipyopt' in requirements:
+            requirements.remove('ipyopt')  # TODO: ipyopt osx wheels? https://gitlab.com/g-braeunlich/ipyopt/-/issues/4
 
 with open(os.path.join(here, 'requirements_dev.txt'), encoding='utf-8') as requirements_dev_file:
     requirements_dev = requirements_dev_file.read().splitlines()

--- a/zfit/minimizers/ipopt.py
+++ b/zfit/minimizers/ipopt.py
@@ -1,8 +1,8 @@
 #  Copyright (c) 2021 zfit
 import math
+import platform
 from typing import Callable, Dict, Optional, Union
 
-import ipyopt
 import numpy as np
 
 from ..core.parameter import assign_values, set_values
@@ -214,6 +214,18 @@ class IpyoptV1(BaseMinimizer):
 
     @minimize_supports(init=True)
     def _minimize(self, loss, params, init):
+        try:
+            import ipyopt
+        except ImportError as error:
+            if platform.system() == 'Darwin':
+                raise ImportError("This requires the ipyopt library (https://gitlab.com/g-braeunlich/ipyopt)"
+                                  " to be installed. As there are no wheels on MacOS available"
+                                  " (https://gitlab.com/g-braeunlich/ipyopt/-/issues/4), this is not in the"
+                                  " requirements for MacOS. Please install ipyopt manually to use this minimizer"
+                                  " or install zfit on a 'Linux' environment.") from error
+            else:
+                raise
+
         if init:
             assign_values(params=params, values=init)
         evaluator = self.create_evaluator()


### PR DESCRIPTION
Fixes #

## Proposed Changes

-

## Tests added

-

## Checklist

-   [ ] change approved
-   [ ] implementation finished
-   [ ] correct namespace imported
-   [ ] tests added
-   [ ] CHANGELOG updated
