### PR TITLE
Fix pip install on arm64 macs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ pandas
 pydantic
 scipy>=1.2
 tabulate
-tensorflow>=2.10, <2.12
+tensorflow>=2.10, <2.12; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos>=2.10, <2.12; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow-addons
 tensorflow_probability>=0.18, <0.20
 texttable

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,8 @@ pydantic
 scipy>=1.2
 tabulate
 tensorflow>=2.10, <2.12; sys_platform != 'darwin' or platform_machine != 'arm64'
-tensorflow-macos>=2.10, <2.12; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow-addons
+tensorflow-macos>=2.10, <2.12; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow_probability>=0.18, <0.20
 texttable
 tf_quant_finance>=v0.0.1-dev24


### PR DESCRIPTION
Currently on macos with Apple Sillicon (I don't know if it's the same with x86 macs), zfit is uninstallable via pip just because tensorflow isn't available as "tensorflow" on pypi but as "tensorflow-macos".

```
iason@quiet:~$ virtualenv test --python=3.10
created virtual environment CPython3.10.10.final.0-64 in 182ms
  creator CPython3Posix(dest=/Users/iason/test, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/Users/iason/Library/Application Support/virtualenv)
    added seed packages: pip==23.0.1, setuptools==67.1.0, wheel==0.38.4
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
iason@quiet:~$ source test/bin/activate
(test) iason@quiet:~$ pip install zfit
Collecting zfit
  Downloading zfit-0.11.1-py2.py3-none-any.whl (424 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 424.2/424.2 kB 7.6 MB/s eta 0:00:00
Collecting colorama
  Downloading colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting colored
  Downloading colored-1.4.4.tar.gz (36 kB)
  Preparing metadata (setup.py) ... done
Collecting boost-histogram
  Downloading boost_histogram-1.3.2-cp310-cp310-macosx_10_9_universal2.whl (3.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.0/3.0 MB 8.0 MB/s eta 0:00:00
Collecting iminuit>=2.3
  Downloading iminuit-2.20.0-cp310-cp310-macosx_10_9_universal2.whl (630 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 630.2/630.2 kB 8.5 MB/s eta 0:00:00
Collecting pandas
  Downloading pandas-1.5.3-cp310-cp310-macosx_11_0_arm64.whl (10.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.9/10.9 MB 10.2 MB/s eta 0:00:00
Collecting deprecated
  Downloading Deprecated-1.2.13-py2.py3-none-any.whl (9.6 kB)
Collecting texttable
  Downloading texttable-1.6.7-py2.py3-none-any.whl (10 kB)
Collecting uproot<5,>=4
  Downloading uproot-4.3.7-py3-none-any.whl (302 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 302.7/302.7 kB 9.6 MB/s eta 0:00:00
Collecting zfit
  Downloading zfit-0.10.1-py2.py3-none-any.whl (419 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 419.7/419.7 kB 9.3 MB/s eta 0:00:00
  Downloading zfit-0.10.0-py2.py3-none-any.whl (410 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 410.5/410.5 kB 9.0 MB/s eta 0:00:00
Collecting numdifftools
  Downloading numdifftools-0.9.41-py2.py3-none-any.whl (100 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.2/100.2 kB 6.3 MB/s eta 0:00:00
Collecting xxhash
  Downloading xxhash-3.2.0-cp310-cp310-macosx_11_0_arm64.whl (31 kB)
Collecting tensorflow-probability<0.18,>=0.17
  Downloading tensorflow_probability-0.17.0-py2.py3-none-any.whl (6.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.5/6.5 MB 10.1 MB/s eta 0:00:00
Collecting tabulate
  Downloading tabulate-0.9.0-py3-none-any.whl (35 kB)
Collecting tf-quant-finance>=v0.0.1-dev24
  Downloading tf_quant_finance-0.0.1.dev34-py2.py3-none-any.whl (1.4 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.4/1.4 MB 5.6 MB/s eta 0:00:00
Collecting dotmap
  Downloading dotmap-1.3.30-py3-none-any.whl (11 kB)
Collecting scipy>=1.2
  Downloading scipy-1.10.1-cp310-cp310-macosx_12_0_arm64.whl (28.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 28.8/28.8 MB 10.1 MB/s eta 0:00:00
Collecting zfit
  Downloading zfit-0.5.6-py2.py3-none-any.whl (264 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 264.9/264.9 kB 7.6 MB/s eta 0:00:00
Collecting tensorflow-addons
  Downloading tensorflow_addons-0.19.0-cp310-cp310-macosx_11_0_arm64.whl (11.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 11.1/11.1 MB 10.4 MB/s eta 0:00:00
Collecting zfit
  Downloading zfit-0.5.5-py2.py3-none-any.whl (263 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 263.9/263.9 kB 8.0 MB/s eta 0:00:00
  Downloading zfit-0.5.4-py2.py3-none-any.whl (253 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 253.5/253.5 kB 9.6 MB/s eta 0:00:00
Collecting ordered-set
  Downloading ordered_set-4.1.0-py3-none-any.whl (7.6 kB)
Collecting uproot
  Downloading uproot-5.0.4-py3-none-any.whl (329 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 329.3/329.3 kB 9.1 MB/s eta 0:00:00
Collecting zfit
  Downloading zfit-0.5.3-py2.py3-none-any.whl (253 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 253.6/253.6 kB 8.7 MB/s eta 0:00:00
  Downloading zfit-0.5.2-py2.py3-none-any.whl (195 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 195.5/195.5 kB 7.8 MB/s eta 0:00:00
  Downloading zfit-0.4.2-py2.py3-none-any.whl (149 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 149.6/149.6 kB 9.4 MB/s eta 0:00:00
Collecting tensorflow-probability>=0.8
  Downloading tensorflow_probability-0.19.0-py2.py3-none-any.whl (6.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.7/6.7 MB 10.0 MB/s eta 0:00:00
Collecting zfit
  Downloading zfit-0.4.1-py2.py3-none-any.whl (147 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 147.4/147.4 kB 7.1 MB/s eta 0:00:00
  Downloading zfit-0.4.0-py2.py3-none-any.whl (147 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 147.2/147.2 kB 7.6 MB/s eta 0:00:00
  Downloading zfit-0.3.7-py2.py3-none-any.whl (140 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 140.3/140.3 kB 8.9 MB/s eta 0:00:00
  Downloading zfit-0.3.6-py2.py3-none-any.whl (139 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 139.7/139.7 kB 6.3 MB/s eta 0:00:00
  Downloading zfit-0.3.5-py2.py3-none-any.whl (137 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 137.4/137.4 kB 7.4 MB/s eta 0:00:00
  Downloading zfit-0.3.3-py2.py3-none-any.whl (128 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 128.5/128.5 kB 7.3 MB/s eta 0:00:00
  Downloading zfit-0.3.2-py2.py3-none-any.whl (127 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 127.9/127.9 kB 4.6 MB/s eta 0:00:00
  Downloading zfit-0.3.1-py2.py3-none-any.whl (120 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 120.0/120.0 kB 7.1 MB/s eta 0:00:00
  Downloading zfit-0.3.0-py2.py3-none-any.whl (118 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 118.8/118.8 kB 7.4 MB/s eta 0:00:00
Collecting pep487
  Downloading pep487-1.0.1-py2.py3-none-any.whl (5.5 kB)
Collecting colorlog
  Downloading colorlog-6.7.0-py2.py3-none-any.whl (11 kB)
Collecting zfit
  Downloading zfit-0.2.3-py2.py3-none-any.whl (116 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 116.2/116.2 kB 7.8 MB/s eta 0:00:00
  Downloading zfit-0.2.0-py2.py3-none-any.whl (116 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 116.2/116.2 kB 7.6 MB/s eta 0:00:00
ERROR: Cannot install zfit==0.10.0, zfit==0.10.1, zfit==0.11.1, zfit==0.2.0, zfit==0.2.3, zfit==0.3.0, zfit==0.3.1, zfit==0.3.2, zfit==0.3.3, zfit==0.3.5, zfit==0.3.6, zfit==0.3.7, zfit==0.4.0, zfit==0.4.1, zfit==0.4.2, zfit==0.5.2, zfit==0.5.3, zfit==0.5.4, zfit==0.5.5 and zfit==0.5.6 because these package versions have conflicting dependencies.

The conflict is caused by:
    zfit 0.11.1 depends on tensorflow<2.12 and >=2.10
    zfit 0.10.1 depends on tensorflow<2.11 and >=2.9
    zfit 0.10.0 depends on tensorflow<2.10 and >=2.9
    zfit 0.5.6 depends on tensorflow<2.4 and >=2.3.1
    zfit 0.5.5 depends on tensorflow<2.4 and >=2.3.1
    zfit 0.5.4 depends on tensorflow==2.2
    zfit 0.5.3 depends on tensorflow==2.2
    zfit 0.5.2 depends on tensorflow>=2.2
    zfit 0.4.2 depends on tensorflow>=2
    zfit 0.4.1 depends on tensorflow>=2
    zfit 0.4.0 depends on tensorflow>=2
    zfit 0.3.7 depends on tensorflow<2 and >=1.14.0
    zfit 0.3.6 depends on tensorflow<2 and >=1.14.0
    zfit 0.3.5 depends on tensorflow<2.0.0 and >=1.10.0
    zfit 0.3.3 depends on tensorflow<2.0.0 and >=1.10.0
    zfit 0.3.2 depends on tensorflow<2.0.0 and >=1.10.0
    zfit 0.3.1 depends on tensorflow<2.0.0 and >=1.10.0
    zfit 0.3.0 depends on tensorflow>=1.10.0
    zfit 0.2.3 depends on tensorflow>=1.10.0
    zfit 0.2.0 depends on tensorflow>=1.10.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```
After the minor change in requirements.txt:

```
(test) iason@quiet:~/zfit_pr/zfit$ pip install .
Processing /Users/iason/zfit_pr/zfit
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting tensorflow-probability<0.20,>=0.18
  Using cached tensorflow_probability-0.19.0-py2.py3-none-any.whl (6.7 MB)
Collecting deprecated
  Using cached Deprecated-1.2.13-py2.py3-none-any.whl (9.6 kB)
Collecting numdifftools
  Using cached numdifftools-0.9.41-py2.py3-none-any.whl (100 kB)
Collecting tf-quant-finance>=v0.0.1-dev24
  Using cached tf_quant_finance-0.0.1.dev34-py2.py3-none-any.whl (1.4 MB)
Collecting ordered-set
  Using cached ordered_set-4.1.0-py3-none-any.whl (7.6 kB)
Collecting uproot<5,>=4
  Using cached uproot-4.3.7-py3-none-any.whl (302 kB)
Collecting zfit-interface
  Using cached zfit_interface-0.0.3-py2.py3-none-any.whl (11 kB)
Collecting iminuit>=2.3
  Using cached iminuit-2.20.0-cp310-cp310-macosx_10_9_universal2.whl (630 kB)
Collecting hist
  Using cached hist-2.6.3-py3-none-any.whl (36 kB)
Collecting uhi
  Using cached uhi-0.3.3-py3-none-any.whl (11 kB)
Collecting dotmap
  Using cached dotmap-1.3.30-py3-none-any.whl (11 kB)
Collecting pandas
  Using cached pandas-1.5.3-cp310-cp310-macosx_11_0_arm64.whl (10.9 MB)
Collecting scipy>=1.2
  Using cached scipy-1.10.1-cp310-cp310-macosx_12_0_arm64.whl (28.8 MB)
Collecting pydantic
  Using cached pydantic-1.10.5-cp310-cp310-macosx_11_0_arm64.whl (2.5 MB)
Collecting boost-histogram
  Using cached boost_histogram-1.3.2-cp310-cp310-macosx_10_9_universal2.whl (3.0 MB)
Collecting texttable
  Using cached texttable-1.6.7-py2.py3-none-any.whl (10 kB)
Collecting xxhash
  Using cached xxhash-3.2.0-cp310-cp310-macosx_11_0_arm64.whl (31 kB)
Collecting tensorflow-macos<2.12,>=2.10
  Using cached tensorflow_macos-2.11.0-cp310-cp310-macosx_12_0_arm64.whl (215.6 MB)
Collecting tensorflow-addons
  Using cached tensorflow_addons-0.19.0-cp310-cp310-macosx_11_0_arm64.whl (11.1 MB)
Collecting colorama
  Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting numpy>=1.16
  Using cached numpy-1.24.2-cp310-cp310-macosx_11_0_arm64.whl (13.9 MB)
Collecting colorlog
  Using cached colorlog-6.7.0-py2.py3-none-any.whl (11 kB)
Collecting tabulate
  Using cached tabulate-0.9.0-py3-none-any.whl (35 kB)
Collecting colored
  Using cached colored-1.4.4-py3-none-any.whl
Collecting jacobi
  Using cached jacobi-0.8.1-py3-none-any.whl (10 kB)
Collecting google-pasta>=0.1.1
  Using cached google_pasta-0.2.0-py3-none-any.whl (57 kB)
Collecting protobuf<3.20,>=3.9.2
  Using cached protobuf-3.19.6-py2.py3-none-any.whl (162 kB)
Collecting six>=1.12.0
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting flatbuffers>=2.0
  Using cached flatbuffers-23.1.21-py2.py3-none-any.whl (26 kB)
Collecting keras<2.12,>=2.11.0
  Using cached keras-2.11.0-py2.py3-none-any.whl (1.7 MB)
Collecting gast<=0.4.0,>=0.2.1
  Using cached gast-0.4.0-py3-none-any.whl (9.8 kB)
Collecting typing-extensions>=3.6.6
  Using cached typing_extensions-4.5.0-py3-none-any.whl (27 kB)
Collecting termcolor>=1.1.0
  Using cached termcolor-2.2.0-py3-none-any.whl (6.6 kB)
Collecting astunparse>=1.6.0
  Using cached astunparse-1.6.3-py2.py3-none-any.whl (12 kB)
Collecting libclang>=13.0.0
  Using cached libclang-15.0.6.1-py2.py3-none-any.whl
Collecting grpcio<2.0,>=1.24.3
  Using cached grpcio-1.51.3-cp310-cp310-macosx_12_0_universal2.whl (8.2 MB)
Collecting opt-einsum>=2.3.2
  Using cached opt_einsum-3.3.0-py3-none-any.whl (65 kB)
Collecting tensorboard<2.12,>=2.11
  Using cached tensorboard-2.11.2-py3-none-any.whl (6.0 MB)
Collecting tensorflow-estimator<2.12,>=2.11.0
  Using cached tensorflow_estimator-2.11.0-py2.py3-none-any.whl (439 kB)
Collecting h5py>=2.9.0
  Using cached h5py-3.8.0-cp310-cp310-macosx_11_0_arm64.whl (2.6 MB)
Collecting packaging
  Using cached packaging-23.0-py3-none-any.whl (42 kB)
Requirement already satisfied: setuptools in /Users/iason/zfit_pr/test/lib/python3.10/site-packages (from tensorflow-macos<2.12,>=2.10->zfit==0.1.dev3405+g4cfe9d8) (67.1.0)
Collecting absl-py>=1.0.0
  Using cached absl_py-1.4.0-py3-none-any.whl (126 kB)
Collecting wrapt>=1.11.0
  Using cached wrapt-1.15.0-cp310-cp310-macosx_11_0_arm64.whl (36 kB)
Collecting decorator
  Using cached decorator-5.1.1-py3-none-any.whl (9.1 kB)
Collecting dm-tree
  Using cached dm_tree-0.1.8-cp310-cp310-macosx_11_0_arm64.whl (110 kB)
Collecting cloudpickle>=1.3
  Using cached cloudpickle-2.2.1-py3-none-any.whl (25 kB)
Collecting attrs>=18.2.0
  Using cached attrs-22.2.0-py3-none-any.whl (60 kB)
Collecting histoprint>=2.2.0
  Using cached histoprint-2.4.0-py3-none-any.whl (16 kB)
Collecting python-dateutil>=2.8.1
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting pytz>=2020.1
  Using cached pytz-2022.7.1-py2.py3-none-any.whl (499 kB)
Collecting typeguard>=2.7
  Using cached typeguard-2.13.3-py3-none-any.whl (17 kB)
Requirement already satisfied: wheel<1.0,>=0.23.0 in /Users/iason/zfit_pr/test/lib/python3.10/site-packages (from astunparse>=1.6.0->tensorflow-macos<2.12,>=2.10->zfit==0.1.dev3405+g4cfe9d8) (0.38.4)
Collecting click>=7.0.0
  Using cached click-8.1.3-py3-none-any.whl (96 kB)
Collecting google-auth-oauthlib<0.5,>=0.4.1
  Using cached google_auth_oauthlib-0.4.6-py2.py3-none-any.whl (18 kB)
Collecting werkzeug>=1.0.1
  Using cached Werkzeug-2.2.3-py3-none-any.whl (233 kB)
Collecting markdown>=2.6.8
  Using cached Markdown-3.4.1-py3-none-any.whl (93 kB)
Collecting google-auth<3,>=1.6.3
  Using cached google_auth-2.16.2-py2.py3-none-any.whl (177 kB)
Collecting tensorboard-data-server<0.7.0,>=0.6.0
  Using cached tensorboard_data_server-0.6.1-py3-none-any.whl (2.4 kB)
Collecting tensorboard-plugin-wit>=1.6.0
  Using cached tensorboard_plugin_wit-1.8.1-py3-none-any.whl (781 kB)
Collecting requests<3,>=2.21.0
  Using cached requests-2.28.2-py3-none-any.whl (62 kB)
Collecting pyasn1-modules>=0.2.1
  Using cached pyasn1_modules-0.2.8-py2.py3-none-any.whl (155 kB)
Collecting rsa<5,>=3.1.4
  Using cached rsa-4.9-py3-none-any.whl (34 kB)
Collecting cachetools<6.0,>=2.0.0
  Using cached cachetools-5.3.0-py3-none-any.whl (9.3 kB)
Collecting requests-oauthlib>=0.7.0
  Using cached requests_oauthlib-1.3.1-py2.py3-none-any.whl (23 kB)
Collecting certifi>=2017.4.17
  Using cached certifi-2022.12.7-py3-none-any.whl (155 kB)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.14-py2.py3-none-any.whl (140 kB)
Collecting charset-normalizer<4,>=2
  Using cached charset_normalizer-3.0.1-cp310-cp310-macosx_11_0_arm64.whl (122 kB)
Collecting idna<4,>=2.5
  Using cached idna-3.4-py3-none-any.whl (61 kB)
Collecting MarkupSafe>=2.1.1
  Using cached MarkupSafe-2.1.2-cp310-cp310-macosx_10_9_universal2.whl (17 kB)
Collecting pyasn1<0.5.0,>=0.4.6
  Using cached pyasn1-0.4.8-py2.py3-none-any.whl (77 kB)
Collecting oauthlib>=3.0.0
  Using cached oauthlib-3.2.2-py3-none-any.whl (151 kB)
Building wheels for collected packages: zfit
  Building wheel for zfit (pyproject.toml) ... done
  Created wheel for zfit: filename=zfit-0.1.dev3405+g4cfe9d8-py2.py3-none-any.whl size=425291 sha256=87234258848d1498c3e3e7d021781ad92937819483e0bb6b36cabf6e44459624
  Stored in directory: /private/var/folders/2c/94kt72fs0_q_9nzr2y5jphb00000gn/T/pip-ephem-wheel-cache-jrdvlck7/wheels/ba/4b/27/6bd9ce1bb368e22700333fbf4eadd1fedfab1efbb0cef48c55
Successfully built zfit
Installing collected packages: texttable, tensorboard-plugin-wit, pytz, pyasn1, libclang, flatbuffers, dotmap, dm-tree, colored, charset-normalizer, xxhash, wrapt, urllib3, typing-extensions, typeguard, termcolor, tensorflow-estimator, tensorboard-data-server, tabulate, six, rsa, pyasn1-modules, protobuf, packaging, ordered-set, oauthlib, numpy, MarkupSafe, markdown, keras, idna, grpcio, gast, decorator, colorlog, colorama, cloudpickle, click, certifi, cachetools, attrs, absl-py, werkzeug, uproot, uhi, tensorflow-probability, tensorflow-addons, scipy, requests, python-dateutil, pydantic, opt-einsum, jacobi, iminuit, h5py, google-pasta, google-auth, deprecated, boost-histogram, astunparse, zfit-interface, tf-quant-finance, requests-oauthlib, pandas, numdifftools, histoprint, hist, google-auth-oauthlib, tensorboard, tensorflow-macos, zfit
Successfully installed MarkupSafe-2.1.2 absl-py-1.4.0 astunparse-1.6.3 attrs-22.2.0 boost-histogram-1.3.2 cachetools-5.3.0 certifi-2022.12.7 charset-normalizer-3.0.1 click-8.1.3 cloudpickle-2.2.1 colorama-0.4.6 colored-1.4.4 colorlog-6.7.0 decorator-5.1.1 deprecated-1.2.13 dm-tree-0.1.8 dotmap-1.3.30 flatbuffers-23.1.21 gast-0.4.0 google-auth-2.16.2 google-auth-oauthlib-0.4.6 google-pasta-0.2.0 grpcio-1.51.3 h5py-3.8.0 hist-2.6.3 histoprint-2.4.0 idna-3.4 iminuit-2.20.0 jacobi-0.8.1 keras-2.11.0 libclang-15.0.6.1 markdown-3.4.1 numdifftools-0.9.41 numpy-1.24.2 oauthlib-3.2.2 opt-einsum-3.3.0 ordered-set-4.1.0 packaging-23.0 pandas-1.5.3 protobuf-3.19.6 pyasn1-0.4.8 pyasn1-modules-0.2.8 pydantic-1.10.5 python-dateutil-2.8.2 pytz-2022.7.1 requests-2.28.2 requests-oauthlib-1.3.1 rsa-4.9 scipy-1.10.1 six-1.16.0 tabulate-0.9.0 tensorboard-2.11.2 tensorboard-data-server-0.6.1 tensorboard-plugin-wit-1.8.1 tensorflow-addons-0.19.0 tensorflow-estimator-2.11.0 tensorflow-macos-2.11.0 tensorflow-probability-0.19.0 termcolor-2.2.0 texttable-1.6.7 tf-quant-finance-0.0.1.dev34 typeguard-2.13.3 typing-extensions-4.5.0 uhi-0.3.3 uproot-4.3.7 urllib3-1.26.14 werkzeug-2.2.3 wrapt-1.15.0 xxhash-3.2.0 zfit-0.1.dev3405+g4cfe9d8 zfit-interface-0.0.3
```
