### PR TITLE
WIP: fix extended sampling was using internal method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Deprecations
 
 Bug fixes and small changes
 ---------------------------
+- extended sampling was erroring for some cases of binned PDFs
 
 Experimental
 ------------
@@ -28,6 +29,7 @@ Requirement changes
 
 Thanks
 ------
+- @YaniBion for discovering the bug in the extended sampling and testing the alpha release
 
 0.9.0a2
 ========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Deprecations
 
 Bug fixes and small changes
 ---------------------------
-- extended sampling errored for some cases of binned PDFs
+- extended sampling errored for some cases of binned PDFs.
 
 Experimental
 ------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Deprecations
 
 Bug fixes and small changes
 ---------------------------
-- extended sampling was erroring for some cases of binned PDFs
+- extended sampling errored for some cases of binned PDFs
 
 Experimental
 ------------

--- a/zfit/core/sample.py
+++ b/zfit/core/sample.py
@@ -436,7 +436,7 @@ def extract_extended_pdfs(pdfs: Union[Iterable[ZfitPDF], ZfitPDF]) -> List[ZfitP
 
 
 def extended_sampling(pdfs: Union[Iterable[ZfitPDF], ZfitPDF], limits: Space) -> tf.Tensor:
-    """Create a sample from extended pdfs by sampling poissonian using the yield.
+    """Create a sample from extended pdfs by sampling from a Poisson using the yield.
 
     Args:
         pdfs:
@@ -452,9 +452,9 @@ def extended_sampling(pdfs: Union[Iterable[ZfitPDF], ZfitPDF], limits: Space) ->
     for pdf in pdfs:
         n = tf.random.poisson(lam=pdf.get_yield(), shape=(), dtype=ztypes.float)
         n = tf.cast(n, dtype=tf.int64)
-        sample = pdf._single_hook_sample(limits=limits, n=n)
+        sample = pdf.sample(limits=limits, n=n)
         # sample.set_shape((n, limits.n_obs))
-        samples.append(sample)
+        samples.append(sample.value())
 
     samples = znp.concatenate(samples, axis=0)
     return samples

--- a/zfit/settings.py
+++ b/zfit/settings.py
@@ -30,7 +30,9 @@ def get_verbosity():
 ztypes = DotMap({'float': tf.float64,
                  'complex': tf.complex128,
                  'int': tf.int64,
-                 tf.float16: tf.float64,
+                 'auto_upcast': True,
+                 })
+upcast_ztypes = {tf.float16: tf.float64,
                  tf.float32: tf.float64,
                  tf.float64: tf.float64,
                  tf.complex64: tf.complex128,
@@ -38,9 +40,7 @@ ztypes = DotMap({'float': tf.float64,
                  tf.int8: tf.int64,
                  tf.int16: tf.int64,
                  tf.int32: tf.int64,
-                 tf.int64: tf.int64,
-                 'auto_upcast': True,
-                 })
+                 tf.int64: tf.int64}
 
 options = DotMap({'epsilon': 1e-8,
                   'numerical_grad': None,

--- a/zfit/z/tools.py
+++ b/zfit/z/tools.py
@@ -2,12 +2,12 @@
 
 import tensorflow as tf
 
-from zfit.settings import ztypes
+from zfit.settings import upcast_ztypes
 
 
 def _auto_upcast(tensor: tf.Tensor):
     if isinstance(tensor, tf.Tensor):
-        new_dtype = ztypes[tensor.dtype]
+        new_dtype = upcast_ztypes[tensor.dtype]
         if new_dtype != tensor.dtype:
             tensor = tf.cast(x=tensor, dtype=new_dtype)
     return tensor


### PR DESCRIPTION


## Proposed Changes

- Use public method in extended sampling to get the samples of the individual pdfs


## Checklist

- [x] change approved
- [x] implementation finished
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
