### PR TITLE
Fix typos in the intro guide

### DIFF
--- a/docs/getting_started/intro/data.rst
+++ b/docs/getting_started/intro/data.rst
@@ -6,7 +6,7 @@ Data
 
 An easy and fast data manipulation are among the crucial aspects in High Energy Particle physics data analysis.
 With the increasing data availability (e.g. with the advent of LHC), this challenge has been pursued in different
-manners. Common strategies vary from multidimensional arrays with attached row/column labels (e.g. ``DataFrame`` in *pandas*) or compressed binary formats (e.g. ROOT). While each of these data structure designs has their own advantages in terms of speed and acessibility, the data concept inplemented in ``zfit`` follows closely the features of ``DataFrame`` in *pandas*.
+manners. Common strategies vary from multidimensional arrays with attached row/column labels (e.g. ``DataFrame`` in *pandas*) or compressed binary formats (e.g. ROOT). While each of these data structure designs have their own advantages in terms of speed and acessibility, the data concept inplemented in ``zfit`` follows closely the features of ``DataFrame`` in *pandas*.
 
 The :py:class:`~zfit.Data` class provides a simple and structured access/manipulation of *data* -- similarly to concept of multidimensional arrays approach from *pandas*. The key feature of :py:class:`~zfit.Data` is its relation to the :py:class:`~zfit.Space` or more explicitly its axis or name. A more equally convention is to name the role of the :py:class:`~zfit.Space` in this context as the *observable* under investigation. Note that no explicit range for the :py:class:`~zfit.Space` is required at the moment of the data definition, since this is only required at the moment some calculation is needed (e.g. integrals, fits, etc).
 
@@ -36,7 +36,7 @@ The ``branches_alias`` can be seen as a list of strings that renames the origina
 .. note::
 
     The implementation of the ``from_root`` method makes uses of the uproot packages,
-    which uses Numpy to cast bocks of data from the ROOT file as Numpy arrays in time optimised manner.
+    which uses Numpy to cast blocks of data from the ROOT file as Numpy arrays in time optimised manner.
     This also means that the *goodies* from uproot can also be used by specifying the root_dir_options,
     such as cuts in the dataset. However, this can be applied later when examining the produced dataset
     and it is the advised implementation of this.

--- a/docs/getting_started/intro/loss.rst
+++ b/docs/getting_started/intro/loss.rst
@@ -62,7 +62,7 @@ driving it away from the minimum.
 Simultaneous fits
 -----------------
 
-There are currently two loss functions implementations in the ``zfit`` library, the :py:class:`~zfit.loss.UnbinnedNLL` and :py:class:`~zfit.loss.ExtendedUnbinnedNLL` classes, which cover non-extended and extended negative log-likelihoods.
+There are currently two loss function implementations in the ``zfit`` library, the :py:class:`~zfit.loss.UnbinnedNLL` and :py:class:`~zfit.loss.ExtendedUnbinnedNLL` classes, which cover non-extended and extended negative log-likelihoods.
 
 A very common use case of likelihood fits in HEP is the possibility to examine simultaneously different datasets (that can be independent or somehow correlated).
 To build loss functions for simultaneous fits, the addition operator can be used (the particular combination that is performed depends on the type of loss function):

--- a/docs/getting_started/intro/minimize.rst
+++ b/docs/getting_started/intro/minimize.rst
@@ -18,7 +18,7 @@ zfit minimizers are stateless and have two main components:
 This makes minimizers interchangeable as they all are invoked in the same way and return a
 :class:`~zfit.result.FitResult`, which has the same structure for all minimizers.
 
-The zfit library is designed such that it is simpel to introduce new sets of minimizers.
+The zfit library is designed such that it is simple to introduce new sets of minimizers.
 
 Minimization
 -------------------
@@ -48,7 +48,7 @@ to the different nature of problem that they usually intend to solve, their perf
 
 
 Any of these minimizers can then be used to minimize the loss function we created
-in :ref:`previous section <loss-section>`, or a pure Python function
+in the :ref:`previous section <loss-section>`, or a pure Python function
 
 .. code-block:: pycon
 
@@ -74,7 +74,7 @@ refine with a local minimizer.
     >>> result_refined = minimizer_ipyopt.minimize(loss=my_loss, params=[mu, sigma], init=result)
 
 
-The result of the fit is return as a :py:class:`~zfit.minimizers.fitresult.FitResult` object,
+The result of the fit is returned as a :py:class:`~zfit.minimizers.fitresult.FitResult` object,
 which provides access the minimiser state.
 zfit separates the minimisation of the loss function with respect to the error calculation
 in order to give the freedom of calculating this error whenever needed.
@@ -103,7 +103,7 @@ The ``result`` object contains all the information about the minimization result
     mu=0.012464509810750313
 
 More on the result and how to get an estimate of the uncertainty is described in
-the :ref:`nexi section <result-section>`.
+the :ref:`next section <result-section>`.
 
 
 Creating your own minimizer

--- a/docs/getting_started/intro/model.rst
+++ b/docs/getting_started/intro/model.rst
@@ -167,7 +167,7 @@ An extended PDF can be easily implemented in zfit in two ways:
 
 This will leave ``gauss1`` unextended while the ``extended_gauss`` is now extended. However, there are cases where
 :meth:`~zfit.pdf.BasePDF.create_extended` may fails, such as if it can't copy the original PDF. A PDF can also be
-extenden in-place
+extended in-place
 
 .. jupyter-execute::
 

--- a/docs/getting_started/intro/result.rst
+++ b/docs/getting_started/intro/result.rst
@@ -46,7 +46,7 @@ The :py:func:`~zfit.minimizers.fitresult.FitResult.errors` method can be used to
 error calculation.
 It returns two objects, the first are the parameter errors and the second is a new ``FitResult`` *in case a new
 minimum was found during the profiling*; this will also render the original result invalid as can
-be check with ``result.valid``.
+be checked with ``result.valid``.
 
 .. code-block:: pycon
 

--- a/docs/getting_started/intro/toy_studies.rst
+++ b/docs/getting_started/intro/toy_studies.rst
@@ -28,7 +28,7 @@ via ``fixed_params``, on :py:meth:`~zfit.core.data.Sampler.resample` by specifyi
 will take which value via ``param_values`` or by changing the attribute of :py:class:`~zfit.core.data.Sampler`.
 
 Reusing the model, obs and parameters from :ref:`basic-model`,
-this is how typically toys look like:
+this is typically how toys look like:
 
 
 .. jupyter-execute::


### PR DESCRIPTION
# Fixes
While going through the documentation, specifically the intro section, I noticed some minor typos. I probably missed some but here are the ones that I found and fixed.