### PR TITLE
clean graph more frequently to reduce memory leaks and overall usage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ Develop
 
 Major Features and Improvements
 -------------------------------
+- reduce the memory footprint on (some) fits, especially repetitive (loops) ones.
+  Reduces the number of cached compiled functions. The cachesize can be set with
+  ``zfit.run.set_cache_size(int)``
+  and specifies the number of compiled functions that are kept in memory. The default is 10, but
+  this can be tuned. Lower values can reduce memory usage, but potentially increase runtime.
 
 Breaking changes
 ------------------

--- a/examples/binned_template_simple.py
+++ b/examples/binned_template_simple.py
@@ -17,15 +17,15 @@ mplhep.histplot(
     histos, stack=True, histtype="fill", label=[f"process {i + 1}" for i in range(5)]
 )
 plt.legend()
-plt.show()
 pdfs = [zfit.pdf.HistogramPDF(h) for h in histos]
 sumpdf = zfit.pdf.BinnedSumPDF(pdfs)
+
 
 h_back = sumpdf.to_hist()
 pdf_syst = zfit.pdf.BinwiseScaleModifier(sumpdf, modifiers=True)
 
 mplhep.histplot(h_back)
-# plt.legend()
 
-plt.show()
 print(h_back)
+# uncomment to show plots
+# plt.show()

--- a/examples/minimize_python_func.py
+++ b/examples/minimize_python_func.py
@@ -8,7 +8,6 @@ Copyright (c) 2021 zfit
 #  Copyright (c) 2022 zfit
 
 import numpy as np
-import tensorflow as tf
 
 import zfit
 
@@ -27,12 +26,15 @@ minimizer = zfit.minimize.IpyoptV1()
 
 
 def func(x):
-    x = np.array(x)  # make sure it's an array
+    x = np.asarray(x)  # make sure it's an array
     return np.sum((x - 0.1) ** 2 + x[1] ** 4)
 
 
 # We can use the same in pure TF, then we can also use
 # the analytic gradient
+#
+# import tensorflow as tf
+#
 # @tf.function
 # def func(x):
 #     x = tf.convert_to_tensor(x)  # make sure it's an array
@@ -60,6 +62,6 @@ params = [1, -3, 2, 1.4, 11]
 result = minimizer.minimize(func, params)
 
 # estimate errors
-result.hesse()
-result.errors()
+result.hesse(name="hesse")
+result.errors(name="errors")
 print(result)

--- a/examples/plot_sig_bkg.py
+++ b/examples/plot_sig_bkg.py
@@ -80,4 +80,5 @@ param_errors, _ = result.errors()
 plot_pdf(title="After fitting")
 plt.legend()
 
-plt.show()
+# uncomment to display plots
+# plt.show()

--- a/examples/signal_bkg_mass_extended_fit_binned.py
+++ b/examples/signal_bkg_mass_extended_fit_binned.py
@@ -84,4 +84,5 @@ print(result.valid)  # check if the result is still valid
 # plot the data
 
 plot_pdf("after fit")
-plt.show()
+# uncomment to display plots
+# plt.show()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def setup_teardown():
             del sys.modules[m]
 
     yield
+
     from zfit.core.parameter import ZfitParameterMixin
 
     ZfitParameterMixin._existing_params.clear()
@@ -47,6 +48,7 @@ def setup_teardown():
     zfit.run.chunking.max_n_points = old_chunksize
     zfit.run.set_graph_mode(old_graph_mode)
     zfit.run.set_autograd_mode(old_autograd_mode)
+    zfit.run.set_graph_cache_size()
     for m in sys.modules.keys():
         if m not in init_modules:
             del sys.modules[m]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -91,7 +91,7 @@ class GraphCreator1(GraphCachable):
 
 
 class GraphCreator2(GraphCreator1):
-    @z.function(experimental_relax_shapes=False)
+    @z.function()
     def calc(self, x):
         self.retrace_runs += 1
         return x + self.value + CONST

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -10,8 +10,16 @@ from zfit import z
     zfit.run.get_graph_mode() is False,
     reason="If not using graph mode, we cannot test if graphs work or not.",
 )
-def test_modes():
+@pytest.mark.parametrize("cachesize", [1, 10, 1000, None])
+def test_modes(cachesize):
     counts = 0
+
+    zfit.run.set_graph_cache_size(cachesize)
+    if cachesize is not None:
+        assert all(
+            register.cachesize == cachesize
+            for register in zfit.z.zextension.FunctionWrapperRegistry.registries
+        )
 
     @z.function(wraps="42")
     def func(x):

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -452,7 +452,7 @@ def test_minimizers(
         not long_clarg
         and not do_long
         and not (
-            chunksize == chunksizes[0] and numgrad == False and spaces is spaces_all[0]
+            chunksize == chunksizes[0] and numgrad is False and spaces is spaces_all[0]
         )
     )
 

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -443,7 +443,7 @@ def test_minimizers(
     if not isinstance(test_error, dict):
         test_error = {"error": test_error}
 
-    numgrad = test_error.get("numgrad", False)
+    # numgrad = test_error.get("numgrad", False)
     do_long = test_error.get("longtests", False)
     has_approx = test_error.get("approx", False)
     test_error = test_error["error"]
@@ -452,15 +452,12 @@ def test_minimizers(
         not long_clarg
         and not do_long
         and not (
-            chunksize == chunksizes[0]
-            and numgrad == numgrads[0]
-            and spaces is spaces_all[0]
+            chunksize == chunksizes[0] and numgrad == False and spaces is spaces_all[0]
         )
     )
 
     if skip_tests:
-        pass
-        # return
+        return
     if not long_clarg and not do_long:
         test_error = False
 

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -94,7 +94,7 @@ class Data(
         self.dataset = dataset.batch(100_000_000)
         self._name = name
 
-        self.set_weights(weights=weights)
+        self._set_weights(weights=weights)
         self._hashint = None
         self._update_hash()
 
@@ -173,20 +173,25 @@ class Data(
         Args:
             weights:
         """
-        if weights is not None:
-            weights = z.convert_to_tensor(weights)
-            weights = z.to_real(weights)
-            if weights.shape.ndims != 1:
-                raise ShapeIncompatibleError("Weights have to be 1-Dim objects.")
+        # weights = self._set_weights(weights)
 
         def setter(value):
-            self._weights = value
-            self._update_hash()
+            self._set_weights(value)
 
         def getter():
             return self.weights
 
         return TemporarilySet(value=weights, getter=getter, setter=setter)
+
+    def _set_weights(self, weights):
+        if weights is not None:
+            weights = z.convert_to_tensor(weights)
+            weights = z.to_real(weights)
+            if weights.shape.ndims != 1:
+                raise ShapeIncompatibleError("Weights have to be 1-Dim objects.")
+        self._weights = weights
+        self._update_hash()
+        return weights
 
     @property
     def space(self) -> ZfitSpace:

--- a/zfit/util/cache.py
+++ b/zfit/util/cache.py
@@ -296,19 +296,37 @@ class FunctionCacheHolder(GraphCachable):
         return tuple(combined_cleaned)
 
     def get_immutable_repr_obj(self, obj):
-        from ..core.interfaces import ZfitData, ZfitParameter, ZfitSpace
+        from ..core.interfaces import (
+            ZfitData,
+            ZfitParameter,
+            ZfitSpace,
+            ZfitLoss,
+            ZfitModel,
+            ZfitConstraint,
+            ZfitPDF,
+            ZfitLimit,
+        )
 
         if isinstance(obj, collections.abc.Mapping):
             obj = obj.items()
-        if isinstance(obj, ZfitData):
+        if isinstance(
+            obj,
+            (
+                ZfitData,
+                ZfitLoss,
+                ZfitModel,
+                ZfitConstraint,
+                ZfitPDF,
+                ZfitLimit,
+                ZfitSpace,
+            ),
+        ):
             obj = id(obj)
         elif isinstance(obj, ZfitParameter):
             if self.stateless_args:
                 obj = (self.IS_TENSOR,)
             else:
                 obj = (ZfitParameter, obj.name)
-        elif isinstance(obj, ZfitSpace):
-            obj = id(obj)
         elif tf.is_tensor(obj):
             obj = (self.IS_TENSOR,)
         elif isinstance(obj, np.ndarray):

--- a/zfit/util/execution.py
+++ b/zfit/util/execution.py
@@ -314,7 +314,7 @@ class RunManager:
         from .graph import jit as jit_obj
 
         # only run eagerly if no graph
-        tf.config.run_functions_eagerly(graph is False)
+        # tf.config.run_functions_eagerly(graph is False)
         if graph is True:
             jit_obj._set_all(True)
         elif graph is False:

--- a/zfit/util/execution.py
+++ b/zfit/util/execution.py
@@ -388,15 +388,26 @@ class RunManager:
         clear_graph_cache()
 
     def set_graph_cache_size(self, size: int | None = None):
-        """Set the size of the graph cache.
+        """Set the size of the graph cache to the same value for all.
+
+        Whenever a function, decorated with `z.function` is called, it is first compiled to a graph, which is cached.
+        For different reasons, there can be different compiled functions of the same Python function (such as changed
+        internal parameters). The cache determines how many compiled functions are kept in memory.
 
         Args:
-            size: The size of the cache. If None, the default size is used.
+            size:(default=10) The size of the cache. If None, the default size is used. With a lower number, a
+                smaller memory footprint *can* be achieved in some cases, but the runtime *can* be slower in some cases
+                (they do not need to be the same). Potentially, the cache should be at least of the size as the number
+                of calls to a function *with different arguments* is expected to happen *outside of any loop*/within
+                one execution of a loop.
         """
         from zfit.z.zextension import FunctionWrapperRegistry
 
+        if size is not None and size < 1:
+            raise ValueError("The size of the cache must be at least 1.")
+
         for registry in FunctionWrapperRegistry.registries:
-            registry.set_cache_size(size)
+            registry.set_graph_cache_size(size)
 
     def assert_executing_eagerly(self):
         """Assert that the execution is eager and Python side effects are taken into account.

--- a/zfit/util/execution.py
+++ b/zfit/util/execution.py
@@ -6,6 +6,7 @@ import contextlib
 import multiprocessing
 import os
 import sys
+from typing import Optional
 
 import tensorflow as tf
 from dotmap import DotMap
@@ -385,6 +386,17 @@ class RunManager:
         from zfit.util.cache import clear_graph_cache
 
         clear_graph_cache()
+
+    def set_graph_cache_size(self, size: int | None = None):
+        """Set the size of the graph cache.
+
+        Args:
+            size: The size of the cache. If None, the default size is used.
+        """
+        from zfit.z.zextension import FunctionWrapperRegistry
+
+        for registry in FunctionWrapperRegistry.registries:
+            registry.set_cache_size(size)
 
     def assert_executing_eagerly(self):
         """Assert that the execution is eager and Python side effects are taken into account.

--- a/zfit/z/math.py
+++ b/zfit/z/math.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from .. import z
+
 if TYPE_CHECKING:
     import zfit
 
@@ -328,7 +330,7 @@ def automatic_value_gradients_hessian(*args, **kwargs):
     return automatic_value_gradient_hessian(*args, **kwargs)
 
 
-@tf.function(autograph=False)
+# @z.function  # TODO: circular import, improve?
 def reduce_geometric_mean(input_tensor, axis=None, weights=None, keepdims=False):
     if weights is not None:
         log_mean = tf.nn.weighted_moments(

--- a/zfit/z/zextension.py
+++ b/zfit/z/zextension.py
@@ -220,7 +220,7 @@ class FunctionWrapperRegistry:
         self.tf_function_kwargs = kwargs
         self.function_cache.clear()
 
-    def set_cache_size(self, cachesize: int | None = None):
+    def set_graph_cache_size(self, cachesize: int | None = None):
         """Set the size of the graph cache.
 
         Args:
@@ -287,7 +287,7 @@ class FunctionWrapperRegistry:
                         warnings.warn(
                             f"Function {function_holder.python_func} was removed from the cache more than 3"
                             f" times (and getting recompiled). Maybe consider increasing the cache size"
-                            f" using `zfit.run.set_cache_size(...)`, the current size is {self.cachesize}."
+                            f" using `zfit.run.set_graph_cache_size(...)`, the current size is {self.cachesize}."
                         )
 
                         self._deleted_cachers - collections.Counter(
@@ -304,18 +304,18 @@ class FunctionWrapperRegistry:
                 self.currently_traced.remove(func)
             return result
 
-        # concrete_func.zfit_graph_cache_registered = False
         return concrete_func
 
 
 # equivalent to tf.function
-def function(func=None, *, stateless_args=None, **kwargs):
+def function(func=None, *, stateless_args=None, cachesize=None, **kwargs):
     """JIT/Graph compilation of functions, `tf.function`-like with additional cache-invalidation functionality.
 
     Args:
         func: Function to be compiled.
         stateless_args: If True, the function is assumed to be stateless and *does not depend on the name of tf.Variables*
             but only needs the values of the variables. This is not the case for taking gradients, for example.
+        cachesize: Size of the cache. If None, the default size is used.
         **kwargs: arguments to `tf.function`
 
     Returns:


### PR DESCRIPTION
## Proposed Changes

- add a cachsize option that limits how many compiled tf.functions are remembered. This will solve widespread problems of memory leaks, but *can* potentially remove too many cachings, in which case the function would be recompiled on every occasion.


## Checklist

- [x] change approved
- [x] implementation finished
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
