### PR TITLE
Enh: allow zfit data to update sampler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ Deprecations
 
 Bug fixes and small changes
 ---------------------------
+- allow the usage of ``ZfitData`` objects (binned and unbinned version respectively) in ``update_data`` method of sampler objects
+  ``zfit.data.SamplerData`` and ``zfit.data.BinnedSamplerData``
+  (for example, the objects that are returned by ``create_sampler``)
+- add an attribute ``num_entries`` to the ``Data`` object that returns the number of entries in the data and an attribute ``samplesize`` reflecting the sum of the weights, deprecating the ambiguous ``nevents`` attribute.
+  The former can be used to define the array shape, the latter matters in statistical tests.
 
 Experimental
 ------------
@@ -27,6 +32,7 @@ Requirement changes
 
 Thanks
 ------
+- @fsouzade for finding the bug in the ``update_data`` method of the sampler objects
 
 
 0.24.3 (6 Jan. 2025)

--- a/tests/data/test_binneddata.py
+++ b/tests/data/test_binneddata.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 import boost_histogram as bh
 import hist
 import numpy as np
@@ -264,4 +264,4 @@ def test_binned_from_numpy_issue602():
     data_normal_np = np.random.normal(size=size_normal, scale=2)    # Generate normal distribution data
 
     data_normal = zfit.Data(data_normal_np, obs=obs)                # Create a zfit Data object with the normal distribution data
-    assert data_normal_np.shape[0] >= data_normal.nevents           # Check that the number of events in the data is correct
+    assert data_normal_np.shape[0] >= data_normal.num_entries           # Check that the number of events in the data is correct

--- a/tests/data/test_binneddata.py
+++ b/tests/data/test_binneddata.py
@@ -122,12 +122,13 @@ def test_binned_data_from_unbinned():
         storage=hist.storage.Weight(),
     )
 
-    x2 = np.random.randn(1_000)
-    y2 = 0.5 * np.random.randn(1_000)
+    num_entries = 1_000
+    x2 = np.random.randn(num_entries)
+    y2 = 0.5 * np.random.randn(num_entries)
 
     h3.fill(x=x2, y=y2)
 
-    from zfit._data.binneddatav1 import BinnedData
+    from zfit.data import BinnedData
 
     xobs = zfit.Space("x", binning=axis1)
     yobs = zfit.Space("y", binning=axis2)
@@ -141,6 +142,7 @@ def test_binned_data_from_unbinned():
     np.testing.assert_allclose(binned_data.variances(), h3.variances())
     np.testing.assert_allclose(binned_data_init.values(), h3.values())
     np.testing.assert_allclose(binned_data_init.variances(), h3.variances())
+    assert pytest.approx(data.samplesize) == binned_data_init.samplesize
 
 
 

--- a/tests/data/test_samplerdata.py
+++ b/tests/data/test_samplerdata.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 import numpy as np
 import pytest
 
@@ -7,15 +7,16 @@ import pytest
 def test_update_data_sampler(weights):
     import zfit
     from zfit.data import SamplerData
-    sample = np.random.normal(0, 1, size=(1000, 3))
-    sample2 = np.random.normal(0, 1, size=(1000, 3))
-    sample3 = np.random.normal(0, 1, size=(1000, 3))
-
+    sample1 = np.random.uniform(-10, 30, size=(1000, 3))
+    sample2 = np.random.uniform(-10, 30, size=(1000, 3))
+    sample3 = np.random.uniform(-10, 30, size=(1000, 3))
     obs = zfit.Space('obs1', limits=(-100, 100)) * zfit.Space('obs2', limits=(-200, 200)) * zfit.Space('obs3', limits=(-150, 150))
-    data = SamplerData.from_sampler(obs=obs, sample_and_weights_func=lambda n, params: (sample, weights), n=1000)
+    data1 = zfit.Data(sample1, obs=obs, weights=weights)
+
+    data = SamplerData.from_sampler(obs=obs, sample_and_weights_func=lambda n, params: (sample1, weights), n=1000)
     if weights is not None:
         assert np.allclose(data.weights, weights)
-    assert np.allclose(data.value(), sample)
+    assert np.allclose(data.value(), sample1)
     if weights is not None:
         with pytest.raises(ValueError):
             data.update_data(sample2, weights=None)
@@ -27,3 +28,10 @@ def test_update_data_sampler(weights):
     else:
         data.update_data(sample3, weights=weights)
         assert np.allclose(data.value(), sample3)
+
+    data.update_data(data1)
+    assert np.allclose(data.value(), sample1)
+    if weights is not None:
+        assert np.allclose(data.weights, weights)
+    else:
+        assert data.weights is None

--- a/tests/data/test_samplerdata.py
+++ b/tests/data/test_samplerdata.py
@@ -31,7 +31,12 @@ def test_update_data_sampler(weights):
 
     data.update_data(data1)
     assert np.allclose(data.value(), sample1)
-    if weights is not None:
-        assert np.allclose(data.weights, weights)
-    else:
+    if weights is None:
         assert data.weights is None
+        samplesize = float(data.num_entries)
+    else:
+        assert np.allclose(data.weights, weights)
+        samplesize = np.sum(weights)
+
+    assert pytest.approx(data.samplesize) == samplesize
+    assert data.num_entries == data.value().shape[0]

--- a/tests/model/test_pdf_histogram.py
+++ b/tests/model/test_pdf_histogram.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 import hist
 import numpy as np
 import pytest
@@ -86,11 +86,11 @@ def test_pdf_formhist():
 
     # test sample
     sample = ext_pdf.sample(n=1_000)
-    assert sample.nevents == 1_000
+    assert sample.samplesize == 1_000.
     assert sample.rank == 2
 
     sample = pdf.sample(n=1_000)
-    assert sample.nevents == 1_000
+    assert sample.samplesize == 1_000.
     assert sample.rank == 2
 
     # test integral

--- a/tests/model/test_pdf_params_args.py
+++ b/tests/model/test_pdf_params_args.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 import numpy as np
 import pytest
 from pytest_cases import parametrize, fixture
@@ -188,7 +188,7 @@ def test_params_as_args_loss(loss):
     param1 = list(params)[0]
     loss_values = loss.value()
     assert np.isfinite(loss_values)
-    loss_values_params = loss.value(params={param1.name: param1 * 1.1})
+    loss_values_params = loss.value(params={param1.name: param1 * 1.15})
     assert abs(loss_values - loss_values_params) > 0.1
 
 @pytest.mark.parametrize('loss', losses)

--- a/tests/model/test_truncated_pdf.py
+++ b/tests/model/test_truncated_pdf.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 
 import pytest
 
@@ -171,7 +171,7 @@ def test_dynamic_truncated_yield():
     result = minimizer.minimize(nll_simultaneous2)
     result.hesse()
 
-    ntrue = data1.nevents + data2.nevents
+    ntrue = data1.samplesize + data2.samplesize
     assert pytest.approx(result.params[globyield]['value'], abs=0.3) == ntrue
 
     nll_norm = zfit.loss.ExtendedUnbinnedNLL(model=gauss1, data=data)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 
 import copy
 
@@ -407,18 +407,18 @@ def test_multidim_data_range():
     assert len(yxdata) == 2
     assert tf.is_tensor(yxdata[0])
     assert xdata.shape == (neventstrue1,)
-    assert dataset.nevents == 6
+    assert dataset.num_entries == 6
     datasetnew1 = dataset.with_obs(obs=obs1)
-    assert datasetnew1.nevents == 6
-    assert dataset.nevents == 6
+    assert datasetnew1.num_entries == 6
+    assert dataset.num_entries == 6
     datasetnew2 = dataset.with_obs(obs=obs2)
-    assert datasetnew2.nevents == 6
+    assert datasetnew2.num_entries == 6
     np.testing.assert_allclose(data_true, datasetnew2.value()[:, 0])
 
     data2 = np.linspace((0, 5), (10, 15), num=11)[:, 1]
     data_range = zfit.Space([obs1], limits=(5, 15))
     dataset = zfit.Data.from_numpy(array=data2, obs=data_range)
-    assert dataset.nevents == 11
+    assert dataset.num_entries == 11
 
 
 def test_data_hashing(space2d):
@@ -429,7 +429,7 @@ def test_data_hashing(space2d):
     testhashpdf = TestHashPDF(obs=space2d, lasthash=data1.hashint)
     assert testhashpdf.lasthash == data1.hashint
     oldhashint = data1.hashint
-    data1 = data1.with_weights(np.random.uniform(size=data1.nevents))
+    data1 = data1.with_weights(np.random.uniform(size=data1.num_entries))
     assert data1.hashint is not None
     assert oldhashint != data1.hashint
     assert data1.hashint != testhashpdf.lasthash
@@ -442,7 +442,7 @@ def test_data_hashing(space2d):
             True
     ):  # meaning integration is now done in graph and has "None"
         oldhashint = data1.hashint
-        data2 = data1.with_weights(np.random.uniform(size=data1.nevents))
+        data2 = data1.with_weights(np.random.uniform(size=data1.num_entries))
         testhashpdf.pdf(data2)
         assert oldhashint != testhashpdf.lasthash
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -378,6 +378,11 @@ def test_data_range(weights_factory):
     np.testing.assert_equal(cut_data1, value_cut)
     if dataset_cut.has_weights:
         np.testing.assert_equal(cut_weights, dataset_cut.weights)
+        samplesize = np.sum(cut_weights)
+    else:
+        samplesize = 2.
+    assert pytest.approx(samplesize) == dataset_cut.samplesize
+    assert dataset_cut.num_entries == 2
     np.testing.assert_equal(
         data1, value_uncut
     )  # check  that the original did NOT change

--- a/tests/test_pdf_bifurgauss.py
+++ b/tests/test_pdf_bifurgauss.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 import numpy as np
 import pytest
 import zfit
@@ -44,7 +44,7 @@ def test_bifurgauss_pdf():
 
     sample = bifurgauss.sample(1000)
     assert np.all(np.isfinite(sample.value())), "Some samples from the bifurgauss PDF are NaN or infinite"
-    assert sample.n_events == 1000
+    assert sample.num_entries == 1000
     assert np.all(tf.logical_and(-5 <= sample.value(), sample.value() <= 5))
 
 

--- a/tests/test_pdf_conditional.py
+++ b/tests/test_pdf_conditional.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 
 import numpy as np
 import pytest
@@ -42,7 +42,7 @@ def test_conditional_pdf_simple():
         pdf=gauss, cond={mu: muobs}, use_vectorized_map=False
     )
     prob2 = cond_gauss2d.pdf(data2d)
-    assert prob2.shape[0] == data2d.nevents
+    assert prob2.shape[0] == data2d.num_entries
     assert prob2.shape.rank == 1
 
     prob_check2 = np.ones_like(prob2)
@@ -53,7 +53,7 @@ def test_conditional_pdf_simple():
 
     cond_gauss1d = zfit.pdf.ConditionalPDFV1(pdf=gauss, cond={mu: xobs})
     prob1 = cond_gauss1d.pdf(data1d)
-    assert prob1.shape[0] == data1d.nevents
+    assert prob1.shape[0] == data1d.num_entries
     assert prob1.shape.rank == 1
 
     prob_check1 = np.ones_like(prob1)
@@ -66,7 +66,7 @@ def test_conditional_pdf_simple():
         pdf=gauss, cond={mu: muobs, sigma: sigmaobs}
     )
     prob3 = cond_gauss3d.pdf(data3d)
-    assert prob3.shape[0] == data3d.nevents
+    assert prob3.shape[0] == data3d.num_entries
     assert prob3.shape.rank == 1
 
     prob_check3 = np.ones_like(prob3)
@@ -83,9 +83,9 @@ def test_conditional_pdf_simple():
     assert result.valid
 
     integrals2 = cond_gauss2d.integrate(limits=xobs, var=data2d)
-    assert integrals2.shape[0] == data2d.nevents
+    assert integrals2.shape[0] == data2d.num_entries
     assert integrals2.shape.rank == 1
     np.testing.assert_allclose(integrals2, np.ones_like(integrals2), atol=1e-5)
 
-    sample2 = cond_gauss2d.sample(n=data1dmu.nevents, limits=xobs, x=data1dmu)
-    assert sample2.value().shape == (data1dmu.nevents, cond_gauss2d.n_obs)
+    sample2 = cond_gauss2d.sample(n=data1dmu.num_entries, limits=xobs, x=data1dmu)
+    assert sample2.value().shape == (data1dmu.num_entries, cond_gauss2d.n_obs)

--- a/tests/test_pdf_gamma.py
+++ b/tests/test_pdf_gamma.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 import numpy as np
 import pytest
 import zfit
@@ -34,7 +34,7 @@ def test_gamma_pdf():
 
     sample = gamma.sample(10_00)
     assert np.all(np.isfinite(sample.value())), "Some samples from the gamma PDF are NaN or infinite"
-    assert sample.n_events == 1000
+    assert sample.num_entries == 1000
     ones_like = np.ones_like(sample.value())
     np.testing.assert_array_less(1 * ones_like, sample.value())
     np.testing.assert_array_less(sample.value(), ones_like * 10)

--- a/tests/test_pdf_johnsonsu.py
+++ b/tests/test_pdf_johnsonsu.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 import numpy as np
 import pytest
 import zfit
@@ -32,7 +32,7 @@ def test_johnsonsu_pdf():
 
     sample = johnsonsu.sample(10_00)
     assert np.all(np.isfinite(sample.value())), "Some samples from the JohnsonSU PDF are NaN or infinite"
-    assert sample.n_events == 1000
+    assert sample.num_entries == 1000
     ones_like = np.ones_like(sample.value())
     np.testing.assert_array_less(1 * ones_like, sample.value())
     np.testing.assert_array_less(sample.value(), ones_like * 10)

--- a/tests/test_pdf_polynomials.py
+++ b/tests/test_pdf_polynomials.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 import copy
 
 import numpy as np
@@ -166,7 +166,7 @@ def test_bernstein(coeffs, obs):
 
     sample = bernstein.sample(1000)
     assert all(np.isfinite(sample.value())), "Some samples from the Bernstein PDF are NaN or infinite"
-    assert sample.n_events == 1000
+    assert sample.num_entries == 1000
     assert all(tf.logical_and(lower <= sample.value(), sample.value() <= upper))
 
 

--- a/tests/test_pdf_qgauss.py
+++ b/tests/test_pdf_qgauss.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 import numpy as np
 import pytest
 import zfit
@@ -35,7 +35,7 @@ def test_qgauss_pdf(q):
 
     sample = qgauss.sample(1000)
     assert np.all(np.isfinite(sample.value())), "Some samples from the qgauss PDF are NaN or infinite"
-    assert sample.n_events == 1000
+    assert sample.num_entries == 1000
     assert np.all(tf.logical_and(-5 <= sample.value(), sample.value() <= 5))
 
 

--- a/zfit/core/data.py
+++ b/zfit/core/data.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 
 from __future__ import annotations
 
@@ -212,7 +212,7 @@ class Data(
         self._permutation_indices_data = None
         self._next_batch = None
         self._dtype = dtype
-        self._nevents = None
+        self._nentries = None
         self._weights = None
         self._label = label if label is not None else (name if name is not None else "Data")
 
@@ -247,11 +247,23 @@ class Data(
         return self._label
 
     @property
+    def num_entries(self):
+        nentries = self._nentries
+        if nentries is None:
+            nentries = self._get_nentries()
+        return nentries
+
+    @property
+    @deprecated(
+        None, "Use `nentries` (for an int) or `samplesize` for a float corresponding to the sum of weights) instead."
+    )
     def nevents(self):
-        nevents = self._nevents
-        if nevents is None:
-            nevents = self._get_nevents()
-        return nevents
+        return self.num_entries
+
+    @property
+    def samplesize(self) -> float:
+        samplesize = znp.sum(self.weights) if self.has_weights else self.num_entries
+        return znp.asarray(samplesize, dtype=ztypes.float)
 
     def enable_hashing(self):
         """Enable hashing for this data object if it was disabled.
@@ -275,11 +287,11 @@ class Data(
 
     @property
     def _approx_nevents(self):
-        return self.nevents
+        return self.num_entries
 
     @property
     def n_events(self):
-        return self.nevents
+        return self.num_entries
 
     @property
     def has_weights(self):
@@ -366,7 +378,7 @@ class Data(
             if weights.shape.ndims != 1:
                 msg = "Weights have to be 1-Dim objects."
                 raise ValueError(msg)
-            if weights.shape[0] != self.nevents:
+            if weights.shape[0] != self.num_entries:
                 msg = "Weights have to have the same length as the data."
                 raise ValueError(msg)
         return self.copy(weights=weights, guarantee_limits=True)
@@ -967,7 +979,7 @@ class Data(
 
     @property
     def shape(self):
-        return self.dataset.nevents
+        return self.dataset.num_entries
 
     def to_numpy(self) -> np.ndarray:
         """Return the data as a numpy array.
@@ -1040,8 +1052,8 @@ class Data(
             space = space.with_coords(self.space, allow_subset=True)
         return space
 
-    def _get_nevents(self):
-        return self.dataset.nevents
+    def _get_nentries(self):
+        return self.dataset.num_entries
 
     def to_binned(
         self,
@@ -1084,7 +1096,7 @@ class Data(
         )
 
     def __len__(self):
-        return self.nevents
+        return self.num_entries
 
     def __getitem__(self, item):
         if isinstance(item, int):
@@ -1104,7 +1116,7 @@ class Data(
         return f"zfit.Data: {self.label} obs={self.obs} array={self.value()}"
 
     def __repr__(self) -> str:
-        nevents = self.nevents
+        nevents = self.num_entries
         try:
             nevents = int(round(float(nevents), ndigits=2))
         except Exception:
@@ -1489,12 +1501,14 @@ class SamplerData(Data):
             dtype=dtype,
         )
 
-    def update_data(self, sample: TensorLike, weights: TensorLike | None = None, guarantee_limits: bool = False):
+    def update_data(
+        self, sample: TensorLike | ZfitUnbinnedData, weights: TensorLike | None = None, guarantee_limits: bool = False
+    ):
         """Load a new sample into the dataset, presumably similar to the previous one.
 
         Args:
             sample: The new sample to load. Has to have the same number of observables as the `obs` of the `SamplerData` but
-                can have a different number of events.
+                can have a different number of events. When a `ZfitUnbinnedData` is given, the weights from it are used.
             weights: The weights of the new sample. If `None`, the weights are not changed. If the `SamplerData` was
                 initialized with weights, this has to be given. If the `SamplerData` was initialized without weights,
                 this cannot be given.
@@ -1503,6 +1517,14 @@ class SamplerData(Data):
                possibly because it was already cut before. This can lead to a performance
                improvement as the data does not have to be checked. |@docend:data.init.guarantee_limits|
         """
+        if isinstance(sample, ZfitUnbinnedData):
+            if weights is not None:
+                msg = "Cannot set weights if `sample` is an `UnbinnedData` object. Create a weighted dataset (i.e. use `with_weights`)."
+                raise ValueError(msg)
+            sample = sample.with_obs(self.space)
+            weights = sample.weights
+            sample = sample.value()
+
         sample = znp.asarray(sample, dtype=self.dtype)
 
         if sample.shape.rank == 1:
@@ -1573,7 +1595,7 @@ class SamplerData(Data):
         self.update_data(sample=new_sample, weights=new_weight, guarantee_limits=self._sampler_guarantee_limits)
 
     def __str__(self) -> str:
-        return f"<SamplerData: {self.label} obs={self.obs} size={int(self.nevents)} weighted={self.has_weights} array={self.value()}>"
+        return f"<SamplerData: {self.label} obs={self.obs} size={int(self.num_entries)} weighted={self.has_weights} array={self.value()}>"
 
     @classmethod
     def get_repr(cls):  # acts as data object once serialized
@@ -1785,7 +1807,7 @@ class LightDataset:
         return self
 
     @property
-    def nevents(self):
+    def num_entries(self):
         return (
             tf.shape(self._tensor)[0] if self._tensor is not None else tf.shape(next(iter(self._tensormap.values())))[0]
         )

--- a/zfit/core/interfaces.py
+++ b/zfit/core/interfaces.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 
 from __future__ import annotations
 
@@ -233,8 +233,17 @@ class ZfitData(ZfitDimensional):
 class ZfitUnbinnedData(ZfitData):
     @property
     @abstractmethod
-    def nevents(self) -> int:
+    def num_entries(self) -> int:
         raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def samplesize(self) -> float:
+        raise NotImplementedError
+
+    @property
+    def shape(self) -> tuple:
+        return self.num_entries, self.n_obs
 
     @property
     @abstractmethod

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -1237,8 +1237,7 @@ class ExtendedUnbinnedNLL(BaseUnbinnedNLL):
             if not mod.is_extended:
                 msg = f"The pdf {mod} is not extended but has to be (for an extended fit)"
                 raise NotExtendedPDFError(msg)
-            nevents = dat.n_events if dat.weights is None else z.reduce_sum(dat.weights)
-            nevents = znp.asarray(nevents, tf.float64)
+            nevents = znp.asarray(dat.samplesize, tf.float64)
             nevents_collected.append(nevents)
             yields.append(znp.atleast_1d(mod.get_yield()))
         yields = znp.concatenate(yields, axis=0)

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 
 from __future__ import annotations
 
@@ -253,7 +253,7 @@ class BaseLoss(ZfitLoss, BaseNumeric):
 
     def _check_init_options(self, options, data):
         try:
-            nevents = sum(d.nevents for d in data)
+            nevents = sum(d.num_entries for d in data)
         except RuntimeError:  # can happen if not yet sampled. What to do? Approx_nevents?
             nevents = 150_000  # sensible default
         options = {} if options is None else copy.copy(options)

--- a/zfit/minimizers/errors.py
+++ b/zfit/minimizers/errors.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 
 from __future__ import annotations
 
@@ -356,7 +356,7 @@ def covariance_with_weights(method, result, params):
             values.append(v)
             if yields is not None:
                 yi = yields[i]
-                nevents_collected = tf.reduce_sum(weights) if weights is not None else d.nevents
+                nevents_collected = d.samplesize
                 term_new = tf.nn.log_poisson_loss(nevents_collected, znp.log(yi), compute_full_loss=True)[
                     ..., None
                 ]  # make it an array like the others

--- a/zfit/models/conditional.py
+++ b/zfit/models/conditional.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 zfit
+#  Copyright (c) 2025 zfit
 
 from __future__ import annotations
 
@@ -176,7 +176,7 @@ class ConditionalPDFV1(BaseFunctor):
     def _single_hook_sample(self, n, limits, x):
         tf.assert_equal(
             n,
-            x.nevents,
+            x.num_entries,
             message="Different number of n requested than x given for " "conditional sampling. Needs to agree",
         )
 


### PR DESCRIPTION
Signed-off-by: Jonas Eschle <mayou36@jonas.eschle.com>Fixes #

## Proposed Changes

- allow zfit data to update sampler
- add `samplesize` and `num_entries` attribute to replace `nevents` (ambiguous) for data

## Tests added

- test the new attributes

## Checklist

- [x] change approved
- [x] implementation finished
- [x]  docs updated
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
- [x] (if large change) tutorial added/updated?
