### PR TITLE
add hash functionality to dataset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,14 +7,12 @@ Changelog
 Develop
 ========
 
-0.9.0a2
-========
-
 Major Features and Improvements
 -------------------------------
 - improved data handling in constructors `from_pandas` (which allows now to
   have weights as columns, dataframes that are a superset of the obs) and
   `from_root` (obs can now be spaces and therefore cuts can be direcly applied)
+- add hashing of unbinned datasets with a `hashint` attribute. None if no hash was possible.
 
 Breaking changes
 ------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,5 @@ texttable
 tf_quant_finance>=v0.0.1-dev24
 uhi
 uproot>=4,<5
+xxhash
 zfit_interface

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -37,13 +37,9 @@ class TestHashPDF(zfit.pdf.BasePDF):
         return znp.abs(x.unstack_x()[0])
 
 
-def create_data1(obs=obs3d, array=np_data1):
-    return zfit.Data.from_numpy(obs=obs3d, array=np_data1)
-
-
 @pytest.fixture
-def data1(np_data1, obs3d):
-    return create_data1()
+def data1(obs3d, np_data1):
+    return zfit.Data.from_numpy(obs=obs3d, array=np_data1)
 
 
 @pytest.fixture
@@ -256,9 +252,9 @@ def test_from_tensors(weights_factory):
         assert weights is None
 
 
-def test_overloaded_operators():
-    data1 = create_data1()
+def test_overloaded_operators(data1):
     a = data1 * 5.0
+    example_data1 = data1.value().numpy()
     np.testing.assert_array_equal(5 * example_data1, a.numpy())
     np.testing.assert_array_equal(example_data1, data1.numpy())
     data_squared = data1 * data1
@@ -268,10 +264,9 @@ def test_overloaded_operators():
     )
 
 
-def test_sort_by_obs():
-    data1 = create_data1(obs3d)
-
+def test_sort_by_obs(data1, obs3d):
     new_obs = (obs3d[1], obs3d[2], obs3d[0])
+    example_data1 = data1.value().numpy()
     new_array = copy.deepcopy(example_data1)[:, np.array((1, 2, 0))]
     # new_array = np.array([new_array[:, 1], new_array[:, 2], new_array[:, 0]])
     assert data1.obs == obs3d, "If this is not True, then the test will be flawed."
@@ -291,10 +286,9 @@ def test_sort_by_obs():
     np.testing.assert_array_equal(example_data1, data1.value().numpy())
 
 
-def test_subdata(obs3d):
-    data1 = create_data1()
+def test_subdata(obs3d, data1):
     new_obs = (obs3d[0], obs3d[1])
-    new_array = copy.deepcopy(example_data1)[:, np.array((0, 1))]
+    new_array = copy.deepcopy(data1.value().numpy())[:, np.array((0, 1))]
     # new_array = np.array([new_array[:, 0], new_array])
     with data1.sort_by_obs(obs=new_obs):
         assert data1.obs == new_obs
@@ -311,7 +305,7 @@ def test_subdata(obs3d):
                     data1.value().numpy()
 
     assert data1.obs == obs3d
-    np.testing.assert_array_equal(example_data1, data1.value())
+    np.testing.assert_array_equal(data1.value().numpy(), data1.value())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -15,8 +15,46 @@ obs1 = ("obs1", "obs2", "obs3")
 example_data1 = np.random.random(size=(7, len(obs1)))
 
 
-def create_data1():
-    return zfit.Data.from_numpy(obs=obs1, array=example_data1)
+@pytest.fixture
+def obs3d():
+    return obs1
+
+
+@pytest.fixture
+def np_data1(obs3d):
+    return np.random.random(size=(7, len(obs3d)))
+
+
+class TestHashPDF(zfit.pdf.BasePDF):
+    def __init__(self, obs, lasthash):
+        super().__init__(obs=obs)
+        self.lasthash = lasthash
+
+    def _unnormalized_pdf(self, x):
+        import zfit.z.numpy as znp
+
+        self.lasthash = x.hashint
+        return znp.abs(x.unstack_x()[0])
+
+
+def create_data1(obs=obs3d, array=np_data1):
+    return zfit.Data.from_numpy(obs=obs3d, array=np_data1)
+
+
+@pytest.fixture
+def data1(np_data1, obs3d):
+    return create_data1()
+
+
+@pytest.fixture
+def space2d():
+    obs = ["obs1", "obs2"]
+    lower1, lower2 = -1, -2
+    upper1, upper2 = 1.9, 3.6
+    space1 = zfit.Space(obs[0], limits=(lower1, upper1))
+    space2 = zfit.Space(obs[1], limits=(lower2, upper2))
+    space2d = space1 * space2
+    return space2d
 
 
 @pytest.mark.parametrize("obs_alias", [None, {"pt1": "pt2", "pt2": "pt1"}])
@@ -111,11 +149,11 @@ def test_from_root(weights_factory):
         lambda: np.random.normal(size=1000),
     ],
 )
-def test_from_numpy(weights_factory):
+def test_from_numpy(weights_factory, obs3d):
     weights = weights_factory()
 
     example_data = np.random.random(size=(1000, len(obs1)))
-    data = zfit.Data.from_numpy(obs=obs1, array=example_data, weights=weights)
+    data = zfit.Data.from_numpy(obs=obs3d, array=example_data, weights=weights)
     x = data.value()
     weights_from_data = data.weights
     if weights_from_data is not None:
@@ -130,11 +168,11 @@ def test_from_numpy(weights_factory):
         assert weights_from_data is None
 
 
-def test_from_to_pandas():
+def test_from_to_pandas(obs3d):
     dtype = np.float32
-    example_data_np = np.random.random(size=(1000, len(obs1)))
-    example_data = pd.DataFrame(data=example_data_np, columns=obs1)
-    data = zfit.Data.from_pandas(obs=obs1, df=example_data, dtype=dtype)
+    example_data_np = np.random.random(size=(1000, len(obs3d)))
+    example_data = pd.DataFrame(data=example_data_np, columns=obs3d)
+    data = zfit.Data.from_pandas(obs=obs3d, df=example_data, dtype=dtype)
     x = data.value()
     assert x.dtype == dtype
     x_np = x.numpy()
@@ -142,9 +180,9 @@ def test_from_to_pandas():
     np.testing.assert_array_equal(example_data_np.astype(dtype=dtype), x_np)
 
     # test auto obs retreavel
-    example_data2 = pd.DataFrame(data=example_data_np, columns=obs1)
+    example_data2 = pd.DataFrame(data=example_data_np, columns=obs3d)
     data2 = zfit.Data.from_pandas(df=example_data2)
-    assert data2.obs == obs1
+    assert data2.obs == obs3d
     x2 = data2.value()
     x_np2 = x2.numpy()
     np.testing.assert_array_equal(example_data_np, x_np2)
@@ -154,7 +192,7 @@ def test_from_to_pandas():
 
 
 @pytest.mark.parametrize("weights_as_branch", [True, False])
-def test_from_pandas_limits(weights_as_branch):
+def test_from_pandas_limits(weights_as_branch, obs3d):
     from skhep_testdata import data_path
 
     path_root = data_path("uproot-Zmumu.root")
@@ -173,9 +211,9 @@ def test_from_pandas_limits(weights_as_branch):
     )
 
     true_weights = true_data.pop(weight_branch)
-    obs1 = zfit.Space("pt1", limits=(lower1, upper1))
+    obs3d = zfit.Space("pt1", limits=(lower1, upper1))
     obs2 = zfit.Space("pt2", limits=(lower2, upper2))
-    obs = obs1 * obs2
+    obs = obs3d * obs2
 
     weights_for_pandas = (
         true_data_uncut[weight_branch] if weights_as_branch else weight_branch
@@ -231,12 +269,12 @@ def test_overloaded_operators():
 
 
 def test_sort_by_obs():
-    data1 = create_data1()
+    data1 = create_data1(obs3d)
 
-    new_obs = (obs1[1], obs1[2], obs1[0])
+    new_obs = (obs3d[1], obs3d[2], obs3d[0])
     new_array = copy.deepcopy(example_data1)[:, np.array((1, 2, 0))]
     # new_array = np.array([new_array[:, 1], new_array[:, 2], new_array[:, 0]])
-    assert data1.obs == obs1, "If this is not True, then the test will be flawed."
+    assert data1.obs == obs3d, "If this is not True, then the test will be flawed."
     with data1.sort_by_obs(new_obs):
         assert data1.obs == new_obs
         np.testing.assert_array_equal(new_array, data1.value().numpy())
@@ -249,13 +287,13 @@ def test_sort_by_obs():
 
         assert data1.obs == new_obs
 
-    assert data1.obs == obs1
+    assert data1.obs == obs3d
     np.testing.assert_array_equal(example_data1, data1.value().numpy())
 
 
-def test_subdata():
+def test_subdata(obs3d):
     data1 = create_data1()
-    new_obs = (obs1[0], obs1[1])
+    new_obs = (obs3d[0], obs3d[1])
     new_array = copy.deepcopy(example_data1)[:, np.array((0, 1))]
     # new_array = np.array([new_array[:, 0], new_array])
     with data1.sort_by_obs(obs=new_obs):
@@ -272,7 +310,7 @@ def test_subdata():
                 with data1.sort_by_obs(obs=new_obs):
                     data1.value().numpy()
 
-    assert data1.obs == obs1
+    assert data1.obs == obs3d
     np.testing.assert_array_equal(example_data1, data1.value())
 
 
@@ -335,3 +373,40 @@ def test_multidim_data_range():
     data_range = zfit.Space([obs1], limits=(5, 15))
     dataset = zfit.Data.from_numpy(array=data2, obs=data_range)
     assert dataset.nevents.numpy() == 11
+
+
+def test_data_hashing(space2d):
+    import zfit.z.numpy as znp
+
+    npdata1 = np.random.uniform(size=(3352, 2))
+    # data1 = data1.transpose()
+    data1 = zfit.Data.from_numpy(obs=space2d, array=npdata1)
+    assert data1.hashint is not None
+    testhashpdf = TestHashPDF(obs=space2d, lasthash=data1.hashint)
+    assert testhashpdf.lasthash == data1.hashint
+    oldhashint = data1.hashint
+    data1.set_weights(np.random.uniform(size=data1.nevents))
+    assert oldhashint != data1.hashint
+    assert data1.hashint != testhashpdf.lasthash
+    assert oldhashint == testhashpdf.lasthash
+    testhashpdf.pdf(data1, norm=False)
+    assert oldhashint != testhashpdf.lasthash
+    assert data1.hashint == testhashpdf.lasthash
+
+    zfit.run.set_graph_mode(
+        True
+    )  # meaning integration is now done in graph and has "None"
+    oldhashint = data1.hashint
+    data1.set_weights(np.random.uniform(size=data1.nevents))
+    testhashpdf.pdf(data1)
+    assert oldhashint != testhashpdf.lasthash
+    assert None == testhashpdf.lasthash
+
+
+def test_hashing_resample(space2d):
+    n = 1534
+    pdf = zfit.pdf.Gauss(obs=space2d.with_obs(space2d.obs[0]), mu=0.4, sigma=0.8)
+    sample = pdf.create_sampler(n)
+    assert sample.hashint is None
+    sample.resample()
+    assert sample.hashint is None

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -724,6 +724,7 @@ class Sampler(Data):
             )
         return super()._value_internal(obs=obs, filter=filter)
 
+    @property
     def hashint(self) -> int | None:
         return None  # since the variable can be changed but this may stays static... and using 128 bits we can't have
         # a tf.Variable that keeps the int

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Union
 
+import xxhash
 from tensorflow.python.util.deprecation import deprecated_args, deprecated
 
 if TYPE_CHECKING:
@@ -25,7 +26,7 @@ import zfit
 import zfit.z.numpy as znp
 
 from .. import z
-from ..settings import ztypes
+from ..settings import ztypes, run
 from ..util import ztyping
 from ..util.cache import GraphCachable, invalidate_graph
 from ..util.container import convert_to_container
@@ -55,8 +56,8 @@ class Data(
         obs: ztyping.ObsTypeInput = None,
         name: str = None,
         weights=None,
-        iterator_feed_dict: dict = None,
         dtype: tf.DType = None,
+        use_hash: bool = None,
     ):
         """Create a data holder from a `dataset` used to feed into `models`.
 
@@ -64,9 +65,13 @@ class Data(
             dataset: A dataset storing the actual values
             obs: Observables where the data is defined in
             name: Name of the `Data`
-            iterator_feed_dict:
+            weights: Weights of the data
             dtype: |dtype_arg_descr|
+            use_hash: Whether to use a hash for caching
         """
+        if use_hash is None:
+            use_hash = run.hashing_data()
+        self._use_hash = use_hash
         if name is None:
             name = "Data"
         if dtype is None:
@@ -86,12 +91,12 @@ class Data(
         self._data_range = (
             self.space
         )  # TODO proper data cuts: currently set so that the cuts in all dims are applied
-        self.batch_size = self.BATCH_SIZE
-        self.dataset = dataset.batch(self.batch_size)
+        self.dataset = dataset.batch(100_000_000)
         self._name = name
-        self.iterator_feed_dict = iterator_feed_dict
-        self.iterator = None
+
         self.set_weights(weights=weights)
+        self._hashint = None
+        self._update_hash()
 
     @property
     def nevents(self):
@@ -99,6 +104,10 @@ class Data(
         if nevents is None:
             nevents = self._get_nevents()
         return nevents
+
+    @property
+    def hashint(self) -> int | None:
+        return self._hashint
 
     # TODO: which naming? nevents or n_events
 
@@ -123,6 +132,7 @@ class Data(
         self._check_n_obs(space=obs)
         obs = obs.with_autofill_axes(overwrite=True)
         self._space = obs
+        self._update_hash()
 
     @property
     def data_range(self):
@@ -137,6 +147,7 @@ class Data(
 
         def setter(value):
             self._data_range = value
+            self._update_hash()
 
         def getter():
             return self._data_range
@@ -170,6 +181,7 @@ class Data(
 
         def setter(value):
             self._weights = value
+            self._update_hash()
 
         def getter():
             return self.weights
@@ -188,6 +200,7 @@ class Data(
         weights: ztyping.WeightsInputType | str = None,
         name: str = None,
         dtype: tf.DType = None,
+        use_hash: bool = None,
     ):
         """Create a `Data` from a pandas DataFrame. If `obs` is `None`, columns are used as obs.
 
@@ -199,6 +212,8 @@ class Data(
             weights: Weights of the data. Has to be 1-D and match the shape
                 of the data (nevents) or a string that is a column in the dataframe.
             name:
+            dtype: dtype of the data
+            use_hash: If `True`, a hash of the data is created and is used to identify it in caching.
         """
         if obs is None:
             obs = list(df.columns)
@@ -218,7 +233,12 @@ class Data(
         array = df[list(obs.obs)].values
 
         return cls.from_numpy(
-            obs=obs, array=array, weights=weights, name=name, dtype=dtype
+            obs=obs,
+            array=array,
+            weights=weights,
+            name=name,
+            dtype=dtype,
+            use_hash=use_hash,
         )
 
     @classmethod
@@ -240,6 +260,7 @@ class Data(
         name: str = None,
         dtype: tf.DType = None,
         root_dir_options=None,
+        use_hash: bool = None,
         # deprecated
         branches: list[str] = None,
         branches_alias: dict = None,
@@ -309,8 +330,13 @@ class Data(
             weights_np = weights
         dataset = LightDataset.from_tensor(data)
 
-        return Data(
-            dataset=dataset, obs=obs, weights=weights_np, name=name, dtype=dtype
+        return cls(
+            dataset=dataset,
+            obs=obs,
+            weights=weights_np,
+            name=name,
+            dtype=dtype,
+            use_hash=use_hash,
         )
 
     @classmethod
@@ -321,6 +347,7 @@ class Data(
         weights: ztyping.WeightsInputType = None,
         name: str = None,
         dtype: tf.DType = None,
+        use_hash=None,
     ):
         """Create `Data` from a `np.array`.
 
@@ -328,7 +355,9 @@ class Data(
             obs: Observables of the data. They will be matched to the data in the same order.
             array: Numpy array containing the data.
             weights: Weights of the data. Has to be 1-D and match the shape of the data (nevents).
-            name:
+            name: Name of the data.
+            dtype: dtype of the data.
+            use_hash: If `True`, a hash of the data is created and is used to identify it in caching.
 
         Returns:
             `zfit.Data`: A `Data` object containing the unbinned data.
@@ -344,7 +373,12 @@ class Data(
             dtype = ztypes.float
         tensor = tf.cast(array, dtype=dtype)
         return cls.from_tensor(
-            obs=obs, tensor=tensor, weights=weights, name=name, dtype=dtype
+            obs=obs,
+            tensor=tensor,
+            weights=weights,
+            name=name,
+            dtype=dtype,
+            use_hash=use_hash,
         )
 
     @classmethod
@@ -355,6 +389,7 @@ class Data(
         weights: ztyping.WeightsInputType = None,
         name: str = None,
         dtype: tf.DType = None,
+        use_hash=None,
     ) -> Data:
         """Create a `Data` from a `tf.Tensor`. `Value` simply returns the tensor (in the right order).
 
@@ -378,7 +413,26 @@ class Data(
         # dataset = tf.data.Dataset.from_tensor_slices(tensor)
         dataset = LightDataset.from_tensor(tensor)
 
-        return Data(dataset=dataset, obs=obs, name=name, weights=weights, dtype=dtype)
+        return cls(
+            dataset=dataset,
+            obs=obs,
+            name=name,
+            weights=weights,
+            dtype=dtype,
+            use_hash=use_hash,
+        )
+
+    def _update_hash(self):
+        if not run.executing_eagerly() or not self._use_hash:
+            self._hashint = None
+        else:
+            try:
+                hashval = xxhash.xxh128(np.asarray(self.value()))
+                if self.has_weights:
+                    hashval.update(np.asarray(self.weights))
+                self._hashint = hashval.intdigest()
+            except AttributeError:  # if the dataset is not yet initialized; this is allowed
+                self._hashint = None
 
     def with_obs(self, obs):
         values = self.value(obs)
@@ -416,17 +470,6 @@ class Data(
 
     def value(self, obs: ztyping.ObsTypeInput = None):
         return znp.asarray(self._value_internal(obs=obs))
-        # TODO: proper iterations
-        # value_iter = self._value_internal(obs=obs)
-        # value = next(value_iter)
-        # try:
-        #     next(value_iter)
-        # except StopIteration:  # it's ok, we're not batched
-        #     return value
-        # else:
-        #     raise DataIsBatchedError(
-        #         f"Data {self} is batched, cannot return only the value. Iterate through it (WIP, make"
-        #         f"an issue on Github if this feature is needed now)")
 
     def numpy(self):
         return self.value().numpy()
@@ -589,14 +632,15 @@ class SampleData(Data):
         weights=None,
         name: str = None,
         dtype: tf.DType = ztypes.float,
+        use_hash: bool = None,
     ):
         super().__init__(
             dataset,
             obs,
             name=name,
             weights=weights,
-            iterator_feed_dict=None,
             dtype=dtype,
+            use_hash=use_hash,
         )
 
     @classmethod
@@ -612,9 +656,12 @@ class SampleData(Data):
         obs: ztyping.ObsTypeInput,
         name: str = None,
         weights=None,
+        use_hash: bool = None,
     ):
         dataset = LightDataset.from_tensor(sample)
-        return SampleData(dataset=dataset, obs=obs, name=name, weights=weights)
+        return SampleData(
+            dataset=dataset, obs=obs, name=name, weights=weights, use_hash=use_hash
+        )
 
 
 class Sampler(Data):
@@ -631,6 +678,7 @@ class Sampler(Data):
         obs: ztyping.ObsTypeInput = None,
         name: str = None,
         dtype: tf.DType = ztypes.float,
+        use_hash: bool = None,
     ):
 
         super().__init__(
@@ -638,8 +686,8 @@ class Sampler(Data):
             obs=obs,
             name=name,
             weights=weights,
-            iterator_feed_dict=None,
             dtype=dtype,
+            use_hash=use_hash,
         )
         if fixed_params is None:
             fixed_params = OrderedDict()
@@ -692,6 +740,7 @@ class Sampler(Data):
         name: str = None,
         weights=None,
         dtype=None,
+        use_hash: bool = None,
     ):
         obs = convert_to_space(obs)
 
@@ -710,7 +759,7 @@ class Sampler(Data):
         )
         dataset = LightDataset.from_tensor(sample_holder)
 
-        return Sampler(
+        return cls(
             dataset=dataset,
             sample_holder=sample_holder,
             sample_func=sample_func,
@@ -719,6 +768,7 @@ class Sampler(Data):
             obs=obs,
             name=name,
             weights=weights,
+            use_hash=use_hash,
         )
 
     def resample(self, param_values: Mapping = None, n: int | tf.Tensor = None):
@@ -763,6 +813,7 @@ class Sampler(Data):
             # self.sample_holder.assign(new_sample)
             self.sample_holder.assign(new_sample, read_value=False)
             self._initial_resampled = True
+        self._update_hash()
 
     def __str__(self) -> str:
         return f"<Sampler: {self.name} obs={self.obs}>"

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -724,6 +724,10 @@ class Sampler(Data):
             )
         return super()._value_internal(obs=obs, filter=filter)
 
+    def hashint(self) -> int | None:
+        return None  # since the variable can be changed but this may stays static... and using 128 bits we can't have
+        # a tf.Variable that keeps the int
+
     @classmethod
     def get_cache_counting(cls):
         counting = cls._cache_counting

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -232,7 +232,7 @@ class Data(
             weights = df[weights]
         array = df[list(obs.obs)].values
 
-        return cls.from_numpy(
+        return Data.from_numpy(  # *not* class, if subclass, keep constructor
             obs=obs,
             array=array,
             weights=weights,
@@ -330,7 +330,7 @@ class Data(
             weights_np = weights
         dataset = LightDataset.from_tensor(data)
 
-        return cls(
+        return Data(  # *not* class, if subclass, keep constructor
             dataset=dataset,
             obs=obs,
             weights=weights_np,
@@ -372,7 +372,7 @@ class Data(
         if dtype is None:
             dtype = ztypes.float
         tensor = tf.cast(array, dtype=dtype)
-        return cls.from_tensor(
+        return Data.from_tensor(  # *not* class, if subclass, keep constructor
             obs=obs,
             tensor=tensor,
             weights=weights,
@@ -413,7 +413,7 @@ class Data(
         # dataset = tf.data.Dataset.from_tensor_slices(tensor)
         dataset = LightDataset.from_tensor(tensor)
 
-        return cls(
+        return Data(  # *not* class, if subclass, keep constructor
             dataset=dataset,
             obs=obs,
             name=name,

--- a/zfit/util/execution.py
+++ b/zfit/util/execution.py
@@ -33,6 +33,7 @@ class RunManager:
         self.numeric_checks = True
         self._mode = self.DEFAULT_MODE.copy()
         self.set_n_cpu(n_cpu=n_cpu)
+        self._hashing_enabled = True
 
         # HACK
         self._enable_parameter_autoconversion = True
@@ -404,6 +405,18 @@ class RunManager:
         Use `clear_graph_caches` instead.
         """
         self.clear_graph_cache()
+
+    def hashing_data(self):
+        """If hashing of data (required for caching) is enabled."""
+        return self._hashing_enabled
+
+    def set_data_hashing(self, enabled: bool):
+        """Enable or disable hashing of data (required for caching).
+
+        Args:
+            enabled: Whether hashing of data is enabled.
+        """
+        self._hashing_enabled = enabled
 
 
 def eval_object(obj: object) -> object:


### PR DESCRIPTION
Needed for caching as in #405 

## Proposed Changes

- adds an eager caching method, namely a `hashint` attribute to unbinned datasets. Resampleable datasets are not hashable.

## Tests added

- checking the invalidation of the hashint

## Checklist

- [x] change approved
- [x] implementation finished
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
