### PR TITLE
fix: simultaneous binned fits correctly sum over all dimensions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: rst-directive-colons
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v2.32.0
     hooks:
       - id: pyupgrade
         args: [ --py37-plus ]
@@ -85,7 +85,7 @@ repos:
       - id: jupyter-notebook-cleanup
 
   - repo: https://github.com/sondrelg/pep585-upgrade
-    rev: 'v1'
+    rev: 'v1.0'
     hooks:
       - id: upgrade-type-hints
         args: [ '--futures=true' ]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Bug fixes and small changes
   are decorated.
 - extended sampling errored for some cases of binned PDFs.
 - ``ConstantParameter`` errored when converted to numpy.
+- Simultaneous binned fits could error with different binning due to a missing sum over
+  a dimension.
 
 Experimental
 ------------
@@ -37,6 +39,7 @@ Requirement changes
 Thanks
 ------
 - @YaniBion for discovering the bug in the extended sampling and testing the alpha release
+- @ResStump for reporting the bug with the simultaneous binned fit
 
 0.9.0a2
 ========


### PR DESCRIPTION
Simultaneous binned fit

## Proposed Changes

- sum over all dimensions in the binned fits would fail with different binnings because a dimension was not summed over and therefore mismatched

## Tests added

- add simultaneous test with different binnings

## Checklist

- [x] change approved
- [x] implementation finished
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
