### PR TITLE
fix: enhance precision of fitresult param values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Depreceations
 Bug fixes and small changes
 ---------------------------
 - KDE datasets are now correctly mirrored around observable space limits
+- increase precision in FitResult string representation and add that the value is rounded
 
 Experimental
 ------------

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -1324,7 +1324,7 @@ def format_value(value, highprec=True):
 
     if isinstance(value, float):
         if highprec:
-            value = f"{value:> 6.4g}"
+            value = f"{value:> 6.7g}"
         else:
             value = f"{value:> 6.2g}"
     return value
@@ -1364,7 +1364,7 @@ class ValuesHolder(NameToParamGetitem, ListWithKeys):
 class ParamHolder(NameToParamGetitem, collections.UserDict):
 
     def __str__(self) -> str:
-        order_keys = ['value', 'hesse']
+        order_keys = ['value (rounded)', 'hesse']
         keys = OrderedSet()
         for pdict in self.values():
             keys.update(OrderedSet(pdict))


### PR DESCRIPTION

## Proposed Changes

- Increase precision in result preview of value and add a remark that the value is rounded

## Tests added

-

## Checklist

- [x] change approved
- [x] implementation finished
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
