### PR TITLE
fix:  use BFGS as default if no hessian is given

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Depreceations
 
 Bug fixes and small changes
 ---------------------------
+- Scipy minimizers with hessian arguments use now `BFGS` as default
 
 Experimental
 ------------

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ coverage>=4.5.1
 docformatter
 flake8>=3.5.0
 ipyopt<0.12
-Jinja2<3  # temp fix for failing, meta not knowns
+Jinja2<3  # temp fix for failing, meta not known
 jupyter-sphinx
 matplotlib  # docs
 mplhep  # docs

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -10,6 +10,7 @@ from ordered_set import OrderedSet
 
 import zfit.minimizers.optimizers_tf
 from zfit.minimizers.base_tf import WrapOptimizer
+from zfit.minimizers.baseminimizer import NOT_SUPPORTED
 from zfit.util.exception import OperationNotAllowedError
 
 true_mu = 4.5
@@ -73,7 +74,9 @@ def make_min_grad_hesse():
 
 def not_allowed(gradient, hessian):
     from scipy.optimize import HessianUpdateStrategy
-    return (gradient in (True, '2-point', '3-point') and not isinstance(hessian, HessianUpdateStrategy))
+    return (gradient in (True, '2-point', '3-point')
+            and not isinstance(hessian, HessianUpdateStrategy)
+            and hessian is not NOT_SUPPORTED)
 
 
 @pytest.mark.parametrize('minimizer_gradient_hessian', make_min_grad_hesse())

--- a/zfit/minimizers/minimizers_scipy.py
+++ b/zfit/minimizers/minimizers_scipy.py
@@ -110,7 +110,8 @@ class ScipyBaseMinimizerV1(BaseMinimizer):
         if 'options' not in minimizer_options:
             minimizer_options['options'] = {}
 
-        if gradient in (True, '2-point', '3-point') and not isinstance(hessian, HessianUpdateStrategy):
+        if gradient in (True, '2-point', '3-point') and not (
+                isinstance(hessian, HessianUpdateStrategy) or hessian is NOT_SUPPORTED):
             raise ValueError("Whenever the gradient is estimated via finite-differences, "
                              "the Hessian has to be estimated using one of the quasi-Newton strategies.")
 
@@ -703,6 +704,9 @@ class ScipyTrustNCGV1(ScipyBaseMinimizerV1):
                 options['initial_trust_radius'] = trust_radius
             return options
 
+        if hessian is None:
+            hessian = BFGS
+
         minimizer_options = {}
         if options:
             minimizer_options['options'] = options
@@ -1017,6 +1021,8 @@ class ScipyNewtonCGV1(ScipyBaseMinimizerV1):
             minimizer_options['options'] = options
 
         scipy_tols = {'xtol': None}
+        if hessian is None:
+            hessian = BFGS
 
         method = "Newton-CG"
         super().__init__(method=method, internal_tol=scipy_tols, gradient=gradient, hessian=hessian,


### PR DESCRIPTION
Fixes Scipy wrong defaulst


## Checklist

-   [x] change approved
-   [x] implementation finished
-   [x] correct namespace imported
-   [x] tests added
-   [x] CHANGELOG updated
