### PR TITLE
fix: use dynamic shape in decorated multinomial func

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Depreceations
 Bug fixes and small changes
 ---------------------------
 - KDE datasets are now correctly mirrored around observable space limits
+- multinomial sampling would return wrong results when invoked multiple times in graph mode due to
+  a non-dynamic shape. This is fixed and the sampling is now working as expected.
 
 Experimental
 ------------
@@ -32,6 +34,7 @@ Requirement changes
 Thanks
 ------
  - schmitse for finding and fixing a mirroring bug in the KDEs
+ - Sebastian Bysiak for finding a bug in the multinomial sampling
 
 0.9.0a0
 ========

--- a/tests/test_z.py
+++ b/tests/test_z.py
@@ -21,3 +21,20 @@ def test_wrapped_func():
     rnd = z.random.uniform(shape=(10,))
     result = wrapped_numpy_func(rnd, z.constant(3.))
     np.testing.assert_allclose(rnd * np.sqrt(3), result)
+
+
+def test_multinomial():
+    import zfit.z.numpy as znp
+
+    probs = np.array([0.5, 0.5])
+    x = z.random.counts_multinomial(10000, probs=probs)
+    assert x.shape == (2,)
+    probs = np.array([0.1, 0.2, 0.7])
+    x = z.random.counts_multinomial(10000, probs=probs)
+    assert x.shape == (3,)
+    probs = np.array([0.5, 0.5])
+    x = z.random.counts_multinomial(10000, probs=probs, dtype=znp.float64)
+    assert x.shape == (2,)
+    probs = np.array([0.1, 0.7, 0.2])
+    x = z.random.counts_multinomial(10000, probs=probs, dtype=znp.float64)
+    assert x.shape == (3,)

--- a/zfit/z/random.py
+++ b/zfit/z/random.py
@@ -84,10 +84,10 @@ def counts_multinomial(total_count: Union[int, tf.Tensor], probs: Iterable[Union
 @function(wraps='tensor')
 def _wrapped_multinomial_func(dtype, logits, probs, total_count):
     if probs is not None:
-        shape = probs.shape
+        shape = tf.shape(probs)
         probs = znp.reshape(probs, [-1])
     else:
-        shape = logits.shape
+        shape = tf.shape(logits)
         logits = znp.reshape(logits, [-1])
     dist = tfp.distributions.Multinomial(total_count=total_count, probs=probs, logits=logits)
     counts_flat = dist.sample()


### PR DESCRIPTION
Fixes #377 

## Proposed Changes

- use the dynamic `get_shape`, otherwise it's hardcoded after the tracing

## Tests added

-

## Checklist

- [x] change approved
- [x] implementation finished
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
