### PR TITLE
fix: shape of unstack_x with an obs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Deprecations
 Bug fixes and small changes
 ---------------------------
 - bandwidth preprocessing was ignored in KDE
+- ``unstack_x`` with an ``obs`` as argument did return the wrong shape
 
 Experimental
 ------------

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -376,14 +376,26 @@ def test_data_range(weights_factory):
 
 
 def test_multidim_data_range():
-    data1 = np.linspace((0, 5), (10, 15), num=11)
-    data_true = np.linspace(10, 15, num=6)
+    nevents1 = 11
+    neventstrue1 = 6
+    data1 = np.linspace((0, 5), (10, 15), num=nevents1)
+    data_true = np.linspace(10, 15, num=neventstrue1)
     lower = ((5, 5),)
     upper = ((10, 15),)
     obs1 = "x"
     obs2 = "y"
     data_range = zfit.Space([obs1, obs2], limits=(lower, upper))
     dataset = zfit.Data.from_numpy(array=data1, obs=data_range)
+    xdata = dataset.unstack_x("x")
+    assert tf.is_tensor(xdata)
+    xdatalist = dataset.unstack_x("x", always_list=True)
+    assert len(xdatalist) == 1
+    assert isinstance(xdatalist, list)
+    assert tf.is_tensor(xdatalist[0])
+    yxdata = dataset.unstack_x(["y", "x"])
+    assert len(yxdata) == 2
+    assert tf.is_tensor(yxdata[0])
+    assert xdata.shape == (neventstrue1,)
     assert dataset.nevents.numpy() == 6
     with dataset.sort_by_obs(obs=obs1):
         assert dataset.nevents.numpy() == 6

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -519,12 +519,16 @@ class Data(
         """Return the unstacked data: a list of tensors or a single Tensor.
 
         Args:
-            obs: which observables to return
+            obs: Observables to return. If ``None``, all observables are returned. Can be a subset of the original
+            always_list: If ``True``, always return a list, even if only one observable is requested.
 
         Returns:
             List(tf.Tensor)
         """
-        return z.unstack_x(self.value(obs=obs), always_list=always_list)
+        value = self.value(obs=obs)
+        if len(value.shape) == 1:
+            value = znp.expand_dims(value, -1)  # to make sure we can unstack it again
+        return z.unstack_x(value, always_list=always_list)
 
     def value(self, obs: ztyping.ObsTypeInput = None):
         """Return the data as a numpy-like object in ``obs`` order.

--- a/zfit/z/zextension.py
+++ b/zfit/z/zextension.py
@@ -85,6 +85,11 @@ def unstack_x(
     except AttributeError:
         unstacked_x = tf.unstack(value=value, num=num, axis=axis, name=name)
     if len(unstacked_x) == 1 and not always_list:
+        assert isinstance(unstacked_x, list), (
+            "unstacked_x has to be a list, otherwise this is a bug. Please report on github: "
+            "https://github.com/zfit/zfit/issues/new?assignees=&labels=bug&projects=&template="
+            "bug_report.md&title=[ASSERT]%20unstack_x%20does%20not%20provide%20a%20list,%20internal%20error"
+        )
         unstacked_x = unstacked_x[0]
     return unstacked_x
 


### PR DESCRIPTION


## Proposed Changes

- fix that `unstack_x` inhibits again legacy behavior

## Tests added

- extended testdata

## Checklist

- [x] change approved
- [x] implementation finished
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
