### PR TITLE
cleanup3: remove/deprecate old .numpy and zfit.run

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,11 +67,12 @@ Deprecations
 - ``Space`` has many deprecated methods, such as ``rect_limits`` and quite a few more. The full discussion can be found `here <https://github.com/zfit/zfit/discussions/533>`_.
 - ``fixed_params`` in ``create_sampler`` is deprecated and will be removed in the future. Use ``params`` instead.
 - ``fixed_params`` attribute of the ``Sampler`` is deprecated and will be removed in the future. Use ``params`` instead.
+- ``zfit.run(...)`` is deprecated and will be removed in the future. Simply remove it should work in most cases.
+  (if an explicity numpy, not just array-like, cast is needed, use ``np.asarray(...)``. But usually this is not needed). This function is an old relic from the past TensorFlow 1.x, ``tf.Session`` times and is not needed anymore. We all remember well these days :)
 
 Bug fixes and small changes
 ---------------------------
 - complete overhaul of partial integration that used some broadcasting tricks that could potentially fail. It uses now a dynamic while loop that _could_ be slower but works for arbitrary PDFs and no problems should be encountered anymore.
-
 - ``result.fmin`` now returns the full likelihood, while ``result.fminopt`` returns the optimized likelihood with potential constant subtraction. The latter is mostly used by the minimizer and other libraries. This behavior is consistent with the behavior of other methods in the loss that return by default the full, unoptimized value.
 - serialization only allowed for one specific limit (space) of each obs. Multiple, independent
   limits can now be serialized.

--- a/docs/getting_started/5_minutes_to_zfit.rst
+++ b/docs/getting_started/5_minutes_to_zfit.rst
@@ -33,7 +33,7 @@ an *observable space*. This can be created using the :py:class:`~zfit.Space` cla
 
 .. jupyter-execute::
 
-    obs = zfit.Space('x', limits=(-10, 10))
+    obs = zfit.Space('x', -10, 10)
 
 The best interpretation of the observable at this stage is that it defines the name and range of the observable axis.
 
@@ -171,22 +171,19 @@ to do the job:
     import matplotlib.pyplot as plt
     import numpy as np
 
-    lower, upper = obs.limits
-    data_np = zfit.run(data.value()[:, 0])
+    lower, upper = obs.v1.limits
 
     # plot the data as a histogramm
     bins = 80
-    counts, bin_edges = np.histogram(data_np, bins, range=(lower[-1][0], upper[0][0]))
+    counts, bin_edges = np.histogram(data['x'], bins, range=(lower, upper))
     mplhep.histplot((counts, bin_edges), yerr=True, color='black', histtype='errorbar')
 
     # evaluate the func at multiple x and plot
-    x_plot = np.linspace(lower[-1][0], upper[0][0], num=1000)
-    y_plot = zfit.run(gauss.pdf(x_plot, norm_range=obs))
-    plt.plot(x_plot, y_plot * data_np.shape[0] / bins * obs.area(), color='xkcd:blue')
+    x_plot = np.linspace(lower, upper, num=1000)
+    y_plot = gauss.pdf(x_plot, norm_range=obs)
+    plt.plot(x_plot, y_plot * data_np.shape[0] / bins * obs.volume(), color='xkcd:blue')
     plt.show()
 
 
-The specific call to :func:`zfit.run` simply converts the Eager Tensor (that is already array-like) to a Numpy array.
-Often, this conversion is however not necessary and a Tensor can directly be used.
 
 The full script :jupyter-download:script:`can be downloaded here <5 minutes to zfit>`.

--- a/docs/tutorials/components/intro/model.rst
+++ b/docs/tutorials/components/intro/model.rst
@@ -67,9 +67,7 @@ to set a temporary normalisation range can be given as
 
     # Get the probabilities of some random generated events
     probs = model_cb.pdf(x=np.random.random(10))
-    # And now execute the tensorflow graph
-    result = zfit.run(probs)
-    print(result)
+    print(probs)
 
 .. jupyter-execute::
 

--- a/examples/custom_3d_pdf_simple.py
+++ b/examples/custom_3d_pdf_simple.py
@@ -37,5 +37,3 @@ custom_pdf = CustomPDF(obs=obs, alpha=alpha, beta=beta)
 integral = custom_pdf.integrate(limits=obs)  # = 1 since normalized
 sample = custom_pdf.sample(n=1000)  # DO NOT USE THIS FOR TOYS!
 prob = custom_pdf.pdf(sample)  # DO NOT USE THIS FOR TOYS!
-
-integral_np, sample_np, prob_np = [integral.numpy(), sample.numpy(), prob.numpy()]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ minversion = "6.0"
 addopts = "-Wd -ra -q"
 testpaths = [
     "tests",
+    "tests/*",
 ]
 markers = [
     "plots: create and safe plots",
@@ -26,7 +27,7 @@ relative_files = true
 omit = [
     # omit anything in a .local directory anywhere
     ".tox/*",
-    "*/test*",
+    "*/tests/*",
     "*minimizers/interface.py",
     "*/core/testing.py",
 ]

--- a/tests/fullexample/test_binned_vs_unbinned.py
+++ b/tests/fullexample/test_binned_vs_unbinned.py
@@ -84,9 +84,9 @@ def test_sig_bkg_fit(n, floatall, use_sampler, nbins, use_wrapper, request):
     def plot_pdf(title):
         plt.figure()
         plt.title(title)
-        y = model.pdf(x).numpy()
-        y_gauss = (gauss.pdf(x) * model_unbinned.params["frac_0"]).numpy()
-        y_exp = (exponential.pdf(x) * model_unbinned.params["frac_1"]).numpy()
+        y = model.pdf(x)
+        y_gauss = (gauss.pdf(x) * model_unbinned.params["frac_0"])
+        y_exp = (exponential.pdf(x) * model_unbinned.params["frac_1"])
         plt.plot(x, y * plot_scaling, label="Sum - Model")
         plt.plot(x, y_gauss * plot_scaling, label="Gauss - Signal")
         plt.plot(x, y_exp * plot_scaling, label="Exp - Background")

--- a/tests/highstats/test_exact_yields.py
+++ b/tests/highstats/test_exact_yields.py
@@ -78,7 +78,7 @@ def test_yield_bias(exact_nsample, ntoys=300):
         nsigs.append(nsig_res)
         nbkg_res = float(result.params[n_bkg]["value"])
         nbkgs.append(nbkg_res)
-        assert nsig_res + nbkg_res == pytest.approx(true_nsig + true_nbkg, abs=0.6)
+        assert pytest.approx(true_nsig + true_nbkg, abs=0.6) == nsig_res + nbkg_res
     nsigs_mean = np.mean(nsigs)
     std_nsigs_mean = np.std(nsigs) / ntoys**0.5 * 5
     nbkg_mean = np.mean(nbkgs)
@@ -118,6 +118,6 @@ def test_yield_bias(exact_nsample, ntoys=300):
     plt.legend()
     pytest.zfit_savefig(folder=plot_folder)
     rel_err_sig = 0.001
-    assert nsigs_mean == pytest.approx(true_nsig, rel=rel_err_sig, abs=std_nsigs_mean)
+    assert pytest.approx(true_nsig, rel=rel_err_sig, abs=std_nsigs_mean) == nsigs_mean
     rel_err_bkg = 0.001
-    assert nbkg_mean == pytest.approx(true_nbkg, rel=rel_err_bkg, abs=std_nbkg_mean)
+    assert pytest.approx(true_nbkg, rel=rel_err_bkg, abs=std_nbkg_mean) == nbkg_mean

--- a/tests/histmath/test_binned_integration.py
+++ b/tests/histmath/test_binned_integration.py
@@ -157,7 +157,7 @@ def test_binned_partial_scaled_asym_axis0():
         1 * binw11 * binw21 + 2 * binw12 * binw21,
         3 * binw11 * binw22 + 4 * binw12 * binw22,
     )
-    assert pytest.approx(true_integral) == zfit.run(integral)
+    np.testing.assert_allclose(true_integral, integral)
 
 
 def test_binned_partial_scaled_asym_axis1():
@@ -176,7 +176,7 @@ def test_binned_partial_scaled_asym_axis1():
         1 * binw11 * binw21 + 3 * binw11 * binw22,
         2 * binw12 * binw21 + 4 * binw12 * binw22,
     )
-    assert pytest.approx(true_integral) == zfit.run(integral)
+    np.testing.assert_allclose(true_integral, integral)
 
 
 def test_binned_scaled_asym_one():

--- a/tests/histmath/test_histograming.py
+++ b/tests/histmath/test_histograming.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023 zfit
+#  Copyright (c) 2024 zfit
 import hist
 import numpy as np
 
@@ -19,8 +19,7 @@ obs = obs1 * obs2 * obs3
 
 def test_histogramdd():
     histdd_kwargs = {"sample": data1}
-    hist = histogramdd(**histdd_kwargs)
-    bincount_np, edges_np = zfit.run(hist)
+    bincount_np, edges_np = histogramdd(**histdd_kwargs)
     bincount_true, edges_true = np.histogramdd(**histdd_kwargs)
     np.testing.assert_allclose(bincount_true, bincount_np)
     np.testing.assert_allclose(edges_true, edges_np)
@@ -35,8 +34,8 @@ def test_midpoints():
     bincounts_nonzero, midpoints_nonzero, bincounts_nonzero_index = midpoints_from_hist(
         bincounts=bincounts, edges=edges
     )
-    np.testing.assert_allclose(np.array([1, 5, 7, 3]), zfit.run(bincounts_nonzero))
-    np.testing.assert_allclose(midpoints_true, zfit.run(midpoints_nonzero))
+    np.testing.assert_allclose(np.array([1, 5, 7, 3]), znp.asarray(bincounts_nonzero))
+    np.testing.assert_allclose(midpoints_true, znp.asarray(midpoints_nonzero))
 
 
 def test_unbinned_to_bins():

--- a/tests/model/test_truncated_pdf.py
+++ b/tests/model/test_truncated_pdf.py
@@ -109,19 +109,20 @@ def test_truncated_pdf_sample(pdf, limits):
     truncated_pdf = zfit.pdf.TruncatedPDF(pdf, limits)
     space = pdf.space
     n = 10_000
-    samples = truncated_pdf.sample(n, limits[0]).numpy()
+    samples = truncated_pdf.sample(n, limits[0]).value()
     assert np.all(samples >= -1)
     assert np.all(samples <= 1)
 
-    samples = truncated_pdf.sample(n, limits[1]).numpy()
+    samples = truncated_pdf.sample(n, limits[1]).value()
     assert np.all(samples >= 2)
     assert np.all(samples <= 3)
 
-    samples = truncated_pdf.sample(n, space)[pdf.obs[0]].numpy()
+    samples = truncated_pdf.sample(n, space)[pdf.obs[0]]
+    samples = np.array(samples)
     all_inside = (samples >= -1) * (samples <= 1) + (samples >= 2) * (samples <= 3)
     np.testing.assert_array_equal(all_inside, np.ones(n, dtype=bool))
 
     space2 = zfit.Space("obs1", (-5, 3))
-    samples = truncated_pdf.sample(n, space2)[pdf.obs[0]].numpy()
+    samples = np.array(truncated_pdf.sample(n, space2)[pdf.obs[0]])
     all_inside = (samples >= -1) * (samples <= 1) + (samples >= 2) * (samples <= 3)
     np.testing.assert_array_equal(all_inside, np.ones(n, dtype=bool))

--- a/tests/serialize/test_basics.py
+++ b/tests/serialize/test_basics.py
@@ -583,7 +583,6 @@ all_constraints = [
 ]
 
 
-# TODO(serialization): add to serializer
 @pytest.mark.parametrize(
     "ext_Loss",
     [(False, zfit.loss.UnbinnedNLL), (True, zfit.loss.ExtendedUnbinnedNLL)],

--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -242,13 +242,13 @@ def test_sampling_simple(gauss_factory):
     gauss = gauss_factory()
     n_draws = 1000
     sample_tensor = gauss.sample(n=n_draws, limits=(low, high))
-    sampled_from_gauss1 = sample_tensor.numpy()
+    sampled_from_gauss1 = sample_tensor.value()
     assert max(sampled_from_gauss1[:, 0]) <= high
     assert min(sampled_from_gauss1[:, 0]) >= low
     assert n_draws == len(sampled_from_gauss1[:, 0])
     if gauss.params:
-        mu_true1 = gauss.params["mu"].numpy()
-        sigma_true1 = gauss.params["sigma"].numpy()
+        mu_true1 = gauss.params["mu"]
+        sigma_true1 = gauss.params["sigma"]
     else:
         mu_true1 = mu_true
         sigma_true1 = sigma_true
@@ -256,7 +256,7 @@ def test_sampling_simple(gauss_factory):
         n=10000,
         limits=(mu_true1 - abs(sigma_true1) * 3, mu_true1 + abs(sigma_true1) * 3),
     )
-    sampled_gauss1_full = sampled_gauss1_full.numpy()
+    sampled_gauss1_full = sampled_gauss1_full.value()
     mu_sampled = np.mean(sampled_gauss1_full)
     sigma_sampled = np.std(sampled_gauss1_full)
     assert pytest.approx(mu_true1, rel=0.07) == mu_sampled
@@ -277,7 +277,7 @@ def test_sampling_multiple_limits(obs1):
     sample_tensor = gauss_params1.sample(
         n=n_draws, limits=lower_interval + upper_interval
     )
-    sampled_from_gauss1 = sample_tensor.numpy()
+    sampled_from_gauss1 = sample_tensor.value()
     between_samples = np.logical_and(
         sampled_from_gauss1 < up1, sampled_from_gauss1 > low2
     )
@@ -286,8 +286,8 @@ def test_sampling_multiple_limits(obs1):
     assert min(sampled_from_gauss1[:, 0]) >= low1
     assert n_draws == len(sampled_from_gauss1[:, 0])
 
-    mu_true = gauss_params1.params["mu"].numpy()
-    sigma_true = gauss_params1.params["sigma"].numpy()
+    mu_true = gauss_params1.params["mu"]
+    sigma_true = gauss_params1.params["sigma"]
     low1, up1 = mu_true - abs(sigma_true) * 4, mu_true
     lower_interval = zfit.Space(obs=obs1, limits=(low1, up1))
     low2, up2 = mu_true, mu_true + abs(sigma_true) * 4
@@ -297,7 +297,7 @@ def test_sampling_multiple_limits(obs1):
     sample_tensor5 = gauss_params1.sample(
         n=10000, limits=lower_interval + upper_interval
     )
-    sampled_gauss1_full = sample_tensor5.numpy()
+    sampled_gauss1_full = sample_tensor5.value()
     mu_sampled = np.mean(sampled_gauss1_full)
     sigma_sampled = np.std(sampled_gauss1_full)
     assert pytest.approx(mu_true, rel=0.07) == mu_sampled
@@ -357,10 +357,10 @@ def test_multiple_limits(obs1):
         limits=multiple_limits_range, norm=False
     )
 
-    integral_simp, integral_mult = [integral_simp.numpy(), integral_mult.numpy()]
+    integral_simp, integral_mult = [integral_simp, integral_mult]
     integral_simp_num, integral_mult_num = [
-        integral_simp_num.numpy(),
-        integral_mult_num.numpy(),
+        integral_simp_num,
+        integral_mult_num,
     ]
     assert pytest.approx(
         integral_mult, rel=1e-2
@@ -463,5 +463,4 @@ def test_projection_pdf(test_values):
         norm=False,
     )
     probs = proj_pdf.pdf(x=test_values)
-    probs = probs.numpy()
     np.testing.assert_allclose(probs, true_probs, rtol=1e-3)  # MC normalization

--- a/tests/test_basePDF.py
+++ b/tests/test_basePDF.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 import pytest
 
+import zfit.z.numpy as znp
 
 @pytest.fixture
 def test_values():
@@ -191,7 +192,7 @@ def test_func(obs1, test_values):
     gauss_func = gauss_params1.as_func(norm=limits)
     vals = gauss_func.func(test_values)
     vals_pdf = gauss_params1.pdf(x=test_values, norm=limits)
-    vals, vals_pdf = zfit.run([vals, vals_pdf])
+    vals, vals_pdf = znp.asarray([vals, vals_pdf])
     np.testing.assert_allclose(vals_pdf, vals, rtol=1e-3)  # better assertion?
 
 
@@ -222,18 +223,16 @@ def test_normalization(obs1, pdf_factory):
         probs = dist.pdf(samples)
         probs_small = dist.pdf(small_samples)
         log_probs = dist.log_pdf(small_samples)
-        probs, log_probs = zfit.run(probs, log_probs)
         probs = np.average(probs) * (high - low)
-        assert probs == pytest.approx(1.0, rel=0.05)
-        assert log_probs == pytest.approx(tf.math.log(probs_small).numpy(), rel=0.05)
+        assert pytest.approx(1.0, rel=0.05) == probs
+        assert pytest.approx(znp.log(probs_small), rel=0.05) == log_probs
         dist = dist.create_extended(z.constant(test_yield))
         probs = dist.pdf(samples)
         probs_extended = dist.ext_pdf(samples)
-        result = probs.numpy()
-        result = np.average(result) * (high - low)
+        result = np.average(probs) * (high - low)
         result_ext = np.average(probs_extended) * (high - low)
-        assert result == pytest.approx(1, rel=0.05)
-        assert result_ext == pytest.approx(test_yield, rel=0.05)
+        assert pytest.approx(1, rel=0.05)  == result
+        assert pytest.approx(test_yield, rel=0.05)  == result_ext
 
 
 @pytest.mark.parametrize("gauss_factory", [create_gauss1, create_test_gauss1])
@@ -260,8 +259,8 @@ def test_sampling_simple(gauss_factory):
     sampled_gauss1_full = sampled_gauss1_full.numpy()
     mu_sampled = np.mean(sampled_gauss1_full)
     sigma_sampled = np.std(sampled_gauss1_full)
-    assert mu_sampled == pytest.approx(mu_true1, rel=0.07)
-    assert sigma_sampled == pytest.approx(sigma_true1, rel=0.07)
+    assert pytest.approx(mu_true1, rel=0.07) == mu_sampled
+    assert pytest.approx(sigma_true1, rel=0.07) == sigma_sampled
 
 
 def test_sampling_multiple_limits(obs1):
@@ -301,8 +300,8 @@ def test_sampling_multiple_limits(obs1):
     sampled_gauss1_full = sample_tensor5.numpy()
     mu_sampled = np.mean(sampled_gauss1_full)
     sigma_sampled = np.std(sampled_gauss1_full)
-    assert mu_sampled == pytest.approx(mu_true, rel=0.07)
-    assert sigma_sampled == pytest.approx(sigma_true, rel=0.07)
+    assert pytest.approx(mu_true, rel=0.07) == mu_sampled
+    assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled
 
 
 def test_analytic_sampling(obs1):
@@ -363,15 +362,15 @@ def test_multiple_limits(obs1):
         integral_simp_num.numpy(),
         integral_mult_num.numpy(),
     ]
-    assert integral_simp == pytest.approx(
+    assert pytest.approx(
         integral_mult, rel=1e-2
-    )  # big tol as mc is used
-    assert integral_simp == pytest.approx(
+    ) == integral_simp  # big tol as mc is used
+    assert pytest.approx(
         integral_simp_num, rel=1e-2
-    )  # big tol as mc is used
-    assert integral_simp_num == pytest.approx(
+    ) == integral_simp  # big tol as mc is used
+    assert pytest.approx(
         integral_mult_num, rel=1e-2
-    )  # big tol as mc is used
+    ) == integral_simp_num  # big tol as mc is used
 
 
 def test_copy(obs1):

--- a/tests/test_binnedloss.py
+++ b/tests/test_binnedloss.py
@@ -126,7 +126,7 @@ def test_binned_extended_simple(Loss):
     nll.value(), nll.gradient()  # TODO: add some check?
 
     nllsum = nll + nll2  # check that sum works
-    assert float(nllsum.value()) == pytest.approx(nll.value() + nll2.value(), rel=1e-3)
+    assert pytest.approx(nll.value() + nll2.value(), rel=1e-3) == float(nllsum.value())
 
 
 @pytest.mark.plots
@@ -239,17 +239,17 @@ def test_binned_loss(weights, Loss, simultaneous):
     abs_tol_val = 0.15 if weights is None else 0.08  # more fluctuating with weights
     abs_tol_val *= 2 if isinstance(loss, zfit.loss.BinnedChi2) else 1
 
-    assert params[mu1]["value"] == pytest.approx(
+    assert pytest.approx(
         np.mean(test_values_np_shifted), abs=abs_tol_val
-    )
-    assert params[sigma1]["value"] == pytest.approx(
+    ) == params[mu1]["value"]
+    assert pytest.approx(
         np.std(test_values_np_shifted), abs=abs_tol_val
-    )
+    ) == params[sigma1]["value"]
     if loss.is_extended:
         nexpected = test_values_np_shifted.shape[0]
-        assert params[scale]["value"] == pytest.approx(
+        assert pytest.approx(
             nexpected, abs=3 * nexpected**0.5
-        )
+        ) == params[scale]["value"]
     constraints = zfit.constraint.GaussianConstraint(
         params=[mu2, sigma2],
         observation=[mu_constr[0], sigma_constr[0]],
@@ -339,9 +339,9 @@ def test_binned_loss_hist(weights, Loss):
 
     nllsum = loss + loss2  # check that sum works
     nllsum += loss2  # check that sum works
-    assert float(nllsum.value(full=True)) == pytest.approx(
+    assert pytest.approx(
         float(
             loss.value(full=True) + 2 * loss2.value(full=True)  # we add loss2 two times
         ),
         rel=1e-3,
-    )
+    ) == float(nllsum.value(full=True))

--- a/tests/test_binnedpdf.py
+++ b/tests/test_binnedpdf.py
@@ -414,12 +414,12 @@ def test_binned_sampler(ndim):
 
     assert sample.values().shape == dims
     assert sampler.values().shape == dims
-    assert np.sum(sample.values()) == pytest.approx(nsampled)
-    assert np.sum(sampler.values()) == pytest.approx(nsampled)
+    assert pytest.approx(nsampled) == np.sum(sample.values())
+    assert pytest.approx(nsampled) == np.sum(sampler.values())
 
     sampler.resample(n=nsampled * 2)
     assert sampler.values().shape == dims
-    assert np.sum(sampler.values()) == pytest.approx(nsampled * 2)
+    assert pytest.approx(nsampled * 2) == np.sum(sampler.values())
 
     if ndim == 2:
         sampler_swapped = sampler.with_obs(
@@ -427,4 +427,4 @@ def test_binned_sampler(ndim):
         )
         values_swapped = sampler_swapped.values()
         assert values_swapped.shape == (dims[1], dims[0])
-        assert np.sum(values_swapped) == pytest.approx(nsampled * 2)
+        assert pytest.approx(nsampled * 2) == np.sum(values_swapped)

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -1,9 +1,10 @@
-#  Copyright (c) 2022 zfit
+#  Copyright (c) 2024 zfit
 
 import numpy as np
 
 import zfit
 from zfit.core.binning import histogramdd
+import zfit.z.numpy as znp
 
 data1 = np.random.normal(size=(1000, 3))
 obs1 = zfit.Space("obs1", limits=(-100, 300))
@@ -15,8 +16,7 @@ obs = obs1 * obs2 * obs3
 
 def test_histogramdd():
     histdd_kwargs = {"sample": data1}
-    hist = histogramdd(**histdd_kwargs)
-    bincount_np, edges_np = zfit.run(hist)
+    bincount_np, edges_np = histogramdd(**histdd_kwargs)
     bincount_true, edges_true = np.histogramdd(**histdd_kwargs)
     np.testing.assert_allclose(bincount_true, bincount_np)
     np.testing.assert_allclose(edges_true, edges_np)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -115,37 +115,37 @@ def test_graph_cache(graph_holder):
     new_value = 8
     result = 47 + CONST
     assert FunctionWrapperRegistry.do_jit_types["tensor"]  # should be true by default
-    assert graph1.calc(add).numpy() == result
-    assert graph1.calc_variable(add).numpy() == result
+    assert graph1.calc(add) == result
+    assert graph1.calc_variable(add) == result
     assert graph1.retrace_runs > 0  # simple
     graph1.retrace_runs = 0  # reset
-    assert graph1.calc(add).numpy() == result
-    assert graph1.calc_variable(add).numpy() == result
+    assert graph1.calc(add) == result
+    assert graph1.calc_variable(add) == result
     assert graph1.retrace_runs == 0  # no retracing must have occurred
 
     graph1.change_value_no_invalidation(10)
-    assert graph1.calc(add).numpy() == result
-    assert graph1.calc_variable(add).numpy() == result
+    assert graph1.calc(add) == result
+    assert graph1.calc_variable(add) == result
     assert graph1.retrace_runs == 0  # no retracing must have occurred
     FunctionWrapperRegistry.do_jit_types["tensor"] = False
     assert graph1.calc_variable(add) == 10 + add + CONST
     FunctionWrapperRegistry.do_jit_types["tensor"] = True
     graph1.change_value(new_value)
-    assert graph1.calc(add).numpy() == new_value + add + CONST
-    assert graph1.calc_variable(add).numpy() == new_value + add + CONST
+    assert graph1.calc(add) == new_value + add + CONST
+    assert graph1.calc_variable(add) == new_value + add + CONST
     assert graph1.retrace_runs > 0
     CONST = 50
-    assert graph1.calc(add).numpy() == new_value + add + 40  # old const
-    assert graph1.calc_variable(add).numpy() == new_value + add + 40  # old const
+    assert graph1.calc(add) == new_value + add + 40  # old const
+    assert graph1.calc_variable(add) == new_value + add + 40  # old const
     clear_graph_cache()
     FunctionWrapperRegistry.do_jit_types["something"] = False
     assert graph1.calc_no_cache(add) == new_value + add + CONST
     assert graph1.calc_variable(add) == new_value + add + CONST
-    assert graph1.calc(add).numpy() == new_value + add + CONST
+    assert graph1.calc(add) == new_value + add + CONST
     graph1.retrace_runs = 0  # reset
 
     graph1.change_value_no_invalidation(10)
-    assert graph1.calc(add).numpy() == new_value + add + CONST
+    assert graph1.calc(add) == new_value + add + CONST
     assert graph1.retrace_runs == 0  # no retracing must have occurred
     CONST = 40
     FunctionWrapperRegistry.do_jit_types["something"] = (

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -110,15 +110,15 @@ def test_gaussian_constraint():
     params = [zfit.Parameter(f"Param{i}", val) for i, val in enumerate(param_vals)]
 
     constr = GaussianConstraint(params=params, observation=observed, uncertainty=sigma)
-    constr_np = constr.value().numpy()
+    constr_np = constr.value()
     assert pytest.approx(true_val) == constr_np
     assert constr.get_cache_deps() == set(params)
 
     param_vals[0] = 2
     params[0].set_value(param_vals[0])
 
-    constr2_np = constr.value().numpy()
-    constr2_newtensor_np = constr.value().numpy()
+    constr2_np = constr.value()
+    constr2_newtensor_np = constr.value()
     assert pytest.approx(constr2_np) == constr2_newtensor_np
 
     true_val2 = true_gauss_constr_value(x=param_vals, mu=observed, sigma=sigma)
@@ -126,11 +126,11 @@ def test_gaussian_constraint():
 
     constr.observation[0].set_value(5)
     observed[0] = 5
-    # print("x: ", param_vals, [p.numpy() for p in params])
-    # print("mu: ", observed, [p.numpy() for p in constr.observation])
+    # print("x: ", param_vals, [p for p in params])
+    # print("mu: ", observed, [p for p in constr.observation])
     # print("sigma: ", sigma, np.sqrt([p for p in np.diag(constr.covariance)]))
     true_val3 = true_gauss_constr_value(x=param_vals, mu=observed, sigma=sigma)
-    constr3_np = constr.value().numpy()
+    constr3_np = constr.value()
     assert pytest.approx(true_val3) == constr3_np
 
 
@@ -143,9 +143,7 @@ def test_gaussian_constraint_orderbug():  # as raised in #162
 
     constr1 = GaussianConstraint(params=params, observation=observed, uncertainty=sigma)
 
-    value_tensor = constr1.value()
-    constr_np = value_tensor.numpy()
-    assert pytest.approx(true_val) == constr_np
+    assert pytest.approx(true_val) == constr1.value()
     assert true_val < 10000
 
 
@@ -165,15 +163,13 @@ def test_gaussian_constraint_orderbug2():  # as raised in #162, failed before fi
 
     constr1 = GaussianConstraint(**constraint)
     # param_vals = [1500, 1.0, 1.0, 1.0, 0.5]
-    constraint["x"] = [m.numpy() for m in constraint["params"]]
+    constraint["x"] = constraint["params"]
 
     true_val = true_gauss_constr_value(
         x=constraint["x"], mu=constraint["observation"], sigma=constraint["uncertainty"]
     )
 
-    value_tensor = constr1.value()
-    constr_np = value_tensor.numpy()
-    assert pytest.approx(true_val) == constr_np
+    assert pytest.approx(true_val) == constr1.value()
     assert true_val < 1000
     assert pytest.approx(
         -8.592, abs=0.1

--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022 zfit
+#  Copyright (c) 2024 zfit
 
 import numpy as np
 import pytest
@@ -37,14 +37,13 @@ def test_extract_extended_pdfs():
     limits = limits.with_autofill_axes()
     extended_sample = extended_sampling(pdfs=sum_all, limits=limits)
     extended_sample_np = extended_sample.numpy()
-    assert np.shape(extended_sample_np)[0] == pytest.approx(
+    assert pytest.approx(
         expected=(45 + 100 + 200), rel=0.1
-    )
+    ) == np.shape(extended_sample_np)[0]
     samples_from_pdf = sum_all.sample(n="extended", limits=limits)
-    samples_from_pdf_np = samples_from_pdf.numpy()
-    assert np.shape(samples_from_pdf_np)[0] == pytest.approx(
+    assert pytest.approx(
         expected=(45 + 100 + 200), rel=0.1
-    )
+    ) == np.shape(samples_from_pdf)[0]
 
 
 def test_set_yield():

--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -36,11 +36,10 @@ def test_extract_extended_pdfs():
     limits = zfit.Space(obs=obs1, limits=(-4, 5))
     limits = limits.with_autofill_axes()
     extended_sample = extended_sampling(pdfs=sum_all, limits=limits)
-    extended_sample_np = extended_sample.numpy()
     assert pytest.approx(
         expected=(45 + 100 + 200), rel=0.1
-    ) == np.shape(extended_sample_np)[0]
-    samples_from_pdf = sum_all.sample(n="extended", limits=limits)
+    ) == np.shape(extended_sample)[0]
+    samples_from_pdf = sum_all.sample(n="extended", limits=limits).value()
     assert pytest.approx(
         expected=(45 + 100 + 200), rel=0.1
     ) == np.shape(samples_from_pdf)[0]

--- a/tests/test_fitresult.py
+++ b/tests/test_fitresult.py
@@ -95,7 +95,7 @@ def create_fitresult(
         n=n, weights=weights, extended=extended, constraints=constraints
     )
 
-    true_minimum = loss.value(full=False).numpy()
+    true_minimum = loss.value(full=False)
 
     if extended:
         a_param, b_param, c_param, yieldgauss, yieldexp = all_params
@@ -109,7 +109,7 @@ def create_fitresult(
         param.assign(param.init_val)  # reset the value
     for ntry in range(3):
         result = minimizer.minimize(loss=loss)
-        cur_val = loss.value(full=False).numpy()
+        cur_val = loss.value(full=False)
         if result.valid:
             break
         else:  # vary param.init_val slightly
@@ -448,7 +448,7 @@ def test_new_minimum(minimizer_class_and_kwargs):
         b_param.floating = True
         c_param.floating = True
 
-        params_dict = {p: p.numpy() for p in params}
+        params_dict = {p: float(p) for p in params}
         hacked_result = FitResult(
             params=params_dict,
             edm=result.edm,

--- a/tests/test_fitresult.py
+++ b/tests/test_fitresult.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import zfit
+import zfit.z.numpy as znp
 from zfit.minimizers.errors import compute_errors
 from zfit.minimizers.fitresult import FitResult
 
@@ -151,9 +152,9 @@ def test_set_values_fitresult(do_pickle, weights, extended):
     lower1 = 0.0
     param1 = zfit.Parameter("param1", 2.0, lower1, upper1)
     param1.set_value(lower1)
-    assert pytest.approx(zfit.run(param1.value())) == lower1
+    assert pytest.approx(znp.asarray(param1.value())) == lower1
     param1.set_value(upper1)
-    assert pytest.approx(zfit.run(param1.value())) == upper1
+    assert pytest.approx(znp.asarray(param1.value())) == upper1
     with pytest.raises(ValueError):
         param1.set_value(lower1 - 0.001)
     with pytest.raises(ValueError):
@@ -175,8 +176,8 @@ def test_set_values_fitresult(do_pickle, weights, extended):
         result.freeze()
         result = pickle.loads(pickle.dumps(result))
     with zfit.param.set_values([param_c, param_b], values=result):
-        assert zfit.run(param_b.value()) == val_b
-        assert zfit.run(param_c.value()) == val_c
+        assert znp.asarray(param_b.value()) == val_b
+        assert znp.asarray(param_c.value()) == val_c
 
     # test partial
     param_new = zfit.Parameter("param_new", 42.0, 12.0, 48.0)
@@ -188,7 +189,7 @@ def test_set_values_fitresult(do_pickle, weights, extended):
     zfit.param.set_values(
         [param_c, param_new], values=result, allow_partial=True
     )  # allow_partial by default false
-    assert zfit.run(param_c.value()) == val_c
+    assert znp.asarray(param_c.value()) == val_c
 
     # test partial in case we have nothing to set
     param_d = zfit.Parameter("param_d", 12)

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -273,13 +273,13 @@ def test_mc_integration(chunksize, limits):
     assert integral.shape == (1,)
     assert integral2.shape == (1,)
     assert integral3.shape == (1,)
-    assert func1_5deps_fully_integrated(limits_simple_5deps) == pytest.approx(
+    assert pytest.approx(
         integral, rel=0.1
-    )
-    assert func2_1deps_fully_integrated(limits2) == pytest.approx(integral2, rel=0.03)
-    assert func3_2deps_fully_integrated(
+    ) == func1_5deps_fully_integrated(limits_simple_5deps)
+    assert pytest.approx(integral2, rel=0.03) == func2_1deps_fully_integrated(limits2)
+    assert pytest.approx(integral3, rel=0.03) == func3_2deps_fully_integrated(
         Space(limits=limits3, axes=(0, 1))
-    ).numpy() == pytest.approx(integral3, rel=0.03)
+    )
 
 
 @pytest.mark.flaky(2)
@@ -359,13 +359,13 @@ def test_analytic_integral():
         limits=Space(limits=limits3, axes=(0, 1)),
         norm=False,
     ).numpy()
-    assert func3_integrated == pytest.approx(
-        func3_2deps_fully_integrated(limits=Space(limits=limits3, axes=(0, 1))).numpy()
-    )
-    assert gauss_integral_infs.numpy() == pytest.approx(
+    assert pytest.approx(
+        func3_2deps_fully_integrated(limits=Space(limits=limits3, axes=(0, 1)))
+    ) == func3_integrated
+    assert pytest.approx(
         np.sqrt(np.pi * 2.0) * sigma_true, rel=0.0001
-    )
-    assert normal_integral_infs.numpy() == pytest.approx(1, rel=0.0001)
+    ) == gauss_integral_infs
+    assert pytest.approx(1, rel=0.0001) == normal_integral_infs
 
 
 def test_analytic_integral_selection():

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -266,9 +266,9 @@ def test_mc_integration(chunksize, limits):
         func=func3_2deps, limits=Space(limits=limits3, axes=(0, 1)), n_axes=2
     )
 
-    integral = num_integral.numpy()
-    integral2 = num_integral2.numpy()
-    integral3 = num_integral3.numpy()
+    integral = num_integral
+    integral2 = num_integral2
+    integral3 = num_integral3
 
     assert integral.shape == (1,)
     assert integral2.shape == (1,)
@@ -276,10 +276,10 @@ def test_mc_integration(chunksize, limits):
     assert pytest.approx(
         integral, rel=0.1
     ) == func1_5deps_fully_integrated(limits_simple_5deps)
-    assert pytest.approx(integral2, rel=0.03) == func2_1deps_fully_integrated(limits2)
-    assert pytest.approx(integral3, rel=0.03) == func3_2deps_fully_integrated(
+    assert pytest.approx(integral2, rel=0.03) == np.atleast_1d(func2_1deps_fully_integrated(limits2))
+    assert pytest.approx(integral3, rel=0.03) == np.atleast_1d(func3_2deps_fully_integrated(
         Space(limits=limits3, axes=(0, 1))
-    )
+    ))
 
 
 @pytest.mark.flaky(2)
@@ -299,8 +299,8 @@ def test_mc_partial_integration():
         func=func4_3deps, limits=limits2, x=data2, draws_per_dim=1000
     )
 
-    integral = num_integral.numpy()
-    integral2 = num_integral2.numpy()
+    integral = num_integral
+    integral2 = num_integral2
     assert len(integral) == len(func4_values)
     assert len(integral2) == len(func4_2values[0])
     integrated = func4_3deps_0and2_integrated(x=func4_values, limits=limits4_2dim)
@@ -358,9 +358,9 @@ def test_analytic_integral():
     func3_integrated = dist_func3.integrate(
         limits=Space(limits=limits3, axes=(0, 1)),
         norm=False,
-    ).numpy()
+    )
     assert pytest.approx(
-        func3_2deps_fully_integrated(limits=Space(limits=limits3, axes=(0, 1)))
+        np.atleast_1d(func3_2deps_fully_integrated(limits=Space(limits=limits3, axes=(0, 1))))
     ) == func3_integrated
     assert pytest.approx(
         np.sqrt(np.pi * 2.0) * sigma_true, rel=0.0001

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -268,7 +268,7 @@ def test_add():
     assert simult_nll.fit_range == ranges
 
     def eval_constraint(constraints):
-        return z.reduce_sum([c.value() for c in constraints]).numpy()
+        return z.reduce_sum([c.value() for c in constraints])
 
     assert eval_constraint(simult_nll.constraints) == eval_constraint(merged_contraints)
     assert set(simult_nll.get_params()) == {param1, param2, param3}
@@ -297,7 +297,7 @@ def test_gradients(chunksize):
     def loss_func(values):
         for val, param in zip(values, nll.get_cache_deps(only_floating=True)):
             param.set_value(val)
-        return nll.value().numpy()
+        return nll.value()
 
     # theoretical, numerical = tf.test.compute_gradient(loss_func, list(params))
     gradient1 = nll.gradient(params=param1)
@@ -361,7 +361,7 @@ def test_simple_loss():
     assert set(loss_deps.get_params()) == set(param_list)
 
     loss_tensor = loss_func(param_list)
-    loss_value_np = loss_tensor.numpy()
+    loss_value_np = loss_tensor
 
     assert pytest.approx(loss_value_np) == loss.value()
     assert pytest.approx(loss_value_np) == loss_deps.value()

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -7,6 +7,7 @@ import zfit.core.basepdf
 import zfit.models.dist_tfp
 import zfit.settings
 from zfit import z
+import zfit.z.numpy as znp
 from zfit.core.loss import UnbinnedNLL
 from zfit.core.space import Space
 from zfit.minimize import Minuit
@@ -145,13 +146,13 @@ def test_extended_unbinned_nll(size):
     minimizer = Minuit(tol=1e-4)
     status = minimizer.minimize(loss=nll)
     params = status.params
-    assert params[mu3]["value"] == pytest.approx(
-        zfit.run(tf.math.reduce_mean(test_values.value())), rel=0.05
-    )
-    assert params[sigma3]["value"] == pytest.approx(
-        zfit.run(tf.math.reduce_std(test_values.value())), rel=0.05
-    )
-    assert params[yield3]["value"] == pytest.approx(size, rel=0.005)
+    assert pytest.approx(
+        np.mean(test_values.value()), rel=0.05
+    ) == params[mu3]["value"]
+    assert pytest.approx(
+        np.std(test_values.value()), rel=0.05
+    ) == params[sigma3]["value"]
+    assert pytest.approx(size, rel=0.005) == params[yield3]["value"]
 
 
 def test_unbinned_simultaneous_nll():
@@ -161,10 +162,10 @@ def test_unbinned_simultaneous_nll():
     params = status.params
     assert set(nll.get_params()) == {mu1, mu2, sigma1, sigma2}
 
-    assert params[mu1]["value"] == pytest.approx(np.mean(test_values_np), rel=0.007)
-    assert params[mu2]["value"] == pytest.approx(np.mean(test_values_np2), rel=0.007)
-    assert params[sigma1]["value"] == pytest.approx(np.std(test_values_np), rel=0.007)
-    assert params[sigma2]["value"] == pytest.approx(np.std(test_values_np2), rel=0.007)
+    assert pytest.approx(np.mean(test_values_np), rel=0.007) == params[mu1]["value"]
+    assert pytest.approx(np.mean(test_values_np2), rel=0.007) == params[mu2]["value"]
+    assert pytest.approx(np.std(test_values_np), rel=0.007) == params[sigma1]["value"]
+    assert pytest.approx(np.std(test_values_np2), rel=0.007) == params[sigma2]["value"]
 
 
 @pytest.mark.flaky(3)
@@ -188,10 +189,10 @@ def test_unbinned_nll(weights, sigma, options):
     params = status.params
     rel_error = 0.12 if weights is None else 0.1  # more fluctuating with weights
 
-    assert params[mu1]["value"] == pytest.approx(np.mean(test_values_np), rel=rel_error)
-    assert params[sigma1]["value"] == pytest.approx(
+    assert pytest.approx(np.mean(test_values_np), rel=rel_error) == params[mu1]["value"]
+    assert pytest.approx(
         np.std(test_values_np), rel=rel_error
-    )
+    ) == params[sigma1]["value"]
 
     constraints = zfit.constraint.nll_gaussian(
         params=[mu2, sigma2],
@@ -302,7 +303,7 @@ def test_gradients(chunksize):
     gradient1 = nll.gradient(params=param1)
     gradient_func = Gradient(loss_func)
     # gradient_func = lambda *args, **kwargs: list(gradient_func_numpy(*args, **kwargs))
-    assert gradient1[0].numpy() == pytest.approx(gradient_func([param1.numpy()]))
+    assert pytest.approx(gradient_func([param1])) == gradient1[0]
     param1.set_value(initial1)
     param2.set_value(initial2)
     params = [param2, param1]
@@ -310,7 +311,7 @@ def test_gradients(chunksize):
     both_gradients_true = list(
         reversed(list(gradient_func([initial1, initial2])))
     )  # because param2, then param1
-    assert [g.numpy() for g in gradient2] == pytest.approx(both_gradients_true)
+    np.testing.assert_allclose(gradient2, both_gradients_true)
 
     param1.set_value(initial1)
     param2.set_value(initial2)
@@ -321,7 +322,7 @@ def test_gradients(chunksize):
             if param_o is param:
                 gradients_true3.append(float(grad))
                 break
-    assert [g.numpy() for g in gradient3] == pytest.approx(gradients_true3)
+    np.testing.assert_allclose(gradient3, gradients_true3)
 
 
 def test_simple_loss():
@@ -362,12 +363,12 @@ def test_simple_loss():
     loss_tensor = loss_func(param_list)
     loss_value_np = loss_tensor.numpy()
 
-    assert loss.value().numpy() == pytest.approx(loss_value_np)
-    assert loss_deps.value().numpy() == pytest.approx(loss_value_np)
+    assert pytest.approx(loss_value_np) == loss.value()
+    assert pytest.approx(loss_value_np) == loss_deps.value()
 
-    assert loss.value(full=True).numpy() == pytest.approx(
-        loss_deps.value(full=True).numpy()
-    )
+    assert pytest.approx(
+        loss_deps.value(full=True)
+    ) == loss.value(full=True)
 
     with pytest.raises(IntentionAmbiguousError):
         _ = loss + loss_deps
@@ -375,17 +376,17 @@ def test_simple_loss():
     minimizer = zfit.minimize.Minuit()
     result = minimizer.minimize(loss=loss)
     assert result.valid
-    assert true_a == pytest.approx(result.params[a_param]["value"], rel=0.03)
-    assert true_b == pytest.approx(result.params[b_param]["value"], rel=0.06)
-    assert true_c == pytest.approx(result.params[c_param]["value"], rel=0.5)
+    assert pytest.approx(result.params[a_param]["value"], rel=0.03) == true_a
+    assert pytest.approx(result.params[b_param]["value"], rel=0.06) == true_b
+    assert pytest.approx(result.params[c_param]["value"], rel=0.5) == true_c
 
-    zfit.param.set_values(param_list, np.array(zfit.run(param_list)) + 0.6)
+    zfit.param.set_values(param_list, znp.asarray(param_list) + 0.6)
     result2 = minimizer.minimize(loss=loss2)
     assert result2.valid
     params = list(result2.params)
-    assert true_a == pytest.approx(result2.params[params[0]]["value"], rel=0.03)
-    assert true_b == pytest.approx(result2.params[params[1]]["value"], rel=0.06)
-    assert true_c == pytest.approx(result2.params[params[2]]["value"], rel=0.5)
+    assert pytest.approx(result2.params[params[0]]["value"], rel=0.03) == true_a
+    assert pytest.approx(result2.params[params[1]]["value"], rel=0.06) == true_b
+    assert pytest.approx(result2.params[params[2]]["value"], rel=0.5) == true_c
 
 
 def test_create_new_nll():
@@ -456,14 +457,14 @@ def test_callable_loss(create_loss):
     loss = create_loss()
 
     params = list(loss.get_params())
-    x = np.array(zfit.run(params)) + 0.1
+    x = np.array(znp.asarray(params)) + 0.1
     value_loss = loss(x)
     with zfit.param.set_values(params, x):
         true_val = zfit.run(loss.value(full=True))
         _ = zfit.run(loss.value(full=True))
-        assert true_val == pytest.approx(zfit.run(value_loss))
+        assert pytest.approx(value_loss) == true_val
         with pytest.raises(BehaviorUnderDiscussion):
-            assert true_val == pytest.approx(zfit.run(loss()))
+            assert pytest.approx((loss())) == true_val
 
     with pytest.raises(ValueError):
         loss(x[:-1])
@@ -478,7 +479,7 @@ def test_iminuit_compatibility(create_loss):
     loss = create_loss()
 
     params = list(loss.get_params())
-    x = np.array(zfit.run(params)) + 0.1
+    x = znp.asarray(params) + 0.1
     zfit.param.set_values(params, x)
 
     with pytest.raises(ValueError):
@@ -496,7 +497,7 @@ def test_iminuit_compatibility(create_loss):
     zfit.param.set_values(params, x)
     minimizer_zfit = zfit.minimize.Minuit()
     result_zfit = minimizer_zfit.minimize(loss)
-    assert float(result_zfit.fmin) == pytest.approx(float(result.fmin.fval), abs=0.03)
+    assert pytest.approx(result.fmin.fval, abs=0.03) == result_zfit.fmin
 
 
 @pytest.mark.flaky(3)
@@ -521,10 +522,10 @@ def test_binned_nll(weights):
     params = status.params
     rel_error = 0.035 if weights is None else 0.15  # more fluctuating with weights
 
-    assert params[mu1]["value"] == pytest.approx(np.mean(test_values_np), rel=rel_error)
-    assert params[sigma1]["value"] == pytest.approx(
+    assert pytest.approx(np.mean(test_values_np), rel=rel_error) == params[mu1]["value"]
+    assert pytest.approx(
         np.std(test_values_np), rel=rel_error
-    )
+    ) == params[sigma1]["value"]
 
     constraints = zfit.constraint.GaussianConstraint(
         params=[mu2, sigma2],

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -42,7 +42,7 @@ def create_loss(obs1):
                 loss = zfit.loss.UnbinnedNLL(
                     model=sum_pdf1, data=sampled_data, options={"subtr_const": True}
                 )
-                minimum = loss.value(full=False).numpy()
+                minimum = loss.value(full=False)
 
     return loss, minimum, (mu_param, sigma_param, lambda_param)
 
@@ -96,7 +96,7 @@ def test_scipy_derivative_options(minimizer_gradient_hessian):
     result = minimizer.minimize(loss=loss)
     assert result.valid
 
-    found_min = loss.value(full=False).numpy()
+    found_min = loss.value(full=False)
     assert true_min + max_distance_to_min >= found_min
 
     aval, bval, cval = znp.asarray((mu_param, sigma_param, lambda_param))
@@ -492,7 +492,7 @@ def test_minimizers(minimizer_class_and_kwargs, chunksize, numgrad, spaces, requ
         assert result.valid
         assert result_hightol.valid
         assert result_lowtol.valid
-        found_min = loss.value(full=False).numpy()
+        found_min = loss.value(full=False)
         assert true_min + max_distance_to_min >= found_min
 
         assert pytest.approx(result.fminopt, abs=2.0) == result_lowtol.fminopt

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022 zfit
+#  Copyright (c) 2024 zfit
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -59,8 +59,8 @@ def test_param_func():
 
     new_func_equivalent = func * param4
 
-    result1 = new_func.func(x=rnd_test_values).numpy()
-    result1_equivalent = new_func_equivalent.func(x=rnd_test_values).numpy()
+    result1 = new_func.func(x=rnd_test_values)
+    result1_equivalent = new_func_equivalent.func(x=rnd_test_values)
     result2 = func.func(x=rnd_test_values) * param4
     np.testing.assert_array_equal(result1, result2)
     np.testing.assert_array_equal(result1_equivalent, result2)
@@ -94,9 +94,9 @@ def test_func_func():
         None, rnd_test_values
     )
 
-    added_values = added_values.numpy()
-    true_added_values = true_added_values.numpy()
-    prod_values = prod_values.numpy()
-    true_prod_values = true_prod_values.numpy()
+    added_values = added_values
+    true_added_values = true_added_values
+    prod_values = prod_values
+    true_prod_values = true_prod_values
     np.testing.assert_allclose(true_added_values, added_values)
     np.testing.assert_allclose(true_prod_values, prod_values)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -5,13 +5,14 @@ import tensorflow as tf
 from ordered_set import OrderedSet
 
 import zfit
+import zfit.z.numpy as znp
 from zfit import Parameter, z
 from zfit.exception import LogicalUndefinedOperationError
 from zfit.param import ComplexParameter, ComposedParameter
 
 
 def test_complex_param():
-    import zfit.z.numpy as znp
+
 
     real_part = 1.3
     imag_part = 0.3
@@ -24,7 +25,7 @@ def test_complex_param():
     )
     some_value = 3.0 * param1**2 - 1.2j
     true_value = 3.0 * complex_value**2 - 1.2j
-    assert true_value == pytest.approx(some_value.numpy(), rel=1e-7)
+    assert pytest.approx(some_value, rel=1e-7) == true_value
     assert not param1.get_params()
 
     # Cartesian complex
@@ -35,10 +36,10 @@ def test_complex_param():
     )
     part1, part2 = param2.get_params()
     part1_val, part2_val = [part1.value().numpy(), part2.value().numpy()]
-    if part1_val == pytest.approx(real_part):
-        assert part2_val == pytest.approx(imag_part)
-    elif part2_val == pytest.approx(real_part):
-        assert part1_val == pytest.approx(imag_part)
+    if pytest.approx(real_part) == part1_val:
+        assert pytest.approx(imag_part) == part2_val
+    elif pytest.approx(real_part) == part2_val:
+        assert pytest.approx(imag_part) == part1_val
     else:
         assert False, "one of the if or elif should be the case"
 
@@ -50,10 +51,10 @@ def test_complex_param():
     param3 = ComplexParameter.from_polar("param3_compl", mod_part_param, arg_part_param)
     part1, part2 = param3.get_cache_deps()
     part1_val, part2_val = [part1.value().numpy(), part2.value().numpy()]
-    if part1_val == pytest.approx(mod_val):
-        assert part2_val == pytest.approx(arg_val)
-    elif part1_val == pytest.approx(arg_val):
-        assert part2_val == pytest.approx(mod_val)
+    if pytest.approx(mod_val) == part1_val:
+        assert pytest.approx(arg_val) == part2_val
+    elif pytest.approx(arg_val) == part1_val:
+        assert pytest.approx(mod_val) == part2_val
     else:
         assert False, "one of the if or elif should be the case"
 
@@ -68,18 +69,18 @@ def test_complex_param():
     param5 = param2.conj
 
     # Test properties (1e-8 is too precise)
-    assert zfit.run(param1.real) == pytest.approx(real_part, rel=1e-6)
-    assert zfit.run(param1.imag) == pytest.approx(imag_part, rel=1e-6)
-    assert zfit.run(param2.real) == pytest.approx(real_part, rel=1e-6)
-    assert zfit.run(param2.imag) == pytest.approx(imag_part, rel=1e-6)
-    assert zfit.run(param2.mod) == pytest.approx(np.abs(complex_value))
-    assert zfit.run(param2.arg) == pytest.approx(np.angle(complex_value))
-    assert zfit.run(param3.mod) == pytest.approx(mod_val, rel=1e-6)
-    assert zfit.run(param3.arg) == pytest.approx(arg_val, rel=1e-6)
-    assert zfit.run(param3.real) == pytest.approx(mod_val * np.cos(arg_val), rel=1e-6)
-    assert zfit.run(param3.imag) == pytest.approx(mod_val * np.sin(arg_val), rel=1e-6)
-    assert zfit.run(param5.real) == pytest.approx(real_part)
-    assert zfit.run(param5.imag) == pytest.approx(-imag_part)
+    assert pytest.approx(real_part, rel=1e-6) == param1.real
+    assert pytest.approx(imag_part, rel=1e-6) == param1.imag
+    assert pytest.approx(real_part, rel=1e-6) == param2.real
+    assert pytest.approx(imag_part, rel=1e-6) == param2.imag
+    assert pytest.approx(np.abs(complex_value)) == param2.mod
+    assert pytest.approx(np.angle(complex_value)) == param2.arg
+    assert pytest.approx(mod_val, rel=1e-6) == param3.mod
+    assert pytest.approx(arg_val, rel=1e-6) == param3.arg
+    assert pytest.approx(mod_val * np.cos(arg_val), rel=1e-6) == param3.real
+    assert pytest.approx(mod_val * np.sin(arg_val), rel=1e-6) == param3.imag
+    assert pytest.approx(real_part) == param5.real
+    assert pytest.approx(-imag_part) == param5.imag
 
 
 def test_repr():
@@ -279,8 +280,8 @@ def test_convert_to_parameters():
     conv_param3 = zfit.param.convert_to_parameters(
         trueval3, lower=truelower3, prefer_constant=False
     )
-    np.testing.assert_allclose(zfit.run(conv_param3), trueval3)
-    np.testing.assert_allclose(zfit.run([p.lower for p in conv_param3]), truelower3)
+    np.testing.assert_allclose(znp.asarray(conv_param3), trueval3)
+    np.testing.assert_allclose(znp.asarray([p.lower for p in conv_param3]), truelower3)
 
     truename4 = ["oe", "myname1", "ue", "eu", "eue"]
     stepsize4 = [23, 1.5, 10.0, 34, 23]
@@ -298,9 +299,9 @@ def test_convert_to_parameters():
     )
     assert [p.name for p in conv_param4dict] == truename4
 
-    np.testing.assert_allclose(zfit.run([p.upper for p in conv_param4dict]), trueupper4)
+    np.testing.assert_allclose(znp.asarray([p.upper for p in conv_param4dict]), trueupper4)
     np.testing.assert_allclose(
-        zfit.run([p.step_size for p in conv_param4dict]), stepsize4
+        znp.asarray([p.step_size for p in conv_param4dict]), stepsize4
     )
 
     truename5 = [name + "_five" for name in truename4]
@@ -313,9 +314,9 @@ def test_convert_to_parameters():
     )
     assert [p.name for p in conv_param4dict] == truename5
 
-    np.testing.assert_allclose(zfit.run([p.upper for p in conv_param4dict]), trueupper4)
+    np.testing.assert_allclose(znp.asarray([p.upper for p in conv_param4dict]), trueupper4)
     np.testing.assert_allclose(
-        zfit.run([p.step_size for p in conv_param4dict]), stepsize4
+        znp.asarray([p.step_size for p in conv_param4dict]), stepsize4
     )
 
 
@@ -323,20 +324,20 @@ def test_convert_to_parameters_equivalence_to_single_multi():
     import zfit
 
     conv_param1 = zfit.param.convert_to_parameters([23, 10.0, 34, 23])[1]
-    assert pytest.approx(zfit.run(conv_param1.value())) == 10
+    assert pytest.approx(znp.asarray(conv_param1.value())) == 10
     assert not conv_param1.floating
 
     conv_param2 = zfit.param.convert_to_parameters(
         [23, 10.0, 34, 12, 23], prefer_constant=False
     )[-2]
-    assert pytest.approx(zfit.run(conv_param2.value())) == 12.0
+    assert pytest.approx(znp.asarray(conv_param2.value())) == 12.0
     assert conv_param2.floating
     assert not conv_param2.has_limits
 
     conv_param3 = zfit.param.convert_to_parameters(
         [23, 10.0, 12, 34, 23], lower=list(range(5)), prefer_constant=False
     )[2]
-    assert pytest.approx(zfit.run(conv_param3.lower)) == 2
+    assert pytest.approx(znp.asarray(conv_param3.lower)) == 2
     assert conv_param3.has_limits
 
     truename4 = ["oe", "myname1", "ue", "eu", "eue"]
@@ -352,25 +353,25 @@ def test_convert_to_parameters_equivalence_to_single_multi():
     assert conv_param4.name == "myname1"
     assert conv_param4.has_limits
     assert conv_param4.floating
-    assert pytest.approx(zfit.run(conv_param4.step_size)) == 1.5
+    assert pytest.approx(znp.asarray(conv_param4.step_size)) == 1.5
 
 
 def test_convert_to_parameters_equivalence_to_single():
     import zfit
 
     conv_param1 = zfit.param.convert_to_parameters(10.0)[0]
-    assert pytest.approx(zfit.run(conv_param1.value())) == 10
+    assert pytest.approx(znp.asarray(conv_param1.value())) == 10
     assert not conv_param1.floating
 
     conv_param2 = zfit.param.convert_to_parameters(12.0, prefer_constant=False)[0]
-    assert pytest.approx(zfit.run(conv_param2.value())) == 12.0
+    assert pytest.approx(znp.asarray(conv_param2.value())) == 12.0
     assert conv_param2.floating
     assert not conv_param2.has_limits
 
     conv_param3 = zfit.param.convert_to_parameters(
         12.0, lower=5.0, prefer_constant=False
     )[0]
-    assert pytest.approx(zfit.run(conv_param3.lower)) == 5.0
+    assert pytest.approx(znp.asarray(conv_param3.lower)) == 5.0
     assert conv_param3.has_limits
 
     truename4 = "myname1"
@@ -382,25 +383,25 @@ def test_convert_to_parameters_equivalence_to_single():
     assert conv_param4.name == truename4
     assert conv_param4.has_limits
     assert conv_param4.floating
-    assert pytest.approx(zfit.run(conv_param4.step_size)) == stepsize4
+    assert pytest.approx(znp.asarray(conv_param4.step_size)) == stepsize4
 
 
 def test_convert_to_parameter():
     import zfit
 
     conv_param1 = zfit.param.convert_to_parameter(10.0)
-    assert pytest.approx(zfit.run(conv_param1.value())) == 10
+    assert pytest.approx(znp.asarray(conv_param1.value())) == 10
     assert not conv_param1.floating
 
     conv_param2 = zfit.param.convert_to_parameter(12.0, prefer_constant=False)
-    assert pytest.approx(zfit.run(conv_param2.value())) == 12.0
+    assert pytest.approx(znp.asarray(conv_param2.value())) == 12.0
     assert conv_param2.floating
     assert not conv_param2.has_limits
 
     conv_param3 = zfit.param.convert_to_parameter(
         12.0, lower=5.0, prefer_constant=False
     )
-    assert pytest.approx(zfit.run(conv_param3.lower)) == 5.0
+    assert pytest.approx(znp.asarray(conv_param3.lower)) == 5.0
     assert conv_param3.has_limits
 
     with pytest.raises(ValueError):
@@ -418,7 +419,7 @@ def test_convert_to_parameter():
     assert conv_param4.name == truename4
     assert conv_param4.has_limits
     assert conv_param4.floating
-    assert pytest.approx(zfit.run(conv_param4.step_size)) == stepsize4
+    assert pytest.approx(znp.asarray(conv_param4.step_size)) == stepsize4
 
 
 def test_set_values():
@@ -508,15 +509,15 @@ def test_to_numpy():
     import zfit
 
     param = zfit.Parameter("param", 42)
-    assert zfit.run(param) == 42
+    assert znp.asarray(param) == 42
 
     p1 = zfit.param.ConstantParameter("aoeu1", 15)
-    assert zfit.run(p1) == 15
+    assert znp.asarray(p1) == 15
 
     p2 = zfit.param.ComposedParameter(
         "aoeu2", lambda params: 2 * params["p1"], {"p1": p1}
     )
-    assert zfit.run(p2) == 30
+    assert znp.asarray(p2) == 30
 
 def test_parameter_label():
 

--- a/tests/test_partial_integration.py
+++ b/tests/test_partial_integration.py
@@ -54,11 +54,10 @@ def test_partial_integral():
     data_np = np.linspace((1, 1), (4, 4), 4000)
     data = zfit.Data.from_numpy(obs=obs, array=data_np)
     probs = cosxy2.pdf(data, norm=False)
-    probs_np = probs.numpy()
     x = data_np[:, 0]
     y = data_np[:, 1]
     probs_func = func_cosxy2_np(x=x, y=y)
-    ratios = probs_np / probs_func
+    ratios = probs / probs_func
     assert pytest.approx(0.0, rel=0.0001) == np.std(ratios)  # ratio should be constant
     ratio = np.average(ratios)
 
@@ -66,13 +65,11 @@ def test_partial_integral():
     datax = data.with_obs(xspace)
     integral_x_tf = cosxy2.partial_integrate(x=datay, limits=xspace, norm=False)
     integral_y_tf = cosxy2.partial_integrate(x=datax, limits=yspace, norm=False)
-    integral_x_np = integral_x_tf.numpy()
-    integral_y_np = integral_y_tf.numpy()
 
     lowerx, upperx = xspace.v1.limits
     lowery, uppery = yspace.v1.limits
     integral_x_true = integral_x(y=y, lowerx=lowerx, upperx=upperx) * ratio
     integral_y_true = integral_y(x=x, lowery=lowery, uppery=uppery) * ratio
 
-    np.testing.assert_allclose(integral_x_true, integral_x_np, atol=1e-2)
-    np.testing.assert_allclose(integral_y_true, integral_y_np, atol=1e-2)
+    np.testing.assert_allclose(integral_x_true, integral_x_tf, atol=1e-2)
+    np.testing.assert_allclose(integral_y_true, integral_y_tf, atol=1e-2)

--- a/tests/test_pdf_bifurgauss.py
+++ b/tests/test_pdf_bifurgauss.py
@@ -31,12 +31,12 @@ def create_bifurgauss(mu, sigmal, sigmar, limits):
 
 def test_bifurgauss_pdf():
     bifurgauss, obs = create_bifurgauss(mu=mu_true, sigmal=sigmal_true, sigmar=sigma_true, limits=(-5, 5))
-    assert bifurgauss.pdf(0.5, norm=False).numpy().item() == pytest.approx(
+    assert pytest.approx(
         numpy_bifurgauss_pdf(0.5, mu=mu_true, sigmal=sigmal_true, sigmar=sigma_true), rel=1e-5
-    )
+    ) == bifurgauss.pdf(0.5, norm=False)
     test_values = tf.range(-5, 5, 10_000)
     np.testing.assert_allclose(
-        bifurgauss.pdf(test_values, norm=False).numpy(),
+        bifurgauss.pdf(test_values, norm=False),
         numpy_bifurgauss_pdf(test_values, mu=mu_true, sigmal=sigmal_true, sigmar=sigma_true),
         rtol=1e-5,
     )
@@ -57,33 +57,33 @@ def test_bifurgauss_integral():
     numpy_full_integral = integrate.quad(
             numpy_bifurgauss_pdf, -5, 5, args=(mu_true, sigmal_true, sigma_true)
         )[0]
-    assert full_interval_analytic == pytest.approx(true_integral, 1e-6)
-    assert full_interval_numeric == pytest.approx(true_integral, 1e-6)
-    assert full_interval_analytic == pytest.approx(numpy_full_integral, 1e-6)
-    assert full_interval_numeric == pytest.approx(numpy_full_integral, 1e-6)
+    assert pytest.approx(true_integral, 1e-6) == full_interval_analytic
+    assert pytest.approx(true_integral, 1e-6) == full_interval_numeric
+    assert pytest.approx(numpy_full_integral, 1e-6) == full_interval_analytic
+    assert pytest.approx(numpy_full_integral, 1e-6) == full_interval_numeric
 
     analytic_integral = bifurgauss.analytic_integrate(limits=(-1, 1), norm=False).numpy()
     numeric_integral = bifurgauss.numeric_integrate(limits=(-1, 1), norm=False).numpy()
     numpy_integral = integrate.quad(
         numpy_bifurgauss_pdf, -1, 1, args=(mu_true, sigmal_true, sigma_true)
     )[0]
-    assert analytic_integral == pytest.approx(numeric_integral, 1e-6)
-    assert analytic_integral == pytest.approx(numpy_integral, 1e-6)
+    assert pytest.approx(numeric_integral, 1e-6) == analytic_integral
+    assert pytest.approx(numpy_integral, 1e-6) == analytic_integral
 
 
 def test_equivalency_with_generalizedcb():
     bifurgauss, obs = create_bifurgauss(mu=mu_true, sigmal=sigmal_true, sigmar=sigma_true, limits=(-5, 5))
     generalized_cb = zfit.pdf.GeneralizedCB(mu=mu_true, sigmal=sigmal_true, alphal=100, nl=1, sigmar=sigma_true, alphar=100, nr=1, obs=obs)
 
-    assert bifurgauss.pdf(0.5).numpy() == pytest.approx(generalized_cb.pdf(0.5).numpy(), rel=1e-5)
+    assert pytest.approx(generalized_cb.pdf(0.5), rel=1e-5) == bifurgauss.pdf(0.5)
     test_values = tf.range(-5, 5, 10_000)
     np.testing.assert_allclose(
-        bifurgauss.pdf(test_values).numpy(),
-        generalized_cb.pdf(test_values).numpy(),
+        bifurgauss.pdf(test_values),
+        generalized_cb.pdf(test_values),
         rtol=1e-5,
     )
 
-    assert bifurgauss.analytic_integrate(obs).numpy() == pytest.approx(generalized_cb.analytic_integrate(obs).numpy(), rel=1e-5)
-    assert bifurgauss.numeric_integrate(obs).numpy() == pytest.approx(generalized_cb.numeric_integrate(obs).numpy(), rel=1e-5)
-    assert bifurgauss.analytic_integrate(limits=(-1, 1)).numpy() == pytest.approx(generalized_cb.analytic_integrate(limits=(-1, 1)).numpy(), rel=1e-5)
-    assert bifurgauss.numeric_integrate(limits=(-1, 1)).numpy() == pytest.approx(generalized_cb.numeric_integrate(limits=(-1, 1)).numpy(), rel=1e-5)
+    assert pytest.approx(generalized_cb.analytic_integrate(obs), rel=1e-5) == bifurgauss.analytic_integrate(obs)
+    assert pytest.approx(generalized_cb.numeric_integrate(obs), rel=1e-5) == bifurgauss.numeric_integrate(obs)
+    assert pytest.approx(generalized_cb.analytic_integrate(limits=(-1, 1)), rel=1e-5) == bifurgauss.analytic_integrate(limits=(-1, 1))
+    assert pytest.approx(generalized_cb.numeric_integrate(limits=(-1, 1)), rel=1e-5) == bifurgauss.numeric_integrate(limits=(-1, 1))

--- a/tests/test_pdf_cauchy.py
+++ b/tests/test_pdf_cauchy.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023 zfit
+#  Copyright (c) 2024 zfit
 
 import zfit
 from zfit import z
@@ -20,10 +20,8 @@ def test_breitwigner1():
     bw1 = zfit.pdf.Cauchy(m=mean, gamma=width, obs=obs1)
 
     probs1 = bw1.pdf(x=test_values)
-    # TODO: add scipy dist?
-    probs1 = probs1.numpy()
     assert all(probs1) > 0
     # np.testing.assert_allclose(probs1, probs1_tfp, rtol=1e-2)
 
     sample1 = bw1.sample(100)
-    assert len(sample1.numpy()) == 100
+    assert len(sample1) == 100

--- a/tests/test_pdf_cb.py
+++ b/tests/test_pdf_cb.py
@@ -38,8 +38,7 @@ tester.register_pdf(pdf_class=CrystalBall, params_factories=_cb_params_factory)
 
 def sample_testing(pdf):
     sample = pdf.sample(n=1000, limits=(-0.5, 1.5))
-    sample_np = sample.numpy()
-    assert not any(np.isnan(sample_np))
+    assert not any(np.isnan(sample.value()))
 
 
 def eval_testing(pdf, x):
@@ -145,17 +144,17 @@ def test_cb_dcb(doublecb):
 
     kwargs = dict(limits=(-5.0, mu), norm_range=lbounds)
     intl = cbl.integrate(**kwargs) - dcb.integrate(**kwargs)
-    assert pytest.approx(intl.numpy(), abs=1e-3) == 0.0
+    assert pytest.approx(intl, abs=1e-3) == 0.0
     intl = cbr.integrate(**kwargs) - dcb.integrate(**kwargs)
-    assert pytest.approx(intl.numpy(), abs=1e-3) != 0
+    assert pytest.approx(intl, abs=1e-3) != 0
 
     # TODO: update test to fixed DCB integral
     kwargs = dict(limits=(mu, 2.0), norm_range=rbounds)
     dcb_integr1 = dcb.integrate(**kwargs)
     intr = cbr.integrate(**kwargs) - dcb_integr1
-    assert pytest.approx(intr.numpy(), abs=1e-3) == 0.0
+    assert pytest.approx(intr, abs=1e-3) == 0.0
     intr = cbl.integrate(**kwargs) - dcb.integrate(**kwargs)
-    assert pytest.approx(intr.numpy(), abs=1e-3) != 0.0
+    assert pytest.approx(intr, abs=1e-3) != 0.0
 
     xl = x[x <= mu]
     xr = x[x > mu]

--- a/tests/test_pdf_cb.py
+++ b/tests/test_pdf_cb.py
@@ -4,6 +4,7 @@ import pytest
 from scipy.stats import crystalball
 
 import zfit
+import zfit.z.numpy as znp
 from zfit.core.testing import tester
 from zfit.models.physics import CrystalBall, DoubleCB, GeneralizedCB
 
@@ -45,7 +46,7 @@ def eval_testing(pdf, x):
     probs = pdf.pdf(x)
     assert probs.shape.rank == 1
     assert probs.shape[0] == x.shape[0]
-    probs = zfit.run(probs)
+    probs = znp.asarray(probs)
     assert not np.any(np.isnan(probs))
     return probs
 
@@ -63,8 +64,6 @@ def test_cb_integral():
     integral_numeric = cbl.numeric_integrate(limits=int_limits, norm=False)
 
     integral = cbl.analytic_integrate(limits=int_limits, norm=False)
-    integral_numeric = zfit.run(integral_numeric)
-    integral = zfit.run(integral)
 
     assert pytest.approx(integral_numeric, 1e-5) == integral
 
@@ -75,8 +74,8 @@ def test_cb_integral():
     ]
 
     integral = np.sum(integrals)
-    integral_full = zfit.run(cbl.integrate(bounds, norm=False))
-    assert pytest.approx(float(integral_full)) == float(integral)
+    integral_full = (cbl.integrate(bounds, norm=False))
+    assert pytest.approx(integral_full) == (integral)
 
 
 @pytest.mark.parametrize("doublecb", ["DoubleCB", "GeneralizedCB"])
@@ -179,5 +178,5 @@ def test_cb_dcb(doublecb):
         integrals.append(dcb.integrate((low, up), norm=False))
 
     integral = np.sum(integrals)
-    integral_full = zfit.run(dcb.integrate((bounds[0], up), norm=False))
+    integral_full = znp.asarray(dcb.integrate((bounds[0], up), norm=False))
     assert pytest.approx(float(integral_full)) == float(integral)

--- a/tests/test_pdf_chisquared.py
+++ b/tests/test_pdf_chisquared.py
@@ -15,5 +15,5 @@ def test_chisquared():
 
     samples = chi2.sample(10000)["obs"]
 
-    assert float(znp.mean(samples)) == pytest.approx(N_true, rel=0.05)
-    assert float(znp.std(samples)) == pytest.approx((2 * N_true) ** 0.5, rel=0.05)
+    assert pytest.approx(N_true, rel=0.05) == znp.mean(samples)
+    assert pytest.approx((2 * N_true) ** 0.5, rel=0.05) == znp.std(samples)

--- a/tests/test_pdf_fftconv.py
+++ b/tests/test_pdf_fftconv.py
@@ -54,18 +54,17 @@ def test_conv_simple(interpolation):
     )
 
     integral = conv.integrate(limits=obs)
-    probs_np = probs.numpy()
     np.testing.assert_allclose(probs, true_conv, rtol=0.01, atol=0.01)
 
-    assert pytest.approx(1, rel=1e-3) == integral.numpy()
-    assert len(probs_np) == n_points
+    assert pytest.approx(1, rel=1e-3) == integral
+    assert len(probs) == n_points
 
     plt.figure()
     plt.title(f"Conv FFT 1Dim, interpolation={interpolation}")
-    plt.plot(x, probs_np, label="zfit")
+    plt.plot(x, probs, label="zfit")
     plt.plot(x, true_conv, label="numpy")
     plt.legend()
-    # pytest.zfit_savefig()
+    pytest.zfit_savefig()
 
 
 @pytest.mark.parametrize("interpolation", interpolation_methods)
@@ -145,14 +144,13 @@ def test_conv_1d_shifted(interpolation):
     integral = conv.integrate(
         limits=obs,
     )
-    probs_np = probs.numpy()
-    np.testing.assert_allclose(probs_np, true_conv, rtol=0.01, atol=0.01)
+    np.testing.assert_allclose(probs, true_conv, rtol=0.01, atol=0.01)
 
-    assert pytest.approx(1, rel=1e-3) == integral.numpy()
+    assert pytest.approx(1, rel=1e-3) == integral
 
     plt.figure()
     plt.title("Conv FFT 1Dim shift testing")
-    plt.plot(x, probs_np, label="zfit")
+    plt.plot(x, probs, label="zfit")
     plt.plot(x, true_conv, label="numpy")
     plt.legend()
     pytest.zfit_savefig()
@@ -294,9 +292,8 @@ def test_conv_2D_simple():
     integral = conv.integrate(
         limits=obs_func,
     )
-    assert pytest.approx(1, rel=1e-3) == integral.numpy()
-    probs_np = probs_rnd.numpy()
-    assert len(probs_np) == n_points
+    assert pytest.approx(1, rel=1e-3) == integral
+    assert len(probs) == n_points
     # probs_plot = np.reshape(probs_np, (-1, n_points))
     # x_plot = linspace[0:, ]
     # probs_plot_projx = np.sum(probs_plot, axis=0)
@@ -327,23 +324,23 @@ def test_conv_2D_simple():
     plt.figure()
     plt.title("FFT conv, custom sampling, addition")
     plt.hist2d(x, y, bins=30)
-    # pytest.zfit_savefig()
+    pytest.zfit_savefig()
 
     plt.figure()
     plt.title("FFT conv, fallback sampling, accept-reject")
     plt.hist2d(xns, yns, bins=30)
-    # pytest.zfit_savefig()
+    pytest.zfit_savefig()
 
     plt.figure()
     plt.title("FFT conv x projection")
-    plt.hist(x.numpy(), bins=50, label="custom", alpha=0.5)
-    plt.hist(xns.numpy(), bins=50, label="fallback", alpha=0.5)
+    plt.hist(x, bins=50, label="custom", alpha=0.5)
+    plt.hist(xns, bins=50, label="fallback", alpha=0.5)
     plt.legend()
-    # pytest.zfit_savefig()
+    pytest.zfit_savefig()
 
     plt.figure()
     plt.title("FFT conv y projection")
-    plt.hist(y.numpy(), bins=50, label="custom", alpha=0.5)
-    plt.hist(yns.numpy(), bins=50, label="fallback", alpha=0.5)
+    plt.hist(y, bins=50, label="custom", alpha=0.5)
+    plt.hist(yns, bins=50, label="fallback", alpha=0.5)
     plt.legend()
-    # pytest.zfit_savefig()
+    pytest.zfit_savefig()

--- a/tests/test_pdf_gamma.py
+++ b/tests/test_pdf_gamma.py
@@ -23,32 +23,32 @@ def test_gamma_pdf():
     assert pytest.approx(
         gamma_scipy.pdf(4.5, a=gamma_true, scale=beta_true, loc=mu_true), rel=1e-5
     ) == gamma.pdf(4.5, norm=False)
-    test_values = tf.range(1, 10, 10_000)
+    test_values = znp.linspace(1, 10, 10_000)
     np.testing.assert_allclose(
         gamma.pdf(test_values, norm=False),
         gamma_scipy.pdf(test_values, a=gamma_true, scale=beta_true, loc=mu_true),
         rtol=1e-5,
     )
-    assert gamma.pdf(test_values, norm=False) <= gamma.pdf(4.5, norm=False)
+    assert np.all(gamma.pdf(test_values, norm=False) <= gamma.pdf(4.5, norm=False))
 
     sample = gamma.sample(10_00)
-    assert all(np.isfinite(sample.value())), "Some samples from the gamma PDF are NaN or infinite"
+    assert np.all(np.isfinite(sample.value())), "Some samples from the gamma PDF are NaN or infinite"
     assert sample.n_events == 1000
-    assert all(tf.logical_and(1 <= sample.value(), sample.value() <= 10))
+    assert np.all(tf.logical_and(1 <= sample.value(), sample.value() <= 10))
 
 
 def test_gamma_integral():
     qgauss, obs = create_gamma(gamma=gamma_true, beta=beta_true, mu=mu_true, limits=(1, 10))
-    full_interval_analytic = qgauss.analytic_integrate(obs, norm=False).numpy()
-    full_interval_numeric = qgauss.numeric_integrate(obs, norm=False).numpy()
+    full_interval_analytic = qgauss.analytic_integrate(obs, norm=False)
+    full_interval_numeric = qgauss.numeric_integrate(obs, norm=False)
     scipy_full_inttegral = gamma_scipy.cdf(10, a=gamma_true, scale=beta_true, loc=mu_true) - gamma_scipy.cdf(
         1, a=gamma_true, scale=beta_true, loc=mu_true
     )
     assert pytest.approx(scipy_full_inttegral, 1e-6) == full_interval_analytic
     assert pytest.approx(scipy_full_inttegral, 1e-6) == full_interval_numeric
 
-    analytic_integral = qgauss.analytic_integrate(limits=(3, 6), norm=False).numpy()
-    numeric_integral = qgauss.numeric_integrate(limits=(3, 6), norm=False).numpy()
+    analytic_integral = qgauss.analytic_integrate(limits=(3, 6), norm=False)
+    numeric_integral = qgauss.numeric_integrate(limits=(3, 6), norm=False)
     scipy_integral = gamma_scipy.cdf(6, a=gamma_true, scale=beta_true, loc=mu_true) - gamma_scipy.cdf(
         3, a=gamma_true, scale=beta_true, loc=mu_true
     )

--- a/tests/test_pdf_gamma.py
+++ b/tests/test_pdf_gamma.py
@@ -21,20 +21,23 @@ def create_gamma(gamma, beta, mu, limits):
 def test_gamma_pdf():
     gamma, _ = create_gamma(gamma=gamma_true, beta=beta_true, mu=mu_true, limits=(1, 10))
     assert pytest.approx(
-        gamma_scipy.pdf(4.5, a=gamma_true, scale=beta_true, loc=mu_true), rel=1e-5
-    ) == gamma.pdf(4.5, norm=False)
+        gamma_scipy.pdf(4, a=gamma_true, scale=beta_true, loc=mu_true), rel=1e-5
+    ) == gamma.pdf(4, norm=False)
     test_values = znp.linspace(1, 10, 10_000)
+    test_values_ones = np.ones_like(test_values)
     np.testing.assert_allclose(
         gamma.pdf(test_values, norm=False),
         gamma_scipy.pdf(test_values, a=gamma_true, scale=beta_true, loc=mu_true),
         rtol=1e-5,
     )
-    assert np.all(gamma.pdf(test_values, norm=False) <= gamma.pdf(4.5, norm=False))
+    np.testing.assert_array_less(gamma.pdf(test_values, norm=False), test_values_ones * gamma.pdf(4.2, norm=False))
 
     sample = gamma.sample(10_00)
     assert np.all(np.isfinite(sample.value())), "Some samples from the gamma PDF are NaN or infinite"
     assert sample.n_events == 1000
-    assert np.all(tf.logical_and(1 <= sample.value(), sample.value() <= 10))
+    ones_like = np.ones_like(sample.value())
+    np.testing.assert_array_less(1 * ones_like, sample.value())
+    np.testing.assert_array_less(sample.value(), ones_like * 10)
 
 
 def test_gamma_integral():

--- a/tests/test_pdf_gamma.py
+++ b/tests/test_pdf_gamma.py
@@ -20,18 +20,18 @@ def create_gamma(gamma, beta, mu, limits):
 
 def test_gamma_pdf():
     gamma, _ = create_gamma(gamma=gamma_true, beta=beta_true, mu=mu_true, limits=(1, 10))
-    assert gamma.pdf(4.5, norm=False).numpy().item() == pytest.approx(
+    assert pytest.approx(
         gamma_scipy.pdf(4.5, a=gamma_true, scale=beta_true, loc=mu_true), rel=1e-5
-    )
+    ) == gamma.pdf(4.5, norm=False)
     test_values = tf.range(1, 10, 10_000)
     np.testing.assert_allclose(
-        gamma.pdf(test_values, norm=False).numpy(),
+        gamma.pdf(test_values, norm=False),
         gamma_scipy.pdf(test_values, a=gamma_true, scale=beta_true, loc=mu_true),
         rtol=1e-5,
     )
     assert gamma.pdf(test_values, norm=False) <= gamma.pdf(4.5, norm=False)
 
-    sample = gamma.sample(1000)
+    sample = gamma.sample(10_00)
     assert all(np.isfinite(sample.value())), "Some samples from the gamma PDF are NaN or infinite"
     assert sample.n_events == 1000
     assert all(tf.logical_and(1 <= sample.value(), sample.value() <= 10))
@@ -44,13 +44,13 @@ def test_gamma_integral():
     scipy_full_inttegral = gamma_scipy.cdf(10, a=gamma_true, scale=beta_true, loc=mu_true) - gamma_scipy.cdf(
         1, a=gamma_true, scale=beta_true, loc=mu_true
     )
-    assert full_interval_analytic == pytest.approx(scipy_full_inttegral, 1e-6)
-    assert full_interval_numeric == pytest.approx(scipy_full_inttegral, 1e-6)
+    assert pytest.approx(scipy_full_inttegral, 1e-6) == full_interval_analytic
+    assert pytest.approx(scipy_full_inttegral, 1e-6) == full_interval_numeric
 
     analytic_integral = qgauss.analytic_integrate(limits=(3, 6), norm=False).numpy()
     numeric_integral = qgauss.numeric_integrate(limits=(3, 6), norm=False).numpy()
     scipy_integral = gamma_scipy.cdf(6, a=gamma_true, scale=beta_true, loc=mu_true) - gamma_scipy.cdf(
         3, a=gamma_true, scale=beta_true, loc=mu_true
     )
-    assert analytic_integral == pytest.approx(numeric_integral, 1e-5)
-    assert analytic_integral == pytest.approx(scipy_integral, 1e-5)
+    assert pytest.approx(numeric_integral, 1e-5) == analytic_integral
+    assert pytest.approx(scipy_integral, 1e-5) == analytic_integral

--- a/tests/test_pdf_gaussexptail.py
+++ b/tests/test_pdf_gaussexptail.py
@@ -53,16 +53,14 @@ tester.register_pdf(pdf_class=GaussExpTail, params_factories=_gaussexptail_param
 
 
 def sample_testing(pdf):
-    sample = pdf.sample(n=1000, limits=(-0.5, 1.5))
-    sample_np = sample.numpy()
-    assert not any(np.isnan(sample_np))
+    sample = pdf.sample(n=1000, limits=(-0.5, 1.5)).value()
+    assert not any(np.isnan(sample))
 
 
 def eval_testing(pdf, x):
     probs = pdf.pdf(x, norm=False)
     assert probs.shape.rank == 1
     assert probs.shape[0] == x.shape[0]
-    probs = probs.numpy()
     assert not np.any(np.isnan(probs))
     return probs
 
@@ -76,8 +74,8 @@ def test_gaussexptail_integral():
 
     gaussexptail = GaussExpTail(obs=obs, mu=mu_, sigma=sigma_, alpha=alphal_)
     int_limits = (-1, 3)
-    integral_numeric = gaussexptail.numeric_integrate(limits=int_limits, norm=False).numpy()
-    integral = gaussexptail.analytic_integrate(limits=int_limits, norm=False).numpy()
+    integral_numeric = gaussexptail.numeric_integrate(limits=int_limits, norm=False)
+    integral = gaussexptail.analytic_integrate(limits=int_limits, norm=False)
     integral_scipy = integrate.quad(numpy_gaussexptail_pdf, *int_limits, args=(mu, sigma, alphal, nl))[0]
 
     assert pytest.approx(integral_numeric, 1e-5) == integral
@@ -90,7 +88,7 @@ def test_gaussexptail_integral():
     ]
 
     integral = np.sum(integrals)
-    integral_full = gaussexptail.integrate(bounds, norm=False).numpy()
+    integral_full = gaussexptail.integrate(bounds, norm=False)
     assert pytest.approx(integral_full) == integral
 
 
@@ -138,19 +136,19 @@ def test_gaussexptail_generalizedgaussexptail():
 
     kwargs = dict(limits=(-5.0, mu), norm_range=lbounds)
     intl = gaussexptaill.integrate(**kwargs) - generalizedgaussexptail.integrate(**kwargs)
-    assert pytest.approx(intl.numpy(), abs=1e-3) == 0.0
+    assert pytest.approx(intl, abs=1e-3) == 0.0
     intl = gaussexptailr.integrate(**kwargs) - generalizedgaussexptail.integrate(**kwargs)
-    assert pytest.approx(intl.numpy(), abs=2e-4) != 0.0
+    assert pytest.approx(intl, abs=2e-4) != 0.0
 
     kwargs = dict(limits=(mu, 2.0), norm_range=rbounds)
     intr = gaussexptailr.integrate(**kwargs) - generalizedgaussexptail.integrate(**kwargs)
-    assert pytest.approx(intr.numpy(), abs=1e-3) == 0.0
+    assert pytest.approx(intr, abs=1e-3) == 0.0
     intr = gaussexptaill.integrate(**kwargs) - generalizedgaussexptail.integrate(**kwargs)
-    assert pytest.approx(intr.numpy(), abs=1e-3) != 0.0
+    assert pytest.approx(intr, abs=1e-3) != 0.0
 
-    integrall = gaussexptaill.integrate(limits=bounds, norm=False).numpy()
-    integralr = gaussexptailr.integrate(limits=bounds, norm=False).numpy()
-    integral = generalizedgaussexptail.integrate(limits=bounds, norm=False).numpy()
+    integrall = gaussexptaill.integrate(limits=bounds, norm=False)
+    integralr = gaussexptailr.integrate(limits=bounds, norm=False)
+    integral = generalizedgaussexptail.integrate(limits=bounds, norm=False)
     integrall_scipy = integrate.quad(numpy_gaussexptail_pdf, *bounds, args=(mu, sigmal, alphal, nl))[0]
     integralr_scipy = integrate.quad(numpy_gaussexptail_pdf, *bounds, args=(mu, sigmar, -alphar, nr))[0]
     integral_scipy = integrate.quad(numpy_generalizedgaussexptail_pdf, *bounds, args=(mu, sigmal, alphal, nl, sigmar, alphar, nr))[0]
@@ -180,5 +178,5 @@ def test_gaussexptail_generalizedgaussexptail():
         integrals.append(generalizedgaussexptail.integrate((low, up), norm=False))
 
     integral = np.sum(integrals)
-    integral_full = generalizedgaussexptail.integrate(bounds, norm=False).numpy()
+    integral_full = generalizedgaussexptail.integrate(bounds, norm=False)
     assert pytest.approx(integral_full) == integral

--- a/tests/test_pdf_kde.py
+++ b/tests/test_pdf_kde.py
@@ -8,6 +8,7 @@ from matplotlib import pyplot as plt
 
 import zfit
 from zfit import z
+import zfit.z.numpy as znp
 from zfit.core.interfaces import ZfitParameter
 
 
@@ -274,7 +275,7 @@ def test_all_kde(kdetype, npoints, jit, request):
             data,
         ) = _run(kdetype, full=full)
 
-    expected_integral = zfit.run(expected_integral)
+    expected_integral = znp.asarray(expected_integral)
 
     if not jit:
         import matplotlib.pyplot as plt
@@ -315,7 +316,7 @@ def test_all_kde(kdetype, npoints, jit, request):
         )
         plt.plot(x, prob, label="KDE")
         plt.plot(x, prob_true, label="true PDF")
-        data_np = zfit.run(data)
+        data_np = znp.asarray(data)
         plt.hist(data_np, bins=40, density=True, alpha=0.3, label="Kernel points")
         plt.legend()
 
@@ -323,16 +324,16 @@ def test_all_kde(kdetype, npoints, jit, request):
     tolfac = 6 if not cfg["type"] == tfp.distributions.Normal else 1
     if cfg.get("binning_method") == "simple":
         tolfac *= 6
-    assert zfit.run(integral) == pytest.approx(expected_integral, abs=abs_tol * tolfac)
+    assert pytest.approx(expected_integral, abs=abs_tol * tolfac) == znp.asarray(integral)
     assert tuple(sample.shape) == (1, 1)
     assert tuple(sample2.shape) == (1500, 1)
     assert prob.shape.rank == 1
     assert prob.shape[0] == x.shape[0]
     assert np.mean(prob - prob_true) < 0.07 * tolfac
     # make sure that on average, most values are close
-    assert np.mean(
+    assert pytest.approx(1, abs=0.1 * tolfac) == np.mean(
         (prob / prob_true)[prob_true > np.mean(prob_true)] ** 2
-    ) == pytest.approx(1, abs=0.1 * tolfac)
+    )
     rtol = 0.05
     np.testing.assert_allclose(prob, prob_true, rtol=rtol, atol=0.01 * tolfac)
 
@@ -435,21 +436,21 @@ def test_kde_border(kdetype, npoints, upper):
     )
     plt.plot(x, prob, label="KDE")
     plt.plot(x, prob_true, label="true PDF")
-    data_np = zfit.run(data)
+    data_np = znp.asarray(data)
     plt.hist(data_np, bins=40, density=True, alpha=0.3, label="Kernel points")
     plt.legend()
 
-    integral = zfit.run(integral)
-    expected_integral = zfit.run(expected_integral)
+    integral = znp.asarray(integral)
+    expected_integral = znp.asarray(expected_integral)
     abs_tol = 0.05
-    assert zfit.run(integral) == pytest.approx(expected_integral, abs=abs_tol)
+    assert pytest.approx(expected_integral, abs=abs_tol) == (integral)
     assert tuple(sample.shape) == (1, 1)
     assert tuple(sample2.shape) == (1500, 1)
     assert prob.shape.rank == 1
     assert np.mean(prob - prob_true) < 0.07
     # make sure that on average, most values are close
-    assert np.mean(
+    assert pytest.approx(1, abs=0.15) == np.mean(
         (prob / prob_true)[prob_true > np.mean(prob_true)] ** 2
-    ) == pytest.approx(1, abs=0.15)
+    )
     rtol = 0.05
     np.testing.assert_allclose(prob, prob_true, rtol=rtol, atol=0.07)

--- a/tests/test_pdf_normal.py
+++ b/tests/test_pdf_normal.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022 zfit
+#  Copyright (c) 2024 zfit
 import numpy as np
 import pytest
 
@@ -75,5 +75,5 @@ def test_truncated_gauss():
     outside_probs_truncated = probs_truncated_np[np.logical_not(bool_index_inside)]
     inside_probs_gauss = probs_gauss_np[bool_index_inside]
 
-    assert inside_probs_gauss == pytest.approx(inside_probs_truncated, rel=1e-3)
+    assert pytest.approx(inside_probs_truncated, rel=1e-3) == inside_probs_gauss
     assert all(outside_probs_truncated == 0)

--- a/tests/test_pdf_normal.py
+++ b/tests/test_pdf_normal.py
@@ -44,14 +44,10 @@ def test_gauss1():
 
     probs1 = gauss1.pdf(x=test_values, norm=norm_range1)
     probs1_tfp = normal1.pdf(x=test_values, norm=norm_range1)
-    probs1 = probs1.numpy()
-    probs1_tfp = probs1_tfp.numpy()
     np.testing.assert_allclose(probs1, probs1_tfp, rtol=1e-2)
 
     probs1_unnorm = gauss1.pdf(x=test_values, norm=False)
     probs1_tfp_unnorm = normal1.pdf(x=test_values, norm=False)
-    probs1_unnorm = probs1_unnorm.numpy()
-    probs1_tfp_unnorm = probs1_tfp_unnorm.numpy()
     assert not np.allclose(probs1_tfp, probs1_tfp_unnorm, rtol=1e-2)
     assert not np.allclose(probs1, probs1_unnorm, rtol=1e-2)
     # np.testing.assert_allclose(probs1_unnorm, probs1_tfp_unnorm, rtol=1e-2)
@@ -68,12 +64,11 @@ def test_truncated_gauss():
     probs_truncated = truncated_gauss.pdf(test_values)
     probs_gauss = gauss.pdf(test_values)
 
-    probs_truncated_np, probs_gauss_np = [probs_truncated.numpy(), probs_gauss.numpy()]
 
     bool_index_inside = np.logical_and(low < test_values, test_values < high)
-    inside_probs_truncated = probs_truncated_np[bool_index_inside]
-    outside_probs_truncated = probs_truncated_np[np.logical_not(bool_index_inside)]
-    inside_probs_gauss = probs_gauss_np[bool_index_inside]
+    inside_probs_truncated = probs_truncated[bool_index_inside]
+    outside_probs_truncated = probs_truncated[np.logical_not(bool_index_inside)]
+    inside_probs_gauss = probs_gauss[bool_index_inside]
 
     assert pytest.approx(inside_probs_truncated, rel=1e-3) == inside_probs_gauss
     assert all(outside_probs_truncated == 0)

--- a/tests/test_pdf_poisson.py
+++ b/tests/test_pdf_poisson.py
@@ -36,9 +36,8 @@ def test_poisson(composed_rate):
         poisson = create_poisson()
 
     probs1 = poisson.pdf(x=test_values)
-    probs1 = probs1.numpy()
     assert np.all(np.isfinite(probs1))
     assert np.all(probs1 >= 0)
-    samples = poisson.sample(10000).numpy()
+    samples = poisson.sample(10000)
 
-    assert pytest.approx(50 ** 0.5, rel=0.05) == np.std(samples)
+    assert pytest.approx(50 ** 0.5, rel=0.05) == np.std(samples.value())

--- a/tests/test_pdf_poisson.py
+++ b/tests/test_pdf_poisson.py
@@ -41,4 +41,4 @@ def test_poisson(composed_rate):
     assert np.all(probs1 >= 0)
     samples = poisson.sample(10000).numpy()
 
-    assert np.std(samples) == pytest.approx(50**0.5, rel=0.05)
+    assert pytest.approx(50 ** 0.5, rel=0.05) == np.std(samples)

--- a/tests/test_pdf_polynomials.py
+++ b/tests/test_pdf_polynomials.py
@@ -152,12 +152,12 @@ def test_bernstein(coeffs, obs):
     bernstein = zfit.pdf.Bernstein(obs=obs, coeffs=coeffs)
     lower, upper = obs.limit1d
 
-    assert bernstein.pdf(0.8, norm=False).numpy().item() == pytest.approx(
+    assert pytest.approx(
         bernstein_numba.density(0.8, beta=coeffs, xmin=lower, xmax=upper), rel=1e-5
-    )
+    ) == bernstein.pdf(0.8, norm=False)
     test_values = tf.range(lower, upper, 10_000)
     np.testing.assert_allclose(
-        bernstein.pdf(test_values, norm=False).numpy(),
+        bernstein.pdf(test_values, norm=False),
         bernstein_numba.density(test_values, beta=coeffs, xmin=lower, xmax=upper),
         rtol=1e-5,
     )
@@ -173,15 +173,15 @@ def test_bernstein(coeffs, obs):
     numba_stats_full_integral = bernstein_numba.integral(x=upper, beta=coeffs, xmin=lower, xmax=upper) - bernstein_numba.integral(
         x=lower, beta=coeffs, xmin=lower, xmax=upper
     )
-    assert full_interval_analytic == pytest.approx(full_interval_numeric, 1e-4)
-    assert full_interval_analytic == pytest.approx(numba_stats_full_integral, 1e-6)
-    assert full_interval_numeric == pytest.approx(numba_stats_full_integral, 1e-6)
+    assert pytest.approx(full_interval_numeric, 1e-4) == full_interval_analytic
+    assert pytest.approx(numba_stats_full_integral, 1e-6) == full_interval_analytic
+    assert pytest.approx(numba_stats_full_integral, 1e-6) == full_interval_numeric
 
     analytic_integral = bernstein.analytic_integrate(limits=(0.6, 0.9), norm=False).numpy()
     numeric_integral = bernstein.numeric_integrate(limits=(0.6, 0.9), norm=False).numpy()
     numba_stats_integral = bernstein_numba.integral(x=0.9, beta=coeffs, xmin=lower, xmax=upper) - bernstein_numba.integral(
         x=0.6, beta=coeffs, xmin=lower, xmax=upper
     )
-    assert analytic_integral == pytest.approx(numeric_integral, 1e-5)
-    assert analytic_integral == pytest.approx(numba_stats_integral, 1e-5)
-    assert numeric_integral == pytest.approx(numba_stats_integral, 1e-5)
+    assert pytest.approx(numeric_integral, 1e-5) == analytic_integral
+    assert pytest.approx(numba_stats_integral, 1e-5) == analytic_integral
+    assert pytest.approx(numba_stats_integral, 1e-5) == numeric_integral

--- a/tests/test_pdf_qgauss.py
+++ b/tests/test_pdf_qgauss.py
@@ -23,27 +23,27 @@ def create_qgauss(q, mu, sigma, limits):
 def test_qgauss_pdf(q):
     qgauss, _ = create_qgauss(q=q, mu=mu_true, sigma=sigma_true, limits=(-5, 5))
     assert pytest.approx(
-        qgaussian_numba.pdf(0.5, q=q, mu=mu_true, sigma=sigma_true), rel=1e-5
+        np.atleast_1d(qgaussian_numba.pdf(0.5, q=q, mu=mu_true, sigma=sigma_true)), rel=1e-5
     ) == qgauss.pdf(0.5, norm=False)
-    test_values = tf.range(-5, 5, 10_000)
+    test_values = znp.linspace(-5, 5, 10_000)
     np.testing.assert_allclose(
         qgauss.pdf(test_values, norm=False),
         qgaussian_numba.pdf(test_values, q=q, mu=mu_true, sigma=sigma_true),
         rtol=1e-5,
     )
-    assert qgauss.pdf(test_values, norm=False) <= qgauss.pdf(0.5, norm=False)
+    assert np.all(qgauss.pdf(test_values, norm=False) <= qgauss.pdf(0.5, norm=False))
 
     sample = qgauss.sample(1000)
-    assert all(np.isfinite(sample.value())), "Some samples from the qgauss PDF are NaN or infinite"
+    assert np.all(np.isfinite(sample.value())), "Some samples from the qgauss PDF are NaN or infinite"
     assert sample.n_events == 1000
-    assert all(tf.logical_and(-5 <= sample.value(), sample.value() <= 5))
+    assert np.all(tf.logical_and(-5 <= sample.value(), sample.value() <= 5))
 
 
 @pytest.mark.parametrize("q", [1.00001, 1.5, 2.0, 2.5, 2.9, 2.99])
 def test_qgauss_integral(q):
     qgauss, obs = create_qgauss(q=q, mu=mu_true, sigma=sigma_true, limits=(-5, 5))
-    full_interval_analytic = qgauss.analytic_integrate(obs, norm=False).numpy()
-    full_interval_numeric = qgauss.numeric_integrate(obs, norm=False).numpy()
+    full_interval_analytic = qgauss.analytic_integrate(obs, norm=False)
+    full_interval_numeric = qgauss.numeric_integrate(obs, norm=False)
     true_integral = true_integral_dict[q]
     numba_stats_full_integral = qgaussian_numba.cdf(5, q=q, mu=mu_true, sigma=sigma_true) - qgaussian_numba.cdf(
         -5, q=q, mu=mu_true, sigma=sigma_true
@@ -53,8 +53,8 @@ def test_qgauss_integral(q):
     assert pytest.approx(numba_stats_full_integral, 1e-6) == full_interval_analytic
     assert pytest.approx(numba_stats_full_integral, 1e-6) == full_interval_numeric
 
-    analytic_integral = qgauss.analytic_integrate(limits=(-1, 1), norm=False).numpy()
-    numeric_integral = qgauss.numeric_integrate(limits=(-1, 1), norm=False).numpy()
+    analytic_integral = qgauss.analytic_integrate(limits=(-1, 1), norm=False)
+    numeric_integral = qgauss.numeric_integrate(limits=(-1, 1), norm=False)
     numba_stats_integral = qgaussian_numba.cdf(1, q=q, mu=mu_true, sigma=sigma_true) - qgaussian_numba.cdf(
         -1, q=q, mu=mu_true, sigma=sigma_true
     )

--- a/tests/test_pdf_qgauss.py
+++ b/tests/test_pdf_qgauss.py
@@ -22,12 +22,12 @@ def create_qgauss(q, mu, sigma, limits):
 @pytest.mark.parametrize("q", [1.00001, 1.5, 2.0, 2.5, 2.9, 2.99])
 def test_qgauss_pdf(q):
     qgauss, _ = create_qgauss(q=q, mu=mu_true, sigma=sigma_true, limits=(-5, 5))
-    assert qgauss.pdf(0.5, norm=False).numpy().item() == pytest.approx(
+    assert pytest.approx(
         qgaussian_numba.pdf(0.5, q=q, mu=mu_true, sigma=sigma_true), rel=1e-5
-    )
+    ) == qgauss.pdf(0.5, norm=False)
     test_values = tf.range(-5, 5, 10_000)
     np.testing.assert_allclose(
-        qgauss.pdf(test_values, norm=False).numpy(),
+        qgauss.pdf(test_values, norm=False),
         qgaussian_numba.pdf(test_values, q=q, mu=mu_true, sigma=sigma_true),
         rtol=1e-5,
     )
@@ -48,15 +48,15 @@ def test_qgauss_integral(q):
     numba_stats_full_integral = qgaussian_numba.cdf(5, q=q, mu=mu_true, sigma=sigma_true) - qgaussian_numba.cdf(
         -5, q=q, mu=mu_true, sigma=sigma_true
     )
-    assert full_interval_analytic == pytest.approx(true_integral, 1e-4)
-    assert full_interval_numeric == pytest.approx(true_integral, 1e-4)
-    assert full_interval_analytic == pytest.approx(numba_stats_full_integral, 1e-6)
-    assert full_interval_numeric == pytest.approx(numba_stats_full_integral, 1e-6)
+    assert pytest.approx(true_integral, 1e-4) == full_interval_analytic
+    assert pytest.approx(true_integral, 1e-4) == full_interval_numeric
+    assert pytest.approx(numba_stats_full_integral, 1e-6) == full_interval_analytic
+    assert pytest.approx(numba_stats_full_integral, 1e-6) == full_interval_numeric
 
     analytic_integral = qgauss.analytic_integrate(limits=(-1, 1), norm=False).numpy()
     numeric_integral = qgauss.numeric_integrate(limits=(-1, 1), norm=False).numpy()
     numba_stats_integral = qgaussian_numba.cdf(1, q=q, mu=mu_true, sigma=sigma_true) - qgaussian_numba.cdf(
         -1, q=q, mu=mu_true, sigma=sigma_true
     )
-    assert analytic_integral == pytest.approx(numeric_integral, 1e-5)
-    assert analytic_integral == pytest.approx(numba_stats_integral, 1e-5)
+    assert pytest.approx(numeric_integral, 1e-5) == analytic_integral
+    assert pytest.approx(numba_stats_integral, 1e-5) == analytic_integral

--- a/tests/test_pdf_studentt.py
+++ b/tests/test_pdf_studentt.py
@@ -22,5 +22,5 @@ def test_studentt():
 
     assert np.all(np.isfinite(probs))
     assert np.all(probs>=0)
-    assert float(znp.mean(samples)) == pytest.approx(2, rel=1e-2)
-    assert float(znp.std(samples)) == pytest.approx(np.sqrt(N_true / (N_true - 2)), rel=1e-2)
+    assert pytest.approx(2, rel=1e-2) == znp.mean(samples)
+    assert pytest.approx(np.sqrt(N_true / (N_true - 2)), rel=1e-2) == znp.std(samples)

--- a/tests/test_pdf_studentt.py
+++ b/tests/test_pdf_studentt.py
@@ -18,7 +18,7 @@ def test_studentt():
     t = zfit.pdf.StudentT(ndof=N, mu=mu, sigma=sigma, obs=obs)
     test_values = np.random.uniform(low=-10.0, high=10.0, size=1000)
     samples = t.sample(100_000)["obs"]
-    probs = t.pdf(x=test_values).numpy()
+    probs = t.pdf(x=test_values)
 
     assert np.all(np.isfinite(probs))
     assert np.all(probs>=0)

--- a/tests/test_pdf_sumpdf.py
+++ b/tests/test_pdf_sumpdf.py
@@ -1,10 +1,11 @@
-#  Copyright (c) 2023 zfit
+#  Copyright (c) 2024 zfit
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import scipy.stats
 
 import zfit
+import zfit.z.numpy as znp
 from zfit.util.exception import SpecificFunctionNotImplemented
 
 
@@ -95,11 +96,11 @@ def test_sampling():
     sample = sumpdf.sample(sample_size).value().numpy()[:, 0]
     sample_true = sumpdf_true.sample(sample_size).value().numpy()[:, 0]
 
-    assert true_mu == pytest.approx(
+    assert pytest.approx(
         np.mean(sample_true), abs=tol
-    )  # if this is not True, it's a problem, the test is flawed
-    assert true_mu == pytest.approx(np.mean(sample), abs=tol)
-    assert np.std(sample_true) == pytest.approx(np.std(sample), abs=tol)
+    ) == true_mu  # if this is not True, it's a problem, the test is flawed
+    assert pytest.approx(np.mean(sample), abs=tol) == true_mu
+    assert pytest.approx(np.std(sample), abs=tol) == np.std(sample_true)
 
     plt.figure()
     plt.title("Sampling of SumPDF")
@@ -137,33 +138,33 @@ def test_integrate():
 
     sumpdf = zfit.pdf.SumPDF([gauss1, gauss2], frac)
     sumpdf_true = SimpleSampleSumPDF([gauss1, gauss2], frac)
-    assert zfit.run(
+    assert pytest.approx(1, abs=0.01) == (
         gauss1.integrate(
             limits,
             norm=limits,
         )
-    ) == pytest.approx(1, abs=0.01)
+    )
     integral = sumpdf.integrate(
         limits=limits,
         norm=False,
-    ).numpy()
+    )
     integral_true = sumpdf_true.integrate(
         limits=limits,
         norm=False,
-    ).numpy()
+    )
     integral_manual_true = gauss1.integrate(
         limits,
     ) * frac + gauss2.integrate(
         limits,
     ) * (1 - frac)
 
-    assert integral_true == pytest.approx(integral_manual_true.numpy(), rel=0.03)
-    assert integral_true == pytest.approx(integral, rel=0.03)
+    assert pytest.approx(integral_manual_true, rel=0.03) == integral_true
+    assert pytest.approx(integral, rel=0.03) == integral_true
     assert integral_true < 0.85
 
-    analytic_integral = sumpdf.analytic_integrate(limits=limits, norm=False).numpy()
+    analytic_integral = sumpdf.analytic_integrate(limits=limits, norm=False)
 
-    assert integral_true == pytest.approx(analytic_integral, rel=0.03)
+    assert pytest.approx(analytic_integral, rel=0.03) == integral_true
 
     rnd_limits = [lower] + sorted(np.random.uniform(lower, upper, 16)) + [upper]
     integrals = [
@@ -172,5 +173,5 @@ def test_integrate():
     ]
 
     integral = np.sum(integrals)
-    integral_full = zfit.run(sumpdf.integrate((lower, upper), norm=False))
-    assert pytest.approx(float(integral_full)) == float(integral)
+    integral_full = sumpdf.integrate((lower, upper), norm=False)
+    assert pytest.approx(integral_full) == integral

--- a/tests/test_pdf_sumpdf.py
+++ b/tests/test_pdf_sumpdf.py
@@ -48,7 +48,7 @@ def test_frac_behavior(yields):
 
         frac2_val = 1 - frac1.value()
         assert (
-            pytest.approx(frac2_val.numpy()) == sumpdf1.params["frac_1"].value().numpy()
+            pytest.approx(frac2_val) == sumpdf1.params["frac_1"].value()
         )
         if isinstance(fracs, list) and len(fracs) == 2:
             assert sumpdf1.params["frac_1"] == frac2
@@ -64,8 +64,8 @@ def test_frac_behavior(yields):
         assert sumpdf2.params["frac_0"] == frac1
         assert sumpdf2.params["frac_1"] == frac2
         assert (
-            pytest.approx(frac3.value().numpy())
-            == sumpdf2.params["frac_2"].value().numpy()
+            pytest.approx(frac3.value())
+            == sumpdf2.params["frac_2"].value()
         )
         assert not sumpdf1.is_extended
 
@@ -93,8 +93,8 @@ def test_sampling():
     sumpdf = zfit.pdf.SumPDF([gauss1, gauss2], frac)
     sumpdf_true = SimpleSampleSumPDF([gauss1, gauss2], frac)
 
-    sample = sumpdf.sample(sample_size).value().numpy()[:, 0]
-    sample_true = sumpdf_true.sample(sample_size).value().numpy()[:, 0]
+    sample = sumpdf.sample(sample_size).value()[:, 0]
+    sample_true = sumpdf_true.sample(sample_size).value()[:, 0]
 
     assert pytest.approx(
         np.mean(sample_true), abs=tol

--- a/tests/test_pdf_template.py
+++ b/tests/test_pdf_template.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023 zfit
+#  Copyright (c) 2024 zfit
 
 import mplhep
 import numpy as np
@@ -177,7 +177,7 @@ def test_morphing_templates2D(alphas):
     for i, a in enumerate(alphas):
         alpha.set_value(a)
         np.testing.assert_allclose(morph.counts(), counts[i])
-        assert pytest.approx(np.sum(counts[i])) == zfit.run(morph.get_yield())
+        assert pytest.approx(np.sum(counts[i])) == znp.asarray(morph.get_yield())
         if len(alphas) > i + 1:
             alpha.set_value((a + alphas[i + 1]) / 2)
             max_dist = (counts[i] - counts[i + 1]) ** 2 + 5  # tolerance

--- a/tests/test_pdfs.py
+++ b/tests/test_pdfs.py
@@ -218,12 +218,11 @@ def test_prod_gauss_nd(binned):
     true_probs = np.prod(
         [gauss.pdf(test_values[:, i]) for i, gauss in enumerate(gaussians)], axis=0
     )
-    probs_np = probs.numpy()
 
     rtol = 1e-5
     if binned:
         rtol = 0.1  # we bin it, so we don't expect a high precision
-    np.testing.assert_allclose(true_probs, probs_np, rtol=rtol)
+    np.testing.assert_allclose(true_probs, probs, rtol=rtol)
 
 
 @pytest.mark.flaky(reruns=3)
@@ -305,14 +304,12 @@ def test_exp():
     lambda_true = 0.031
     lambda_ = zfit.Parameter("lambda1", lambda_true)
     exp1 = zfit.pdf.Exponential(lam=lambda_, obs=zfit.Space("obs1", (-11, 11)))
-    sample = exp1.sample(n=1000, limits=(-10, 10))
-    sample_np = sample.numpy()
-    assert not any(np.isnan(sample_np))
+    sample = exp1.sample(n=1000, limits=(-10, 10)).value()
+    assert not any(np.isnan(sample))
 
     exp2 = zfit.pdf.Exponential(lam=lambda_, obs=zfit.Space("obs1", (5250, 5750)))
     probs2 = exp2.pdf(x=np.linspace(5300, 5700, num=1100))
-    probs2_np = probs2.numpy()
-    assert not any(np.isnan(probs2_np))
+    assert not any(np.isnan(probs2))
     normalization_testing(exp2, limits=(5400, 5800))
 
     intlim = [5400, 5500]
@@ -337,8 +334,7 @@ def normalization_testing(pdf, limits=None):
 
         samples = zfit.Data.from_tensor(obs=space, tensor=samples)
         probs = pdf.pdf(samples)
-        result = probs.numpy()
-        result = znp.asarray(np.average(result) * space._legacy_area())
+        result = znp.asarray(np.average(probs) * space._legacy_area())
         assert pytest.approx(result, rel=0.03) == 1
 
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -142,10 +142,10 @@ def test_multiple_limits_sampling(gauss_factory):
     sample2 = gauss.sample(n=n, limits=obs_split)
 
     rel_tol = 1e-2
-    assert float(np.mean(sample1.value())) == pytest.approx(mu_true, rel_tol)
-    assert float(np.std(sample1.value())) == pytest.approx(sigma_true, rel_tol)
-    assert float(np.mean(sample2.value())) == pytest.approx(mu_true, rel_tol)
-    assert float(np.std(sample2.value())) == pytest.approx(sigma_true, rel_tol)
+    assert pytest.approx(mu_true, rel_tol) == (np.mean(sample1.value()))
+    assert pytest.approx(sigma_true, rel_tol) == (np.std(sample1.value()))
+    assert pytest.approx(mu_true, rel_tol) == (np.mean(sample2.value()))
+    assert pytest.approx(sigma_true, rel_tol) == (np.std(sample2.value()))
 
 
 @pytest.mark.parametrize(
@@ -175,8 +175,8 @@ def test_sampling_fixed(gauss_factory):
     sampled_gauss1_full = gauss_full_sample.numpy()
     mu_sampled = np.mean(sampled_gauss1_full)
     sigma_sampled = np.std(sampled_gauss1_full)
-    assert mu_sampled == pytest.approx(mu_true, rel=0.07)
-    assert sigma_sampled == pytest.approx(sigma_true, rel=0.07)
+    assert pytest.approx(mu_true, rel=0.07) == mu_sampled
+    assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled
 
     with mu.set_value(mu_true - 1):
         sample_tensor.resample()
@@ -188,8 +188,8 @@ def test_sampling_fixed(gauss_factory):
         sampled_gauss1_full = gauss_full_sample.numpy()
         mu_sampled = np.mean(sampled_gauss1_full)
         sigma_sampled = np.std(sampled_gauss1_full)
-        assert mu_sampled == pytest.approx(mu_true, rel=0.07)
-        assert sigma_sampled == pytest.approx(sigma_true, rel=0.07)
+        assert pytest.approx(mu_true, rel=0.07) == mu_sampled
+        assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled
 
     gauss_full_sample2 = gauss.create_sampler(n=10000, limits=(-10, 10))
 
@@ -197,15 +197,15 @@ def test_sampling_fixed(gauss_factory):
     sampled_gauss2_full = gauss_full_sample2.value()
     mu_sampled = np.mean(sampled_gauss2_full)
     sigma_sampled = np.std(sampled_gauss2_full)
-    assert mu_sampled == pytest.approx(mu_true - 1.0, rel=0.08)
-    assert sigma_sampled == pytest.approx(sigma_true, rel=0.08)
+    assert pytest.approx(mu_true - 1.0, rel=0.08) == mu_sampled
+    assert pytest.approx(sigma_true, rel=0.08) == sigma_sampled
 
     gauss_full_sample2.resample(params={sigma: sigma_true + 1.0})
     sampled_gauss2_full = gauss_full_sample2.numpy()
     mu_sampled = np.mean(sampled_gauss2_full)
     sigma_sampled = np.std(sampled_gauss2_full)
-    assert mu_sampled == pytest.approx(mu_true, rel=0.07)
-    assert sigma_sampled == pytest.approx(sigma_true + 1.0, rel=0.07)
+    assert pytest.approx(mu_true, rel=0.07) == mu_sampled
+    assert pytest.approx(sigma_true + 1.0, rel=0.07) == sigma_sampled
 
 
 @pytest.mark.parametrize("gauss_factory", gaussian_dists)
@@ -236,14 +236,14 @@ def test_sampling_floating(gauss_factory):
     sampled_gauss1_full = gauss_full_sample.numpy()
     mu_sampled = np.mean(sampled_gauss1_full)
     sigma_sampled = np.std(sampled_gauss1_full)
-    assert mu_sampled == pytest.approx(mu_true, rel=0.07)
-    assert sigma_sampled == pytest.approx(sigma_true, rel=0.07)
+    assert pytest.approx(mu_true, rel=0.07) == mu_sampled
+    assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled
 
     sampled_gauss1_full_fixed = gauss_full_sample_fixed.numpy()
     mu_sampled_fixed = np.mean(sampled_gauss1_full_fixed)
     sigma_sampled_fixed = np.std(sampled_gauss1_full_fixed)
-    assert mu_sampled_fixed == pytest.approx(mu_true, rel=0.07)
-    assert sigma_sampled_fixed == pytest.approx(sigma_true, rel=0.07)
+    assert pytest.approx(mu_true, rel=0.07) == mu_sampled_fixed
+    assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled_fixed
 
     mu_diff = 0.7
     new_muval = mu_true - mu_diff
@@ -258,15 +258,16 @@ def test_sampling_floating(gauss_factory):
         sampled_gauss1_full_fixed = gauss_full_sample_fixed.numpy()
         mu_sampled_fixed = np.mean(sampled_gauss1_full_fixed)
         sigma_sampled_fixed = np.std(sampled_gauss1_full_fixed)
-        assert mu_sampled_fixed == pytest.approx(mu_true, rel=0.07)
-        assert sigma_sampled_fixed == pytest.approx(sigma_true, rel=0.07)
+        assert pytest.approx(mu_true, rel=0.07) == mu_sampled_fixed
+        assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled_fixed
 
         gauss_full_sample.resample({mu: new_muval})
         sampled_gauss1_full = gauss_full_sample.numpy()
         mu_sampled = np.mean(sampled_gauss1_full)
         sigma_sampled = np.std(sampled_gauss1_full)
-        assert mu_sampled == pytest.approx(new_muval, rel=0.07)
-        assert sigma_sampled == pytest.approx(sigma_true, rel=0.07)
+        assert pytest.approx(new_muval, rel=0.07) == mu_sampled
+        assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled
+
 
 @pytest.mark.parametrize("gauss_binnedfactory", gaussian_binneddists)
 def test_binned_sampling_floating(gauss_binnedfactory):
@@ -296,14 +297,13 @@ def test_binned_sampling_floating(gauss_binnedfactory):
     mu_sampled = np.average(centers, weights=sampled_gauss1_full)
     sigma_sampled = np.sqrt(np.cov(centers, aweights=sampled_gauss1_full))
 
-    assert mu_sampled == pytest.approx(mu_true, rel=0.07)
-    assert sigma_sampled == pytest.approx(sigma_true, rel=0.07)
-
+    assert pytest.approx(mu_true, rel=0.07) == mu_sampled
+    assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled
 
     mu_sampled_fixed = np.average(centers, weights=gauss_full_sample_fixed.counts())
     sigma_sampled_fixed = np.sqrt(np.cov(centers, aweights=gauss_full_sample_fixed.counts()))
-    assert mu_sampled_fixed == pytest.approx(mu_true, rel=0.07)
-    assert sigma_sampled_fixed == pytest.approx(sigma_true, rel=0.07)
+    assert pytest.approx(mu_true, rel=0.07) == mu_sampled_fixed
+    assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled_fixed
 
     mu_diff = 0.7
     new_muval = mu_true - mu_diff
@@ -315,14 +315,14 @@ def test_binned_sampling_floating(gauss_binnedfactory):
 
         mu_sampled_fixed = np.average(centers, weights=sampler.counts())
         sigma_sampled_fixed = std(centers, weights=sampler.counts())
-        assert mu_sampled_fixed == pytest.approx(mu_true, rel=0.07)
-        assert sigma_sampled_fixed == pytest.approx(sigma_true, rel=0.07)
+        assert pytest.approx(mu_true, rel=0.07) == mu_sampled_fixed
+        assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled_fixed
 
         gauss_full_sample.resample({mu: new_muval})
         mu_sampled_fixed = np.average(centers, weights=gauss_full_sample.counts())
         sigma_sampled_fixed = std(centers, weights=gauss_full_sample.counts())
-        assert mu_sampled_fixed == pytest.approx(new_muval, rel=0.07)
-        assert sigma_sampled_fixed == pytest.approx(sigma_true, rel=0.07)
+        assert pytest.approx(new_muval, rel=0.07) == mu_sampled_fixed
+        assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled_fixed
 
 
 # @pytest.mark.skipif(not zfit.EXPERIMENTAL_FUNCTIONS_RUN_EAGERLY, reason="deadlock in tf.function, issue #35540")  # currently, importance sampling is not working, odd deadlock in TF
@@ -377,10 +377,10 @@ def test_importance_sampling(n):
         mean2 = np.mean(sample_np2)
         std = np.std(sample_np)
         std2 = np.std(sample_np2)
-        assert mean == pytest.approx(mu_pdf, rel=0.02)
-        assert mean2 == pytest.approx(mu_pdf, rel=0.02)
-        assert std == pytest.approx(sigma_pdf, rel=0.02)
-        assert std2 == pytest.approx(sigma_pdf, rel=0.02)
+        assert pytest.approx(mu_pdf, rel=0.02) == mean
+        assert pytest.approx(mu_pdf, rel=0.02) == mean2
+        assert pytest.approx(sigma_pdf, rel=0.02) == std
+        assert pytest.approx(sigma_pdf, rel=0.02) == std2
 
 
 @pytest.mark.flaky(3)  # statistical

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -157,14 +157,14 @@ def test_sampling_fixed(gauss_factory):
     n_draws = 1000
     sample_tensor = gauss.create_sampler(n=n_draws, limits=(low, high))
     sample_tensor.resample()
-    sampled_from_gauss1 = sample_tensor.numpy()
+    sampled_from_gauss1 = sample_tensor.value()
     assert max(sampled_from_gauss1[:, 0]) <= high
     assert min(sampled_from_gauss1[:, 0]) >= low
     assert n_draws == len(sampled_from_gauss1[:, 0])
 
     new_n_draws = 867
     sample_tensor.resample(n=new_n_draws)
-    sampled_from_gauss1_small = sample_tensor.numpy()
+    sampled_from_gauss1_small = sample_tensor.value()
     assert new_n_draws == len(sampled_from_gauss1_small[:, 0])
     assert not np.allclose(sampled_from_gauss1[:new_n_draws], sampled_from_gauss1_small)
 
@@ -172,7 +172,7 @@ def test_sampling_fixed(gauss_factory):
         n=10000, limits=(mu_true - abs(sigma_true) * 3, mu_true + abs(sigma_true) * 3)
     )
     gauss_full_sample.resample()
-    sampled_gauss1_full = gauss_full_sample.numpy()
+    sampled_gauss1_full = gauss_full_sample.value()
     mu_sampled = np.mean(sampled_gauss1_full)
     sigma_sampled = np.std(sampled_gauss1_full)
     assert pytest.approx(mu_true, rel=0.07) == mu_sampled
@@ -180,12 +180,12 @@ def test_sampling_fixed(gauss_factory):
 
     with mu.set_value(mu_true - 1):
         sample_tensor.resample()
-        sampled_from_gauss1 = sample_tensor.numpy()
+        sampled_from_gauss1 = sample_tensor.value()
         assert max(sampled_from_gauss1[:, 0]) <= high
         assert min(sampled_from_gauss1[:, 0]) >= low
         assert n_draws == len(sampled_from_gauss1[:, 0])
 
-        sampled_gauss1_full = gauss_full_sample.numpy()
+        sampled_gauss1_full = gauss_full_sample.value()
         mu_sampled = np.mean(sampled_gauss1_full)
         sigma_sampled = np.std(sampled_gauss1_full)
         assert pytest.approx(mu_true, rel=0.07) == mu_sampled
@@ -201,7 +201,7 @@ def test_sampling_fixed(gauss_factory):
     assert pytest.approx(sigma_true, rel=0.08) == sigma_sampled
 
     gauss_full_sample2.resample(params={sigma: sigma_true + 1.0})
-    sampled_gauss2_full = gauss_full_sample2.numpy()
+    sampled_gauss2_full = gauss_full_sample2.value()
     mu_sampled = np.mean(sampled_gauss2_full)
     sigma_sampled = np.std(sampled_gauss2_full)
     assert pytest.approx(mu_true, rel=0.07) == mu_sampled
@@ -233,13 +233,13 @@ def test_sampling_floating(gauss_factory):
     gauss_full_sample.resample()
     gauss_full_sample_fixed.resample()
     assert gauss_full_sample_fixed.params == {mu.name: mu_true, sigma.name: sigma_true}
-    sampled_gauss1_full = gauss_full_sample.numpy()
+    sampled_gauss1_full = gauss_full_sample.value()
     mu_sampled = np.mean(sampled_gauss1_full)
     sigma_sampled = np.std(sampled_gauss1_full)
     assert pytest.approx(mu_true, rel=0.07) == mu_sampled
     assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled
 
-    sampled_gauss1_full_fixed = gauss_full_sample_fixed.numpy()
+    sampled_gauss1_full_fixed = gauss_full_sample_fixed.value()
     mu_sampled_fixed = np.mean(sampled_gauss1_full_fixed)
     sigma_sampled_fixed = np.std(sampled_gauss1_full_fixed)
     assert pytest.approx(mu_true, rel=0.07) == mu_sampled_fixed
@@ -248,21 +248,21 @@ def test_sampling_floating(gauss_factory):
     mu_diff = 0.7
     new_muval = mu_true - mu_diff
     with mu.set_value(new_muval):
-        assert mu.numpy() == new_muval
+        assert mu.value() == new_muval
         sampler.resample()
-        sampled_from_gauss1 = sampler.numpy()
+        sampled_from_gauss1 = sampler.value()
         assert max(sampled_from_gauss1[:, 0]) <= high
         assert min(sampled_from_gauss1[:, 0]) >= low
         assert n_draws == len(sampled_from_gauss1[:, 0])
 
-        sampled_gauss1_full_fixed = gauss_full_sample_fixed.numpy()
+        sampled_gauss1_full_fixed = gauss_full_sample_fixed.value()
         mu_sampled_fixed = np.mean(sampled_gauss1_full_fixed)
         sigma_sampled_fixed = np.std(sampled_gauss1_full_fixed)
         assert pytest.approx(mu_true, rel=0.07) == mu_sampled_fixed
         assert pytest.approx(sigma_true, rel=0.07) == sigma_sampled_fixed
 
         gauss_full_sample.resample({mu: new_muval})
-        sampled_gauss1_full = gauss_full_sample.numpy()
+        sampled_gauss1_full = gauss_full_sample.value()
         mu_sampled = np.mean(sampled_gauss1_full)
         sigma_sampled = np.std(sampled_gauss1_full)
         assert pytest.approx(new_muval, rel=0.07) == mu_sampled
@@ -308,7 +308,7 @@ def test_binned_sampling_floating(gauss_binnedfactory):
     mu_diff = 0.7
     new_muval = mu_true - mu_diff
     with mu.set_value(new_muval):
-        assert mu.numpy() == new_muval
+        assert mu.value() == new_muval
         sampler.resample()
         assert n_draws == np.sum(sampler.counts())
 
@@ -371,12 +371,11 @@ def test_importance_sampling(n):
     assert sample.shape == sample2.value().shape
     assert sample.shape == (n, 1)
     if n > 1000:
-        sample_np, sample_np2 = [sample.numpy(), sample2.numpy()]
 
-        mean = np.mean(sample_np)
-        mean2 = np.mean(sample_np2)
-        std = np.std(sample_np)
-        std2 = np.std(sample_np2)
+        mean = np.mean(sample)
+        mean2 = np.mean(sample)
+        std = np.std(sample)
+        std2 = np.std(sample)
         assert pytest.approx(mu_pdf, rel=0.02) == mean
         assert pytest.approx(mu_pdf, rel=0.02) == mean2
         assert pytest.approx(sigma_pdf, rel=0.02) == std
@@ -410,9 +409,8 @@ def test_importance_sampling_uniform():
     n_sample = 10000
     sample = uniform.sample(n=n_sample)
     assert importance_sampling_called[0]
-    sample_np = sample.numpy()
     n_bins = 20
-    bin_counts, _ = np.histogram(sample_np, bins=n_bins)
+    bin_counts, _ = np.histogram(sample.value(), bins=n_bins)
     expected_per_bin = n_sample / n_bins
 
     assert np.std(bin_counts) < np.sqrt(expected_per_bin) * 2
@@ -446,15 +444,14 @@ def test_sampling_fixed_eventlimits():
         mu=0.3, sigma=4, obs=zfit.Space(obs=obs1, limits=(-12, 12))
     )
 
-    sample = gauss1.sample(n=n_samples_tot, limits=limits)
-    sample_np = sample.numpy()
-    assert sample_np.shape[0] == n_samples_tot
-    assert all(lower1 <= sample_np[:n_samples1])
-    assert all(sample_np[:n_samples1] <= upper1)
-    assert all(lower2 <= sample_np[n_samples1:n_samples2])
-    assert all(sample_np[n_samples1:n_samples2] <= upper2)
-    assert all(lower3 <= sample_np[n_samples2:n_samples3])
-    assert all(sample_np[n_samples2:n_samples3] <= upper3)
+    sample = gauss1.sample(n=n_samples_tot, limits=limits).value()
+    assert sample.shape[0] == n_samples_tot
+    assert all(lower1 <= sample[:n_samples1])
+    assert all(sample[:n_samples1] <= upper1)
+    assert all(lower2 <= sample[n_samples1:n_samples2])
+    assert all(sample[n_samples1:n_samples2] <= upper2)
+    assert all(lower3 <= sample[n_samples2:n_samples3])
+    assert all(sample[n_samples2:n_samples3] <= upper3)
     # with pytest.raises(InvalidArgumentError):  # cannot use the exact message, () are regex syntax... bug in pytest
     #     _ = gauss1.sample(n=n_samples_tot + 1, limits=limits)  # TODO(Mayou36): catch analytic integral
 

--- a/tests/test_simple_subclass.py
+++ b/tests/test_simple_subclass.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023 zfit
+#  Copyright (c) 2024 zfit
 
 import numpy as np
 import pytest
@@ -21,7 +21,6 @@ def test_pdf_simple_subclass():
     gauss1 = SimpleGauss(obs="obs1", mu=3, sigma=5)
 
     prob = gauss1.pdf(np.random.random(size=(10, 1)), norm=False)
-    prob.numpy()
 
     with pytest.raises(ValueError):
         gauss2 = SimpleGauss("obs1", 1.0, sigma=5.0)

--- a/tests/test_space_0.py
+++ b/tests/test_space_0.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import zfit
+import zfit.z.numpy as znp
 from zfit.core.space import Space, convert_to_space
 from zfit.util.exception import (
     CoordinatesUnderdefinedError,
@@ -80,9 +81,9 @@ def test_equality(space1, space2):
     assert space1.axes == space2.axes
     assert space1.obs == space2.obs
     np.testing.assert_allclose(space1.v1.limits, space2.v1.limits)
-    assert zfit.run(space1._legacy_area()) == pytest.approx(
-        zfit.run(space2._legacy_area()), rel=1e-8
-    )
+    assert pytest.approx(
+        (space2._legacy_area()), rel=1e-8
+    ) == (space1._legacy_area())
 
 
 # @pytest.mark.skip  # eq missing

--- a/tests/test_tfext.py
+++ b/tests/test_tfext.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023 zfit
+#  Copyright (c) 2024 zfit
 
 
 # deactivating CUDA capable gpus
@@ -27,7 +27,7 @@ def test_polynomial():
     polynom_np = np.polyval(coeffs[::-1], 5.0)
 
     result = polynom_tf.numpy()
-    assert result == pytest.approx(polynom_np, rel=prec)
+    assert pytest.approx(polynom_np, rel=prec) == result
 
 
 def test_auto_upcast():

--- a/tests/test_tfext.py
+++ b/tests/test_tfext.py
@@ -26,8 +26,7 @@ def test_polynomial():
     polynom_tf = zfit.z.math.poly_complex(*coeffs, x)
     polynom_np = np.polyval(coeffs[::-1], 5.0)
 
-    result = polynom_tf.numpy()
-    assert pytest.approx(polynom_np, rel=prec) == result
+    assert pytest.approx(polynom_np, rel=prec) == polynom_tf
 
 
 def test_auto_upcast():

--- a/tests/test_z_random.py
+++ b/tests/test_z_random.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022 zfit
+#  Copyright (c) 2024 zfit
 
 import numpy as np
 import pytest
@@ -21,9 +21,9 @@ def test_counts_multinomial():
 
     assert (3,) == counts_np[0].shape
     assert all(total_count == np.sum(counts_np, axis=1))
-    probs_scaled = np.array(probs) * total_count
-    assert probs_scaled == pytest.approx(mean, rel=0.05)
-    assert [9, 14, 16] == pytest.approx(std, rel=0.5)  # flaky
+    probs_scaled = probs * total_count
+    assert pytest.approx(mean, rel=0.05) == probs_scaled
+    assert pytest.approx(std, rel=0.5) == [9, 14, 16]  # flaky
 
     total_count2 = 5000
     counts_np2 = [

--- a/tests/test_z_random.py
+++ b/tests/test_z_random.py
@@ -9,11 +9,11 @@ from zfit import z
 
 @pytest.mark.flaky(2)
 def test_counts_multinomial():
-    probs = [0.1, 0.3, 0.6]
+    probs = np.array([0.1, 0.3, 0.6])
     total_count = 1000.0
     total_count_var = tf.Variable(total_count, trainable=False)
     counts_np = [
-        z.random.counts_multinomial(total_count=total_count_var, probs=probs).numpy()
+        z.random.counts_multinomial(total_count=total_count_var, probs=probs)
         for _ in range(20)
     ]
     mean = np.mean(counts_np, axis=0)
@@ -27,7 +27,7 @@ def test_counts_multinomial():
 
     total_count2 = 5000
     counts_np2 = [
-        z.random.counts_multinomial(total_count=total_count2, probs=probs).numpy()
+        z.random.counts_multinomial(total_count=total_count2, probs=probs)
         for _ in range(3)
     ]
     mean2 = np.mean(counts_np2, axis=0)
@@ -42,7 +42,7 @@ def test_counts_multinomial():
         z.random.counts_multinomial(
             total_count=total_count3,  # sigmoid: inverse of logits (softmax)
             logits=probs * 30,
-        ).numpy()
+        )
         for _ in range(5)
     ]
 

--- a/zfit/core/basemodel.py
+++ b/zfit/core/basemodel.py
@@ -548,7 +548,8 @@ class BaseModel(BaseNumeric, GraphCachable, BaseDimensional, ZfitModel):
         norm = self._check_input_norm(norm)
         limits = self._check_input_limits(limits=limits)
         with self._check_set_input_params(params=params):
-            return self._single_hook_analytic_integrate(limits=limits, norm=norm)
+            integral = self._single_hook_analytic_integrate(limits=limits, norm=norm)
+        return znp.atleast_1d(integral)
 
     def _single_hook_analytic_integrate(self, limits, norm):
         return self._hook_analytic_integrate(limits=limits, norm=norm)

--- a/zfit/core/basepdf.py
+++ b/zfit/core/basepdf.py
@@ -459,7 +459,7 @@ class BasePDF(ZfitPDF, BaseModel, metaclass=PDFMeta):
             value = self._single_hook_pdf(x=x, norm=norm)
         if run.numeric_checks:
             z.check_numerics(value, message="Check if pdf output contains any NaNs of Infs")
-        return znp.asarray(z.to_real(value))
+        return znp.atleast_1d(znp.asarray(z.to_real(value)))
 
     def _single_hook_pdf(self, x, norm):
         return self._hook_pdf(x=x, norm=norm)

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -193,6 +193,7 @@ class Data(
 
         if dtype is None:
             dtype = ztypes.float
+
         super().__init__(name=name)
 
         self._permutation_indices_data = None
@@ -200,7 +201,7 @@ class Data(
         self._dtype = dtype
         self._nevents = None
         self._weights = None
-        self._label = label if label is not None else name
+        self._label = label if label is not None else (name if name is not None else "Data")
 
         self._data_range = None
         self._set_space(obs)
@@ -879,7 +880,7 @@ class Data(
         obs_str = list(convert_to_obs_str(obs))
         data = {ob: self.value(obs=ob) for ob in obs_str}
         if self.has_weights:
-            weights = self.weights.numpy()
+            weights = self.weights
             if weightsname is None:
                 weightsname = ""
             data.update({weightsname: weights})
@@ -944,6 +945,10 @@ class Data(
 
     def numpy(self) -> np.ndarray:
         return self.to_numpy()
+
+    @property
+    def shape(self):
+        return self.dataset.nevents
 
     def to_numpy(self) -> np.ndarray:
         """Return the data as a numpy array.
@@ -1090,6 +1095,9 @@ class Data(
             use_hash=use_hash or self._use_hash,
         )
 
+    def __len__(self):
+        return self.nevents
+
     def __getitem__(self, item):
         if isinstance(item, int):
             return self.value(axis=item)
@@ -1110,7 +1118,7 @@ class Data(
     def __repr__(self) -> str:
         nevents = self.nevents
         try:
-            nevents = round(float(nevents), ndigits=2)
+            nevents = int(round(float(nevents), ndigits=2))
         except Exception:
             nevents = None
         return f"<zfit.Data: {self.label} obs={self.obs} shape={(nevents, self.n_obs)}>"

--- a/zfit/core/integration.py
+++ b/zfit/core/integration.py
@@ -74,7 +74,7 @@ def auto_integrate(
     else:
         msg = f"Method {method} not a legal choice for integration method."
         raise ValueError(msg)
-    return integral
+    return znp.atleast_1d(integral)
 
 
 # TODO implement numerical integration method
@@ -129,9 +129,9 @@ def simpson(func, lower, upper, num_points=1001, dtype=None):
       `Tensor` of shape `func_batch_shape + limits_batch_shape`, containing
         value of the definite integral.
     """
-    lower = tf.convert_to_tensor(lower, dtype=dtype, name="lower")
+    lower = tf.convert_to_tensor(lower, dtype=dtype)
     dtype = lower.dtype
-    upper = tf.convert_to_tensor(upper, dtype=dtype, name="upper")
+    upper = tf.convert_to_tensor(upper, dtype=dtype)
     num_points = tf.convert_to_tensor(num_points, dtype=tf.int32, name="num_points")
 
     assertions = [
@@ -149,7 +149,7 @@ def simpson(func, lower, upper, num_points=1001, dtype=None):
         weights_last = tf.constant([4.0, 1.0], dtype=dtype)
         weights = tf.concat([weights_first, weights_mid, weights_last], axis=0)
 
-    return tf.reduce_sum(func(grid) * weights, axis=-1) * dx / 3.0
+    return znp.sum(func(grid) * weights, axis=-1) * dx / 3.0
 
 
 def simpson_integrate(func, limits, num_points):  # currently not vectorized
@@ -397,7 +397,8 @@ def mc_integrate(
                 tf.cond(error > tol, print_none_return, lambda: None)
         integral = avg * znp.asarray(z.convert_to_tensor(space.area()), dtype=avg.dtype)
         integrals.append(integral)
-    return z.reduce_sum(integrals, axis=0)
+    integral = z.reduce_sum(integrals, axis=0)
+    return znp.atleast_1d(integral)
 
 
 # TODO(Mayou36): Make more flexible for sampling

--- a/zfit/minimizers/baseminimizer.py
+++ b/zfit/minimizers/baseminimizer.py
@@ -18,7 +18,6 @@ from ordered_set import OrderedSet
 
 from ..core.interfaces import ZfitLoss, ZfitParameter
 from ..core.parameter import assign_values, convert_to_parameters
-from ..settings import run
 from ..util import ztyping
 from ..util.container import convert_to_container
 from ..util.exception import (
@@ -715,7 +714,7 @@ class BaseStepMinimizer(BaseMinimizer):
         maxiter = self.get_maxiter(len(params))
         criterion_val = None
         while True:
-            cur_val = run(self._step(loss=loss, params=params, init=prelim_result))
+            cur_val = self._step(loss=loss, params=params, init=prelim_result)
             niter += 1
 
             changes.popleft()
@@ -723,8 +722,8 @@ class BaseStepMinimizer(BaseMinimizer):
             sum_changes = np.sum(changes)
             maxiter_reached = niter > maxiter
             if (sum_changes < self.tol and niter % 3) or maxiter_reached:  # test the last time surely
-                xvalues = np.array(run(params))
-                hesse = run(loss.hessian(params))
+                xvalues = np.asarray(params)
+                hesse = loss.hessian(params)
                 inv_hesse = np.linalg.inv(hesse)
                 status = 10
                 params_result = dict(zip(params, xvalues))

--- a/zfit/minimizers/errors.py
+++ b/zfit/minimizers/errors.py
@@ -325,7 +325,7 @@ def covariance_with_weights(method, result, params):
     if loss.constraints:
         constraints = loss.constraints
 
-    old_vals = run(params)
+    old_vals = np.asarray(params)
 
     Hinv_dict = method(result=result, params=params)  # inverse of the hessian matrix
     if not Hinv_dict:

--- a/zfit/minimizers/errors.py
+++ b/zfit/minimizers/errors.py
@@ -187,7 +187,7 @@ def compute_errors(
                         loss_value = znp.array(999999.0)
                         gradient = z.random.normal(stddev=0.1, shape=(len(all_params) - 1,))
                         # raise FailEvalLossNaN(msg)
-                    zeroed_loss = loss_value.numpy() - fmin
+                    zeroed_loss = loss_value - fmin
 
                     gradient = znp.array(gradient)
 

--- a/zfit/minimizers/fitresult.py
+++ b/zfit/minimizers/fitresult.py
@@ -38,7 +38,6 @@ from ..core.interfaces import (
     ZfitParameter,
 )
 from ..core.parameter import set_values
-from ..settings import run
 from ..util.container import convert_to_container
 from ..util.deprecation import deprecated, deprecated_args
 from ..util.warnings import ExperimentalFeatureWarning, warn_changed_feature
@@ -1086,7 +1085,7 @@ class FitResult(ZfitResult):
     @contextlib.contextmanager
     def _input_check_reset_params(self, params):
         params = self._input_check_params(params=params)
-        old_values = run(params)
+        old_values = np.asarray(params)
         try:
             yield params
         except Exception:
@@ -1618,7 +1617,7 @@ class ParamHolder(NameToParamGetitem, collections.UserDict):
             if isinstance(param, ZfitParameter):
                 row.append(
                     color_on_bool(
-                        run(param.at_limit),
+                        bool(param.at_limit),
                         on_true=colored.bg("light_red"),
                         on_false=False,
                     )

--- a/zfit/minimizers/ipopt.py
+++ b/zfit/minimizers/ipopt.py
@@ -8,7 +8,6 @@ import math
 import numpy as np
 
 from ..core.parameter import assign_values
-from ..settings import run
 from ..util.exception import MaximumIterationReached
 from .baseminimizer import BaseMinimizer, minimize_supports, print_minimization_status
 from .fitresult import FitResult
@@ -240,7 +239,7 @@ class IpyoptV1(BaseMinimizer):
         criterion = self.create_criterion()
 
         # initial values as array
-        xvalues = np.array(run(params))
+        xvalues = np.array(params)
 
         # get and set the limits
         lower = np.array([p.lower for p in params])

--- a/zfit/minimizers/minimizer_minuit.py
+++ b/zfit/minimizers/minimizer_minuit.py
@@ -11,7 +11,6 @@ import numpy as np
 from .. import z
 from ..core.interfaces import ZfitLoss
 from ..core.parameter import Parameter, assign_values
-from ..settings import run
 from ..util.cache import GraphCachable
 from ..util.deprecation import deprecated_args
 from ..util.exception import MaximumIterationReached
@@ -276,7 +275,7 @@ class Minuit(BaseMinimizer, GraphCachable):
         if minimizer_options:
             msg = f"The following options are not (yet) supported: {minimizer_options}"
             raise ValueError(msg)
-        init_values = np.array(run(params))
+        init_values = np.array(params)
 
         # create Minuit compatible names
         params_name = [param.name for param in params]

--- a/zfit/minimizers/minimizer_nlopt.py
+++ b/zfit/minimizers/minimizer_nlopt.py
@@ -19,7 +19,6 @@ except ImportError as error:
 import numpy as np
 
 from ..core.parameter import assign_values
-from ..settings import run
 from ..util.exception import MaximumIterationReached
 from .baseminimizer import (
     NOT_SUPPORTED,
@@ -188,7 +187,7 @@ class NLoptBaseMinimizerV1(BaseMinimizer):
         minimizer = nlopt.opt(nlopt.LD_LBFGS, len(params))
 
         # initial values as array
-        xvalues = initial_xvalues = np.asarray(run(params))
+        xvalues = initial_xvalues = np.asarray(params)
 
         # get and set the limits
         lower = np.array([p.lower for p in params])

--- a/zfit/minimizers/minimizer_tfp.py
+++ b/zfit/minimizers/minimizer_tfp.py
@@ -51,8 +51,6 @@ class BFGS(BaseMinimizer):
 
     @minimize_supports()
     def _minimize(self, loss, params):
-        from .. import run
-
         minimizer_fn = tfp.optimizer.bfgs_minimize
         params = tuple(params)
 
@@ -90,16 +88,16 @@ class BFGS(BaseMinimizer):
                 if do_print:
                     print_gradient(
                         params,
-                        run(values),
-                        [float(run(g)) for g in gradient],
-                        loss=run(value),
+                        (values),
+                        [float(g) for g in gradient],
+                        loss=float(value),
                     )
-            loss_evaluated = run(value)
+            loss_evaluated = value
             is_nan = is_nan or np.isnan(loss_evaluated)
             if is_nan:
                 nan_counter += 1
                 info_values = {}
-                info_values["loss"] = run(value)
+                info_values["loss"] = value
                 info_values["old_loss"] = current_loss
                 info_values["nan_counter"] = nan_counter
                 value = self.strategy.minimize_nan(loss=loss, params=params, minimizer=self, values=info_values)
@@ -124,19 +122,19 @@ class BFGS(BaseMinimizer):
         result = minimizer_fn(to_minimize_func, **minimizer_kwargs)
 
         # save result
-        params_result = run(result.position)
+        params_result = np.asarray(result.position)
         assign_values(params, values=params_result)
 
         info = {
-            "n_eval": run(result.num_objective_evaluations),
-            "n_iter": run(result.num_iterations),
-            "grad": run(result.objective_gradient),
+            "n_eval": np.asarray(result.num_objective_evaluations),
+            "n_iter": np.asarray(result.num_iterations),
+            "grad": np.asarray(result.objective_gradient),
             "original": result,
         }
         edm = None
-        fmin = run(result.objective_value)
+        fmin = float(result.objective_value)
         status = None
-        converged = run(result.converged)
+        converged = bool(result.converged)
         params = dict(zip(params, params_result))
         return FitResult(
             params=params,

--- a/zfit/minimizers/minimizers_scipy.py
+++ b/zfit/minimizers/minimizers_scipy.py
@@ -12,7 +12,6 @@ import scipy.optimize
 from scipy.optimize import BFGS, HessianUpdateStrategy
 
 from ..core.parameter import assign_values
-from ..settings import run
 from ..util.container import convert_to_container
 from ..util.exception import MaximumIterationReached
 from ..util.warnings import warn_experimental_feature
@@ -213,8 +212,8 @@ class ScipyBaseMinimizerV1(BaseMinimizer):
 
         evaluator = self.create_evaluator(loss=loss, params=params, numpy_converter=np.array)
 
-        limits = [(run(p.lower), run(p.upper)) for p in params]
-        init_values = np.array(run(params))
+        limits = [(float(p.lower), float(p.upper)) for p in params]
+        init_values = np.array(params)
 
         minimizer_options = self.minimizer_options.copy()
 

--- a/zfit/minimizers/strategy.py
+++ b/zfit/minimizers/strategy.py
@@ -9,7 +9,6 @@ from collections.abc import Mapping
 import numpy as np
 
 from ..core.interfaces import ZfitLoss, ZfitParameter
-from ..settings import run
 from ..util import ztyping
 from .fitresult import FitResult
 
@@ -72,7 +71,7 @@ class ToyStrategyFail(BaseStrategy):
 
     def minimize_nan(self, loss: ZfitLoss, params: ztyping.ParamTypeInput, values: Mapping | None = None) -> float:
         del values  # unused
-        param_vals = run(params)
+        param_vals = np.asarray(params)
         param_vals = dict(zip(params, param_vals))
         self.fit_result = FitResult(
             params=param_vals,

--- a/zfit/models/polynomials.py
+++ b/zfit/models/polynomials.py
@@ -24,7 +24,7 @@ import zfit.z.numpy as znp
 from zfit import z
 
 from ..core.basepdf import BasePDF
-from ..core.space import Space
+from ..core.space import Space, supports
 from ..settings import ztypes
 from ..util import ztyping
 from ..util.container import convert_to_container
@@ -809,9 +809,14 @@ def de_casteljau(x, coeffs):
     """De Casteljau's algorithm."""
     beta = list(coeffs)  # values in this list are overridden
     n = len(beta)
+    if n < 1:
+        msg = "Need at least one coefficient in de_casteljau of Bernstein."
+        raise ValueError(msg)
     for j in range(1, n):
         for k in range(n - j):
             beta[k] = beta[k] * (1 - x) + beta[k + 1] * x
+    if n == 1:
+        beta[0] = beta[0] * znp.ones_like(x)  # needed for no coefficients, cannot just return scalar beta[0]
     return beta[0]
 
 
@@ -873,13 +878,14 @@ class Bernstein(BasePDF, SerializableMixin):
         """Int: degree of the polynomial, starting from 0."""
         return self._degree
 
-    def _unnormalized_pdf(self, x):
-        x = x.unstack_x()
+    @supports()
+    def _unnormalized_pdf(self, x, params):
+        x = x[0]
         x = self._polynomials_rescale(x)
-        return self._poly_func(x=x)
+        return self._poly_func(x=x, params=params)
 
-    def _poly_func(self, x):
-        coeffs = convert_coeffs_dict_to_list(self.params)
+    def _poly_func(self, x, params):
+        coeffs = convert_coeffs_dict_to_list(params)
         return bernstein_shape(x=x, coeffs=coeffs)
 
 

--- a/zfit/util/execution.py
+++ b/zfit/util/execution.py
@@ -115,6 +115,14 @@ class RunManager:
             yield cpu
             self._cpu.extend(cpu)
 
+    @deprecated(
+        None,
+        "The `run(...)` method originates from the old `tf.Session` API in TF1 and is not needed anymore. In most cases, it can simply be removed. "
+        "It's current functionality converts the input to numpy, which most of the time is not needed anyways."
+        "Alternatively, use `znp.asarray(...)` to convert to zfit-friendly array (that acts nearly like numpy) or `np.asarray(...) if a numpy"
+        " array is *really needed*.",
+        "Remove the `run(...)` method.",
+    )
     def __call__(self, *args, **kwargs):
         # TODO: catch maybe sets, as they change the number of elements if we have identical ones
         # and convert them. Before it's fine, e.g. Parameters are unique, but after it's a value.
@@ -161,7 +169,7 @@ class RunManager:
          - **numpy-like/eager**: in this mode, the syntax slightly differs from pure numpy but is similar. For example,
             `tf.sqrt`, `tf.math.log` etc. The return values are `EagerTensors` that represent "wrapped Numpy arrays" and
             can directly be used with any Numpy function. They can explicitly be converted to a Numpy array with
-            `zfit.run(EagerTensor)`, which takes also care of nested structures and already existing `np.ndarrays`,
+            `znp.asarray(EagerTensor)`, which takes also care of nested structures and already existing `np.ndarrays`,
             or just a `.numpy()` method.
             The difference to Numpy is that TensorFlow tries to optimize the calculation slightly beforehand and may
             also executes on the GPU. This will result in a slight performance penalty for *very small* computations


### PR DESCRIPTION
Signed-off-by: Jonas Eschle <mayou36@jonas.eschle.com>Fixes #


## Checklist

- [x] change approved
- [x] implementation finished
- [x]  docs updated
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
- [x] (if large change) tutorial added/updated?
