### PR TITLE
Implementing missing methods: create_sampler, to_binned, to_unbinned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
             use-graph: 1
             extras: alldev-windows
 
-
     steps:
       - uses: actions/checkout@v3
       - name: Get history and tags for SCM versioning to work

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ on:
 jobs:
   unittests:
     runs-on: ${{ matrix.os }}
-#    env:
-#      ZFIT_DO_JIT: ${{ matrix.use-graph }}
     timeout-minutes: 180 # for eager mode
     name: tests on ${{ matrix.os }} with ${{ matrix.python-version }} compiled = ${{ matrix.use-graph }}
     env:
@@ -76,7 +74,7 @@ jobs:
       - name: Test with pytest
         # TODO: maybe reactivate long tests?
         #          if [ "$GITHUB_REF" == 'refs/heads/develop' ]; then
-        #            echo "PYTEST_ADDOPTS=--longtests-kde" >> "$GITHUB_ENV"
+        #            echo "PYTEST_ADDOPTS=--longtests-kde --longtests" >> "$GITHUB_ENV"
         #          fi
         run: |
           coverage run --source=. --omit=".tox/*,*/test*,*/minimizers/interface.py,*/core/testing.py" --branch -m pytest .

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Bug fixes and small changes
 - Sum of histograms failed for calling the pdf method (can be indirectly), integrated over wrong axis.
 - Binned PDFs expected binned spaces for limits, now unbinned limits are also allowed and automatically
     converted to binned limits using the PDFs binning.
+- Speedup sampling of binned distributions.
+- add ``to_binned`` and ``to_unbinned`` methods to PDF
 
 Experimental
 ------------

--- a/examples/signal_bkg_mass_extended_fit_binned.py
+++ b/examples/signal_bkg_mass_extended_fit_binned.py
@@ -5,7 +5,6 @@ import mplhep
 import numpy as np
 
 import zfit
-import zfit.models.tobinned
 
 n_bins = 50
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,9 +85,10 @@ def pytest_configure():
         if not title_sanitized:
             raise RuntimeError("Title has to be set for plot that should be saved.")
         if folder is not None:
-            title_sanitized = pathlib.Path(folder).joinpath(title_sanitized)
+            folder = pathlib.Path(folder)
+            folder.mkdir(exist_ok=True, parents=True)
+            title_sanitized = folder.joinpath(title_sanitized)
         savepath = images_dir.joinpath(title_sanitized)
-        savepath.mkdir(exist_ok=True, parents=True)
         plt.savefig(str(savepath))
 
     pytest.zfit_savefig = savefig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def pytest_configure():
     )
     images_dir.mkdir(exist_ok=True)
 
-    def savefig(figure=None):
+    def savefig(figure=None, folder=None):
         if figure is None:
             figure = plt.gcf()
         title_sanitized = (
@@ -84,7 +84,10 @@ def pytest_configure():
         )
         if not title_sanitized:
             raise RuntimeError("Title has to be set for plot that should be saved.")
+        if folder is not None:
+            title_sanitized = pathlib.Path(folder).joinpath(title_sanitized)
         savepath = images_dir.joinpath(title_sanitized)
+        savepath.mkdir(exist_ok=True, parents=True)
         plt.savefig(str(savepath))
 
     pytest.zfit_savefig = savefig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,17 +78,21 @@ def pytest_configure():
             .replace(" ", "_")
             .replace("$", "_")
             .replace("\\", "_")
+            .replace("__", "_")
         )
         title_sanitized = (
-            title_sanitized.replace("/", "_").replace(".", "_").replace(":", "_")
+            title_sanitized.replace("/", "_")
+            .replace(".", "_")
+            .replace(":", "_")
+            .replace(",", "")
         )
         if not title_sanitized:
             raise RuntimeError("Title has to be set for plot that should be saved.")
+        foldersave = images_dir
         if folder is not None:
-            folder = pathlib.Path(folder)
-            folder.mkdir(exist_ok=True, parents=True)
-            title_sanitized = folder.joinpath(title_sanitized)
-        savepath = images_dir.joinpath(title_sanitized)
+            foldersave = foldersave.joinpath(folder)
+        foldersave.mkdir(exist_ok=True, parents=True)
+        savepath = foldersave.joinpath(title_sanitized)
         plt.savefig(str(savepath))
 
     pytest.zfit_savefig = savefig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,8 +58,8 @@ def setup_teardown():
 
 
 def pytest_addoption(parser):
-    parser.addoption("--longtests", action="store", default=False)
-    parser.addoption("--longtests-kde", action="store", default=False)
+    parser.addoption("--longtests", action="store_true", default=False)
+    parser.addoption("--longtests-kde", action="store_true", default=False)
 
 
 def pytest_configure():

--- a/tests/fullexample/test_binned_vs_unbinned.py
+++ b/tests/fullexample/test_binned_vs_unbinned.py
@@ -70,9 +70,9 @@ def test_sig_bkg_fit(n, floatall, use_sampler, nbins, use_wrapper):
     x = np.linspace(-10, 10, 1000)
 
     plot_folder = (
-        f'NLL_profile_nbins{nbins} n{n} floatall_{floatall} {"sampler" if use_sampler else ""}'
-        f' {"wrapper" if use_wrapper else ""}'.replace(" ", "_")
-    )
+        f'NLL_profile/nbins{nbins} n{n} floatall_{floatall} {"sampler" if use_sampler else ""}'
+        f' {"wrapper" if use_wrapper else ""}'
+    ).replace(" ", "_")
 
     def plot_pdf(title):
         plt.figure()

--- a/tests/fullexample/test_binned_vs_unbinned.py
+++ b/tests/fullexample/test_binned_vs_unbinned.py
@@ -70,8 +70,8 @@ def test_sig_bkg_fit(n, floatall, use_sampler, nbins, use_wrapper):
     x = np.linspace(-10, 10, 1000)
 
     plot_folder = (
-        f'NLL_profile/nbins{nbins} n{n} floatall_{floatall} {"sampler" if use_sampler else ""}'
-        f' {"wrapper" if use_wrapper else ""}'
+        f'NLL_profile/nbins{nbins} n{n} floatall_{floatall}{" sampler" if use_sampler else ""}'
+        f'{" wrapper" if use_wrapper else ""}'
     ).replace(" ", "_")
 
     def plot_pdf(title):

--- a/tests/fullexample/test_binned_vs_unbinned.py
+++ b/tests/fullexample/test_binned_vs_unbinned.py
@@ -9,13 +9,10 @@ import pytest
 @pytest.mark.parametrize(
     "use_sampler", [True, False], ids=["useSampler", "onetimeSample"]
 )
-@pytest.mark.parametrize("nbins", [20, 90, 311], ids=lambda x: f"nbins={x:,}")
+@pytest.mark.parametrize("nbins", [27, 90, 311], ids=lambda x: f"nbins={x:,}")
 @pytest.mark.parametrize(
     "use_wrapper",
-    [
-        # True,
-        False
-    ],
+    [True, False],
     ids=lambda x: f"useWrapper={x}",
 )
 @pytest.mark.flaky(reruns=1)  # in case a fit fails
@@ -27,11 +24,9 @@ def test_sig_bkg_fit(n, floatall, use_sampler, nbins, use_wrapper):
 
     import zfit
 
-    n_bins = 100
-
     # create space
     obs_binned = zfit.Space(
-        "x", binning=zfit.binned.RegularBinning(n_bins, -10, 10, name="x")
+        "x", binning=zfit.binned.RegularBinning(nbins, -10, 10, name="x")
     )
     obs = obs_binned.with_binning(None)
 
@@ -70,7 +65,7 @@ def test_sig_bkg_fit(n, floatall, use_sampler, nbins, use_wrapper):
         data = model.sample(n=n_sample)
         data_unbinned = model_unbinned.sample(n=n_sample)
 
-    plot_scaling = n_sample / n_bins * obs.area()
+    plot_scaling = n_sample / nbins * obs.area()
 
     x = np.linspace(-10, 10, 1000)
 
@@ -304,7 +299,6 @@ def test_nbins():
 
         plt.figure()
         plt.title(f"{nbins} bins binned vs unbinned curve")
-        # mplhep.histplot(model_binned.to_hist().density() * 300, label="binned")
         x = np.linspace(0, 10, nbins)
         scaled_density = model_binned.to_hist().density() * model_binned.get_yield()
         plt.plot(x, scaled_density, "x", label="binned")
@@ -343,6 +337,6 @@ def test_nbins():
     plt.ylabel("n_bkg")
     plt.legend()
     pytest.zfit_savefig(folder=plot_folder)
-    plt.show()
+    # plt.show()
     # 4 sigma away, factor of two because binned is less precise
     assert pytest.approx(mean, abs=std * 4 * 2) == result.params["n_bkg"]["value"]

--- a/tests/fullexample/test_binned_vs_unbinned.py
+++ b/tests/fullexample/test_binned_vs_unbinned.py
@@ -1,0 +1,199 @@
+#  Copyright (c) 2022 zfit
+import pytest
+
+
+@pytest.mark.parametrize("n", [300, 10000, 200_000], ids=lambda x: f"samplesize={x:,}")
+@pytest.mark.parametrize(
+    "floatall", [True, False], ids=["floatAll", "floatSigBkgLambdaOnly"]
+)
+@pytest.mark.parametrize(
+    "use_sampler", [True, False], ids=["useSampler", "onetimeSample"]
+)
+@pytest.mark.flaky(reruns=1)  # in case a fit fails
+def test_sig_bkg_fit(n, floatall, use_sampler):
+    #  Copyright (c) 2022 zfit
+
+    import matplotlib.pyplot as plt
+    import mplhep
+    import numpy as np
+
+    import zfit
+
+    n_bins = 100
+
+    # create space
+    obs_binned = zfit.Space(
+        "x", binning=zfit.binned.RegularBinning(n_bins, -10, 10, name="x")
+    )
+    obs = obs_binned.with_binning(None)
+
+    # parameters
+    mu = zfit.Parameter("mu", 1.0, -4, 6, floating=floatall)
+    sigma = zfit.Parameter("sigma", 1.0, 0.1, 10, floating=floatall)
+
+    lambd = zfit.Parameter("lambda", -0.06, -1, -0.01)
+
+    # model building, pdf creation
+    gauss = zfit.pdf.Gauss(mu=mu, sigma=sigma, obs=obs)
+    exponential = zfit.pdf.Exponential(lambd, obs=obs)
+
+    n_bkg_init = 20000
+    n_sig_init = 2000
+    n_bkg = zfit.Parameter("n_bkg", n_bkg_init)
+    n_sig = zfit.Parameter("n_sig", n_sig_init)
+    gauss_extended = gauss.create_extended(n_sig)
+    exp_extended = exponential.create_extended(n_bkg)
+    model_unbinned = zfit.pdf.SumPDF([gauss_extended, exp_extended])
+
+    # make binned
+    model = zfit.pdf.BinnedFromUnbinnedPDF(model_unbinned, space=obs_binned)
+
+    # data
+    n_sample = n
+    if use_sampler:
+        data = model.create_sampler(n=n_sample)
+        data.resample(n=n_sample)
+        data_unbinned = model_unbinned.create_sampler(n=n_sample)
+        data_unbinned.resample(n=n_sample)
+    else:
+        data = model.sample(n=n_sample)
+        data_unbinned = model_unbinned.sample(n=n_sample)
+
+    plot_scaling = n_sample / n_bins * obs.area()
+
+    x = np.linspace(-10, 10, 1000)
+
+    def plot_pdf(title):
+        plt.figure()
+        plt.title(title)
+        y = model.pdf(x).numpy()
+        y_gauss = (gauss.pdf(x) * model_unbinned.params["frac_0"]).numpy()
+        y_exp = (exponential.pdf(x) * model_unbinned.params["frac_1"]).numpy()
+        plt.plot(x, y * plot_scaling, label="Sum - Model")
+        plt.plot(x, y_gauss * plot_scaling, label="Gauss - Signal")
+        plt.plot(x, y_exp * plot_scaling, label="Exp - Background")
+        mplhep.histplot(data.to_hist(), yerr=True, color="black", histtype="errorbar")
+        plt.ylabel("Counts")
+        plt.xlabel("obs: $B_{mass}$")
+        plt.legend()
+
+    # create NLL
+    nll = zfit.loss.ExtendedBinnedNLL(model=model, data=data)
+    nll_unbinned = zfit.loss.ExtendedUnbinnedNLL(
+        model=model_unbinned, data=data_unbinned
+    )
+
+    # create a minimizer
+    minimizer = zfit.minimize.Minuit()
+    results = []
+    rel = 0.03 * n**0.5 / 17  # 17 is 300 ** 0.5
+    if floatall:
+        rel *= 3  # higher tolerance if we float all
+    for loss in [nll, nll_unbinned]:
+        if floatall:
+            mu.set_value(0.5)
+            sigma.set_value(1.2)
+        lambd.set_value(-0.05)
+        if not use_sampler:
+            plot_pdf(
+                f"before fit - {loss.name} n:{n_sample:,} {'floatAll' if floatall else 'fixedSigShape'}"
+            )
+
+        result = minimizer.minimize(nll)
+        results.append(result)
+        # do the error calculations, here with hesse, than with minos
+        _ = result.hesse()
+        (
+            param_errors,
+            _,
+        ) = result.errors()  # this returns a new FitResult if a new minimum was found
+        # print(result.valid)  # check if the result is still valid
+        # print(result)
+        # plot the data
+        if not use_sampler:
+            plot_pdf(
+                f"after fit - {loss.name} n:{n_sample:,} {'floatAll' if floatall else 'fixedSigShape'}"
+            )
+
+    assert (
+        pytest.approx(results[0].params["lambda"]["value"], rel=rel)
+        == results[1].params["lambda"]["value"]
+    )
+    assert (
+        pytest.approx(results[0].params["lambda"]["hesse"], rel=rel)
+        == results[1].params["lambda"]["hesse"]
+    )
+    assert (
+        pytest.approx(results[0].params["lambda"]["errors"]["lower"], rel=rel)
+        == results[1].params["lambda"]["errors"]["lower"]
+    )
+    assert (
+        pytest.approx(results[0].params["lambda"]["errors"]["upper"], rel=rel)
+        == results[1].params["lambda"]["errors"]["upper"]
+    )
+    assert (
+        pytest.approx(results[0].params["n_bkg"]["value"], rel=rel)
+        == results[1].params["n_bkg"]["value"]
+    )
+    assert (
+        pytest.approx(results[0].params["n_bkg"]["hesse"], rel=rel)
+        == results[1].params["n_bkg"]["hesse"]
+    )
+    assert (
+        pytest.approx(results[0].params["n_bkg"]["errors"]["lower"], rel=rel)
+        == results[1].params["n_bkg"]["errors"]["lower"]
+    )
+    assert (
+        pytest.approx(results[0].params["n_bkg"]["errors"]["upper"], rel=rel)
+        == results[1].params["n_bkg"]["errors"]["upper"]
+    )
+    assert (
+        pytest.approx(results[0].params["n_sig"]["value"], rel=rel)
+        == results[1].params["n_sig"]["value"]
+    )
+    assert (
+        pytest.approx(results[0].params["n_sig"]["hesse"], rel=rel)
+        == results[1].params["n_sig"]["hesse"]
+    )
+    assert (
+        pytest.approx(results[0].params["n_sig"]["errors"]["lower"], rel=rel)
+        == results[1].params["n_sig"]["errors"]["lower"]
+    )
+    assert (
+        pytest.approx(results[0].params["n_sig"]["errors"]["upper"], rel=rel)
+        == results[1].params["n_sig"]["errors"]["upper"]
+    )
+
+    if floatall:
+        assert (
+            pytest.approx(results[0].params["mu"]["value"], rel=rel)
+            == results[1].params["mu"]["value"]
+        )
+        assert (
+            pytest.approx(results[0].params["mu"]["hesse"], rel=rel)
+            == results[1].params["mu"]["hesse"]
+        )
+        assert (
+            pytest.approx(results[0].params["mu"]["errors"]["lower"], rel=rel)
+            == results[1].params["mu"]["errors"]["lower"]
+        )
+        assert (
+            pytest.approx(results[0].params["mu"]["errors"]["upper"], rel=rel)
+            == results[1].params["mu"]["errors"]["upper"]
+        )
+        assert (
+            pytest.approx(results[0].params["sigma"]["value"], rel=rel)
+            == results[1].params["sigma"]["value"]
+        )
+        assert (
+            pytest.approx(results[0].params["sigma"]["hesse"], rel=rel)
+            == results[1].params["sigma"]["hesse"]
+        )
+        assert (
+            pytest.approx(results[0].params["sigma"]["errors"]["lower"], rel=rel)
+            == results[1].params["sigma"]["errors"]["lower"]
+        )
+        assert (
+            pytest.approx(results[0].params["sigma"]["errors"]["upper"], rel=rel)
+            == results[1].params["sigma"]["errors"]["upper"]
+        )

--- a/tests/highstats/test_exact_yields.py
+++ b/tests/highstats/test_exact_yields.py
@@ -92,9 +92,9 @@ def test_yield_bias(exact_nsample, ntoys=100):
         assert nsig_res + nbkg_res == pytest.approx(true_nsig + true_nbkg, abs=0.5)
 
     nsigs_mean = np.mean(nsigs)
-    std_nsigs_mean = np.std(nsigs) / ntoys**0.5
+    std_nsigs_mean = np.std(nsigs) / ntoys**0.5 * 4
     nbkg_mean = np.mean(nbkgs)
-    std_nbkg_mean = np.std(nbkgs) / ntoys**0.5
+    std_nbkg_mean = np.std(nbkgs) / ntoys**0.5 * 4
 
     # for debugging and testing
     # print(result)

--- a/tests/highstats/test_exact_yields.py
+++ b/tests/highstats/test_exact_yields.py
@@ -1,4 +1,5 @@
 #  Copyright (c) 2022 zfit
+import pathlib
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -9,6 +10,10 @@ import pytest
 def test_yield_bias(exact_nsample, ntoys=100):
     import zfit
     import zfit.z.numpy as znp
+
+    plot_folder = pathlib.Path(
+        f"{'exact' if exact_nsample else 'binomial_sum'}_yield_sampling"
+    )
 
     # create space
     obs = zfit.Space("x", limits=(-10, 10))
@@ -99,9 +104,9 @@ def test_yield_bias(exact_nsample, ntoys=100):
 
     plt.figure("yield_bias_toys")
     plt.title(
-        f'{"Exact" if exact_nsample else "Binomial sum"} sampled. Fit with {minimizer.name}. Signal yield: {nsigs_mean :.2f} +- {std_nsigs_mean:.2f}'
+        f'{"Exact" if exact_nsample else "Binomial sum"} sampled. Fit with {minimizer.name}.'
     )
-    counts, edges, _ = plt.hist(nsigs, bins=50, label="nsig", alpha=0.5)
+    counts, edges, _ = plt.hist(nsigs, bins=50, label=f" Signal yields", alpha=0.5)
     npoints = 50
     plt.plot(
         np.ones(npoints) * true_nsig, np.linspace(0, np.max(counts)), "gx", label="true"
@@ -110,7 +115,7 @@ def test_yield_bias(exact_nsample, ntoys=100):
         np.ones(npoints) * nsigs_mean,
         np.linspace(0, np.max(counts) * 2 / 3),
         "bo",
-        label="mean",
+        label=f"Signal mean: {nsigs_mean :.2f} +- {std_nsigs_mean:.2f}",
     )
 
     plt.plot(
@@ -126,7 +131,7 @@ def test_yield_bias(exact_nsample, ntoys=100):
         label="+std",
     )
     plt.legend()
-    pytest.zfit_savefig()
+    pytest.zfit_savefig(folder=plot_folder)
 
     rel_err_sig = 5 / true_nsig**0.5 / ntoys**0.5
     assert nsigs_mean == pytest.approx(true_nsig, rel=rel_err_sig)

--- a/tests/test_binnedloss.py
+++ b/tests/test_binnedloss.py
@@ -158,6 +158,12 @@ def test_binned_loss(weights, Loss, simultaneous):
     obs_binned = obs.with_binning(binning)
     test_values_binned = test_values.to_binned(obs_binned)
     binned_gauss = zfit.pdf.BinnedFromUnbinnedPDF(gaussian1, obs_binned, extended=scale)
+    binned_gauss_alt = gaussian2.to_binned(obs_binned, extended=scale)
+    counts = binned_gauss.counts()
+    counts_alt = binned_gauss_alt.counts()
+    assert np.allclose(counts, counts_alt)
+    binned_gauss_closure = binned_gauss.to_binned(obs_binned)
+    assert np.allclose(counts, binned_gauss_closure.counts())
     if simultaneous:
         obs_binned2 = obs.with_binning(14)
         test_values_binned2 = test_values.to_binned(obs_binned2)

--- a/tests/test_binnedpdf.py
+++ b/tests/test_binnedpdf.py
@@ -5,7 +5,7 @@ import hist
 import mplhep
 import numpy as np
 import pytest
-import tqdm
+
 from matplotlib import pyplot as plt
 
 import zfit.pdf

--- a/tests/test_binnedpdf.py
+++ b/tests/test_binnedpdf.py
@@ -94,7 +94,12 @@ def test_unbinned_from_binned_from_unbinned():
     pytest.zfit_savefig()
 
     unbinned = zfit.pdf.UnbinnedFromBinnedPDF(gauss_binned, obs=obs)
+    unbinned2 = gauss_binned.to_unbinned()
     y = unbinned.ext_pdf(x)
+    y2 = unbinned2.ext_pdf(x)
+    assert np.allclose(y, y2)
+    y3 = unbinned.to_unbinned().ext_pdf(x)
+    assert np.allclose(y, y3)
     y_true = gauss.ext_pdf(x)
     plt.figure()
     plt.title("Comparison of unbinned gauss to binned to unbinned again")
@@ -350,7 +355,7 @@ def test_binned_sampler(ndim):
         gauss = create_gauss_binned(n=100000, nbins=dims[0])
         gauss = gauss[1]
     elif ndim == 2:
-        dims = (nbins, 5)
+        dims = (nbins, 57)
         gauss = create_gauss2d_binned(n=100000, nbins=dims)
         obs2d = gauss[3]
         gauss = gauss[1]

--- a/tests/test_binnedpdf.py
+++ b/tests/test_binnedpdf.py
@@ -337,8 +337,8 @@ def test_binned_from_unbinned_2D():
 @pytest.mark.parametrize(
     "ndim",
     [
-        # 1,
-        # 2,
+        1,
+        2,
         3,
     ],
     ids=lambda x: f"{x}D",
@@ -364,12 +364,12 @@ def test_binned_sampler(ndim):
         gauss = np.random.normal(
             loc=[0.5, 1.5, 3.6], scale=[1.2, 2.1, 0.4], size=(100000, ndim)
         )
+
         data = zfit.data.Data.from_numpy(obs=obs, array=gauss).to_binned(dims)
         gauss = zfit.pdf.HistogramPDF(data=data, extended=True)
     else:
         raise ValueError("ndim must be 1 or 2")
-    nsampled = 10000
-    gauss = gauss[1]
+    nsampled = 100000
     sample = gauss.sample(n=nsampled)
     sampler = gauss.create_sampler(n=nsampled)
 
@@ -394,8 +394,8 @@ def test_binned_sampler(ndim):
         sampler_swapped.resample(n=nsampled * 3)
         assert np.sum(sampler_swapped.values()) == pytest.approx(nsampled * 3)
 
-    # TODO: extremely slow, why? integrals in multiple dimensions?
-    start = time.time()
-    for _ in tqdm.tqdm(range(1000)):
-        sampler.resample(n=nsampled)
-    print(f"Time taken {(time.time() - start) / 1000}")
+    sampler.resample(n=nsampled)
+    # start = time.time()
+    # for _ in tqdm.tqdm(range(15)):
+    #     sampler.resample(n=nsampled)
+    # print(f"Time taken {(time.time() - start)}")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -387,14 +387,14 @@ def test_data_hashing(space2d):
     assert oldhashint != testhashpdf.lasthash
     assert data1.hashint == testhashpdf.lasthash
 
-    zfit.run.set_graph_mode(
+    with zfit.run.set_graph_mode(
         True
-    )  # meaning integration is now done in graph and has "None"
-    oldhashint = data1.hashint
-    data1.set_weights(np.random.uniform(size=data1.nevents))
-    testhashpdf.pdf(data1)
-    assert oldhashint != testhashpdf.lasthash
-    assert None == testhashpdf.lasthash
+    ):  # meaning integration is now done in graph and has "None"
+        oldhashint = data1.hashint
+        data1.set_weights(np.random.uniform(size=data1.nevents))
+        testhashpdf.pdf(data1)
+        assert oldhashint != testhashpdf.lasthash
+        assert None == testhashpdf.lasthash
 
 
 def test_hashing_resample(space2d):

--- a/tests/test_fitresult.py
+++ b/tests/test_fitresult.py
@@ -151,7 +151,9 @@ if not platform.system() in (
 minimizers = sorted(minimizers, key=lambda val: repr(val))
 
 
-@pytest.mark.parametrize("minimizer_class_and_kwargs", minimizers)
+@pytest.mark.parametrize(
+    "minimizer_class_and_kwargs", minimizers, ids=lambda val: val[0].__name__
+)
 def test_freeze(minimizer_class_and_kwargs):
     result = create_fitresult(minimizer_class_and_kwargs)["result"]
 

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -429,10 +429,8 @@ error_scales = {None: 1, 1: 1, 2: 2}
 )
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.timeout(280)
-def test_minimizers(
-    minimizer_class_and_kwargs, chunksize, numgrad, spaces, pytestconfig
-):
-    long_clarg = pytestconfig.getoption("longtests")
+def test_minimizers(minimizer_class_and_kwargs, chunksize, numgrad, spaces, request):
+    long_clarg = request.config.getoption("--longtests")
     # long_clarg = True
     # zfit.run.chunking.active = True
     # zfit.run.chunking.max_n_points = chunksize

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -350,9 +350,6 @@ def test_importance_sampling_uniform():
 
     assert np.std(bin_counts) < np.sqrt(expected_per_bin) * 2
     assert all(abs(bin_counts - expected_per_bin) < np.sqrt(expected_per_bin) * 5)
-    # import matplotlib.pyplot as plt
-    # plt.hist(sample_np, bins=40)
-    # plt.show()
 
 
 # @pytest.mark.xfail  # TODO(mayou36): hacked, EventSpace, needed for phasespace sampling

--- a/utils/api/argdocs.yaml
+++ b/utils/api/argdocs.yaml
@@ -483,7 +483,9 @@ loss.init.explain.negativelog: |1+
 
 loss.init.explain.spdtransform: |1+
     A scaled Poisson distribution is
-         used as described by Bohm and Zech, NIMA 748 (2014) 1-6
+         used as described by Bohm and Zech, NIMA 748 (2014) 1-6 if the variance
+         of the data is not ``None``. The scaling is forced to be >= 1 in order
+         to avoid issues with empty bins.
 
 loss.init.explain.weightednll: |1+
     If the dataset has weights, a weighted likelihood will be constructed instead

--- a/zfit/_data/binneddatav1.py
+++ b/zfit/_data/binneddatav1.py
@@ -1,11 +1,14 @@
 #  Copyright (c) 2022 zfit
 
-from collections.abc import Mapping
 from collections.abc import Callable
+from collections.abc import Mapping
 
 #  Copyright (c) 2022 zfit
 
 from __future__ import annotations
+
+#  Copyright (c) 2022 zfit
+
 
 from typing import TYPE_CHECKING
 

--- a/zfit/_data/binneddatav1.py
+++ b/zfit/_data/binneddatav1.py
@@ -240,6 +240,10 @@ class BinnedData(
         return znp.sum(self.values())
 
     @property
+    def n_events(self):  # LEGACY, what should be the name?
+        return self.nevents
+
+    @property
     def _approx_nevents(self):
         return znp.sum(self.values())
 

--- a/zfit/_data/binneddatav1.py
+++ b/zfit/_data/binneddatav1.py
@@ -405,7 +405,12 @@ class BinnedSampler(BinnedData):
             self._initial_resampled = True
 
     def with_obs(self, obs: ztyping.ObsTypeInput) -> BinnedSampler:
-        """"""
+        """Create a new :py:class:`~zfit.core.data.BinnedSampler` with the same sample but different ordered
+        observables.
+
+        Args:
+            obs: The new observables
+        """
         from ..core.space import convert_to_space
 
         obs = convert_to_space(obs)

--- a/zfit/_data/binneddatav1.py
+++ b/zfit/_data/binneddatav1.py
@@ -327,14 +327,6 @@ class BinnedSampler(BinnedData):
             nevents = self.n
         return nevents
 
-    # def _value_internal(self, obs: ztyping.ObsTypeInput = None, filter: bool = True):
-    #     if not self._initial_resampled:
-    #         raise RuntimeError(
-    #             "No data generated yet. Use `resample()` to generate samples or directly use `model.sample()`"
-    #             "for single-time sampling."
-    #         )
-    #     return super()._value_internal(obs=obs, filter=filter)
-
     @property
     def hashint(self) -> int | None:
         return None  # since the variable can be changed but this may stays static... and using 128 bits we can't have
@@ -408,19 +400,7 @@ class BinnedSampler(BinnedData):
             list(temp_param_values.keys()), list(temp_param_values.values())
         ):
 
-            # if not (n and self._initial_resampled):  # we want to load and make sure that it's initialized
-            #     # means it's handled inside the function
-            #     # TODO(Mayou36): check logic; what if new_samples loaded? get's overwritten by initializer
-            #     # fixed with self.n, needs cleanup
-            #     if not (isinstance(self.n_samples, str) or self.n_samples is None):
-            #         self.sess.run(self.n_samples.initializer)
-            # if n:
-            #     if not isinstance(self.n_samples, tf.Variable):
-            #         raise RuntimeError("Cannot set a new `n` if not a Tensor-like object was given")
-            # self.n_samples.assign(n)
-
             new_sample = self.sample_func(n)
-            # self.sample_holder.assign(new_sample)
             self.sample_holder.assign(new_sample, read_value=False)
             self._initial_resampled = True
 

--- a/zfit/_data/binneddatav1.py
+++ b/zfit/_data/binneddatav1.py
@@ -1,16 +1,11 @@
 #  Copyright (c) 2022 zfit
 
-from collections.abc import Callable
-from collections.abc import Mapping
-
-#  Copyright (c) 2022 zfit
-
 from __future__ import annotations
 
-#  Copyright (c) 2022 zfit
-
-
 from typing import TYPE_CHECKING
+
+from collections.abc import Callable
+from collections.abc import Mapping
 
 from ..core.parameter import set_values
 

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -1144,6 +1144,8 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
             raise TypeError("`Fixed_params` has to be a list, tuple or a boolean.")
 
         def sample_func(n=n):
+            if n is not None:
+                n = znp.array(n)
             return self._create_sampler_tensor(limits=limits, n=n)
 
         sample_data = Sampler.from_sample(
@@ -1156,7 +1158,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
 
         return sample_data
 
-    @z.function(wraps="model")
+    @z.function(wraps="sampler")
     def _create_sampler_tensor(self, limits, n):
 
         sample = self._single_hook_sample(n=n, limits=limits, x=None)
@@ -1206,7 +1208,6 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
                 )
         limits = self._check_input_limits(limits=limits, none_is_error=True)
 
-        @z.function(wraps="model_sampling")
         def run_tf(n, limits, x):
             sample = self._single_hook_sample(n=n, limits=limits, x=x)
             return sample
@@ -1222,6 +1223,7 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
 
         return sample_data
 
+    @z.function(wraps="sample")
     def _single_hook_sample(self, n, limits, x=None):
         del x
         return self._hook_sample(n=n, limits=limits)

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -799,3 +799,15 @@ class BasePDF(ZfitPDF, BaseModel):
                 dtype=self.dtype.name,
             )
         )
+
+    def to_unbinned(self):
+        """Convert to unbinned pdf, returns self if already unbinned."""
+        return self
+
+    def to_binned(self, space, *, extended=None, norm=None):
+        """Convert to binned pdf, returns self if already binned."""
+        from ..models.tobinned import BinnedFromUnbinnedPDF
+
+        return BinnedFromUnbinnedPDF(
+            pdf=self, space=space, extended=extended, norm=norm
+        )

--- a/zfit/core/binnedpdf.py
+++ b/zfit/core/binnedpdf.py
@@ -34,6 +34,7 @@ from .interfaces import (
     ZfitPDF,
     ZfitBinnedData,
     ZfitUnbinnedData,
+    ZfitBinning,
 )
 from .parameter import convert_to_parameter
 from .space import supports, convert_to_space
@@ -927,6 +928,33 @@ class BaseBinnedPDFV1(
 
     def set_norm_range(self):
         raise RuntimeError("set_norm_range is removed and should not be used anymore.")
+
+    def to_binned(self, space, *, extended=None, norm=None):
+        """Convert the PDF to a binned PDF."""
+        if isinstance(space, ZfitBinning):
+            if space != self.space.binning:
+                raise ValueError(
+                    "The binning of the PDF and the binning of the space must be equal."
+                )
+        if space != self.space:
+            raise ValueError(
+                f"Space must be the same as the PDF's space, as {self} is already a binned PDF."
+            )
+        if extended is not None:
+            raise WorkInProgressError(
+                "extended is not implemented yet. Create an extended PDF manually."
+            )
+        if norm is not None:
+            raise WorkInProgressError(
+                "norm is not implemented yet. Create a pdf with a different norm range manually."
+            )
+        return self
+
+    def to_unbinned(self):
+        """Convert the PDF to an unbinned PDF."""
+        from zfit.models.unbinnedpdf import UnbinnedFromBinnedPDF
+
+        return UnbinnedFromBinnedPDF(self, self.space.with_binning(None))
 
 
 def binned_rect_integration(

--- a/zfit/core/binnedpdf.py
+++ b/zfit/core/binnedpdf.py
@@ -253,7 +253,7 @@ class BaseBinnedPDFV1(
                 raise ValueError("norm cannot be None for this function.")
         elif norm is not False and not isinstance(norm, ZfitSpace):
             raise TypeError(f"`norm` needs to be a binned ZfitSpace, not {norm}.")
-        elif not norm.is_binned:
+        elif norm is not False and not norm.is_binned:
             norm = norm.with_binning(self.space.binning)
         return norm
 

--- a/zfit/core/binnedpdf.py
+++ b/zfit/core/binnedpdf.py
@@ -609,7 +609,9 @@ class BaseBinnedPDFV1(
             raise TypeError("`Fixed_params` has to be a list, tuple or a boolean.")
 
         def sample_func(n=n):
-            return self._create_sampler_tensor(limits=limits, n=n)
+            n = znp.array(n)
+            sample = self._create_sampler_tensor(limits=limits, n=n)
+            return sample
 
         sample_data = BinnedSampler.from_sample(
             sample_func=sample_func,
@@ -621,7 +623,7 @@ class BaseBinnedPDFV1(
 
         return sample_data
 
-    @z.function(wraps="model")
+    @z.function(wraps="sampler")
     def _create_sampler_tensor(self, limits, n):
         sample = self._call_sample(n=n, limits=limits)
         return sample
@@ -657,7 +659,7 @@ class BaseBinnedPDFV1(
             values = values.with_obs(original_limits)
         return values
 
-    @z.function(wraps="model")
+    @z.function(wraps="sample")
     def _call_sample(self, n, limits):
         with suppress(SpecificFunctionNotImplemented):
             self._sample(n, limits)

--- a/zfit/core/binning.py
+++ b/zfit/core/binning.py
@@ -8,7 +8,7 @@ import tensorflow_probability as tfp
 
 import zfit.z.numpy as znp
 from zfit import z
-from zfit.core.interfaces import ZfitData, ZfitRectBinning
+from zfit.core.interfaces import ZfitData, ZfitRectBinning, ZfitSpace
 from zfit.util.ztyping import XTypeInput
 
 
@@ -69,6 +69,16 @@ def unbinned_to_binned(data, space, binned_class=None):
         from zfit._data.binneddatav1 import BinnedData
 
         binned_class = BinnedData
+    if not isinstance(space, ZfitSpace):
+        try:
+            space = data.space.with_binning(space)
+        except Exception as error:
+            raise ValueError(
+                f"The space provided is not a valid space for the data. "
+                f"Either provide a valid space or a binning. "
+                f"The error was: {error}"
+            ) from error
+
     values = data.value()
     weights = data.weights
     if weights is not None:

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Union
 import xxhash
 from tensorflow.python.util.deprecation import deprecated_args, deprecated
 
+from .parameter import set_values
+
 if TYPE_CHECKING:
     import zfit
 
@@ -801,12 +803,9 @@ class Sampler(Data):
         if param_values is not None:
             temp_param_values.update(param_values)
 
-        with ExitStack() as stack:
-
-            _ = [
-                stack.enter_context(param.set_value(val))
-                for param, val in temp_param_values.items()
-            ]
+        with set_values(
+            list(temp_param_values.keys()), list(temp_param_values.values())
+        ):
 
             # if not (n and self._initial_resampled):  # we want to load and make sure that it's initialized
             #     # means it's handled inside the function

--- a/zfit/core/interfaces.py
+++ b/zfit/core/interfaces.py
@@ -566,6 +566,17 @@ class ZfitSpace(ZfitLimit, ZfitOrderableDimensional, ZfitObject, metaclass=ABCMe
         """
         raise NotImplementedError
 
+    def with_binning(self, binning: ztyping.BinningTypeInput) -> ZfitSpace:
+        """Return a copy of the space with the new ``binning``.
+
+        Args:
+            binning: Binning to use.
+
+        Returns:
+            Copy of the current object with the new binning.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def get_subspace(self, obs, axes, name):
         """Create a :py:class:`~zfit.Space` consisting of only a subset of the `obs`/`axes` (only one allowed).

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -452,7 +452,6 @@ class BaseLoss(ZfitLoss, BaseNumeric):
         # value = value_substracted[0] - value_substracted[1]
 
     def _value(self, model, data, fit_range, constraints, log_offset):
-        # try:
         return self._loss_func(
             model=model,
             data=data,
@@ -460,9 +459,6 @@ class BaseLoss(ZfitLoss, BaseNumeric):
             constraints=constraints,
             log_offset=log_offset,
         )
-
-    # except NotImplementedError as error:
-    #     raise NotImplementedError(f"_loss_func not properly defined! error {error}") from error
 
     def __add__(self, other):
         if not isinstance(other, BaseLoss):

--- a/zfit/models/convolution.py
+++ b/zfit/models/convolution.py
@@ -240,7 +240,7 @@ class FFTConvPDFV1(BaseFunctor):
             "nbins_func": nbins_func,
         }
 
-    @z.function(wraps="model")
+    @z.function(wraps="model_convolution")
     def _unnormalized_pdf(self, x):
 
         lower_func, upper_func = self._conv_limits["func"]

--- a/zfit/models/tobinned.py
+++ b/zfit/models/tobinned.py
@@ -47,6 +47,13 @@ class BinnedFromUnbinnedPDF(BaseBinnedFunctorPDF):
                 )
             else:
                 extended = pdf.get_yield()
+        if not isinstance(space, ZfitSpace):
+            try:
+                space = pdf.space.with_binning(space)
+            except Exception as error:
+                raise ValueError(
+                    f"Could not create space {space} from pdf {pdf} with binning {space}"
+                ) from error
         super().__init__(
             obs=space,
             extended=extended,

--- a/zfit/util/cache.py
+++ b/zfit/util/cache.py
@@ -197,7 +197,6 @@ def invalidate_graph(func):
 
 class FunctionCacheHolder(GraphCachable):
     IS_TENSOR = object()
-    _debug_all_caches = weakref.WeakSet()
 
     def __init__(
         self,
@@ -240,7 +239,7 @@ class FunctionCacheHolder(GraphCachable):
         if stateless_args is None:
             stateless_args = False
         self.stateless_args = stateless_args
-        self.wrapped_func = wrapped_func
+        self.wrapped_func = weakref.proxy(wrapped_func, deleter)
 
         self.python_func = func
 
@@ -265,7 +264,6 @@ class FunctionCacheHolder(GraphCachable):
         super().__init__()  # resets the cache
         self.add_cache_deps(cachables_all)
         self.is_valid = True  # needed to make the cache valid again
-        self._debug_all_caches.add(self)
         self.deleter = deleter
 
     def reset_cache_self(self):

--- a/zfit/util/cache.py
+++ b/zfit/util/cache.py
@@ -60,6 +60,7 @@ from typing import Optional
 
 import numpy as np
 import tensorflow as tf
+import uhi.typing.plottable
 
 from . import ztyping
 from .container import convert_to_container
@@ -315,6 +316,7 @@ class FunctionCacheHolder(GraphCachable):
                 ZfitPDF,
                 ZfitLimit,
                 ZfitSpace,
+                uhi.typing.plottable.PlottableHistogram,
             ),
         ):
             obj = id(obj)

--- a/zfit/z/random.py
+++ b/zfit/z/random.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 from functools import wraps
 from typing import Any
 
+import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 

--- a/zfit/z/zextension.py
+++ b/zfit/z/zextension.py
@@ -7,7 +7,7 @@ import functools
 import collections
 import logging
 import warnings
-from weakref import WeakSet
+from weakref import WeakSet, WeakKeyDictionary
 import math as _mt
 from collections import defaultdict
 from collections.abc import Callable
@@ -160,9 +160,8 @@ def run_no_nan(func, x):
 
 class FunctionWrapperRegistry:
     registries = WeakSet()
-    _debug_all_tf_functions = WeakSet()
     allow_jit = True
-    DEFAULT_CACHE_SIZE = 10
+    DEFAULT_CACHE_SIZE = 20
     _DEFAULT_DO_JIT_TYPES = defaultdict(lambda: True)
     _DEFAULT_DO_JIT_TYPES.update(
         {
@@ -253,7 +252,7 @@ class FunctionWrapperRegistry:
             self.currently_traced.add(func)
             nonlocal wrapped_func
 
-            def deleter(function_holder):
+            def deleter(proxy):
                 with contextlib.suppress(ValueError):
                     cache.remove(function_holder)
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

- implement create_sampler for the binned pdf

## Tests added

- Testing of sampler vs normal sample
- test fit of unbinned fit vs binned fit

## Checklist

- [x] change approved
- [x] implementation finished
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
