### PR TITLE
build: set zfit version with importlib-metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ deprecated
 dotmap
 hist
 iminuit>=2.3
+importlib-metadata; python_version <"3.8.0"
 numdifftools
 numpy>=1.16
 ordered-set

--- a/zfit/__init__.py
+++ b/zfit/__init__.py
@@ -1,11 +1,15 @@
 """Top-level package for zfit."""
 
 #  Copyright (c) 2022 zfit
+import sys
 import warnings
 
-from pkg_resources import get_distribution
+if sys.version_info < (3, 8):
+    from importlib_metadata import version
+else:
+    from importlib.metadata import version
 
-__version__ = get_distribution(__name__).version
+__version__ = version(__name__)
 
 __license__ = "BSD 3-Clause"
 __copyright__ = "Copyright 2018, zfit"


### PR DESCRIPTION
[`importlib.metadata`](https://docs.python.org/3/library/importlib.metadata.html) is preferred over the older `pkg_resources`. The current setup with `pkg_resources` [also causes CI problems](https://github.com/ComPWA/compwa-org/runs/6612064353?check_suite_focus=true#step:5:210).

See also https://github.com/zfit/phasespace/issues/80