### PR TITLE
fix:  number of entries in binned case for NLL subtraction and BinnedSampler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Deprecations
 
 Bug fixes and small changes
 ---------------------------
+- Allow BinnedSamplerData to be instantiated from a histogram and fix variance handling if not given.
+- Enhance the precision of binned loss functions
 
 Experimental
 ------------

--- a/examples/signal_bkg_mass_extended_fit_binned.py
+++ b/examples/signal_bkg_mass_extended_fit_binned.py
@@ -18,7 +18,7 @@ mu = zfit.Parameter("mu", 1.0, -4, 6)
 sigma = zfit.Parameter("sigma", 1.0, 0.1, 10)
 nr = zfit.Parameter("nr", 2, 0, 5)
 alpha = zfit.Parameter("alpha", 1.5, 0, 5)
-n_sig = zfit.Parameter("n_sig", 5000 * 0.3)
+n_sig = zfit.Parameter("n_sig", 5000 * 0.3, stepsize=100)
 doublecb = zfit.pdf.GeneralizedCB(
     mu=mu,
     sigmal=sigma,
@@ -66,7 +66,7 @@ def plot_pdf(title):
 
 
 # set the values to a start value for the fit
-zfit.param.set_values({mu: 0.5, sigma: 1.2, nr: 2.0, alpha: 1.5, lambd: -0.05})
+zfit.param.set_values({mu: 0.5, sigma: 1.2, nr: 2.0, alpha: 1.5, lambd: -0.05, n_sig: 5300, n_bkg: 4500})
 # alternatively, we can set the values with a list/array
 # zfit.param.set_values([mu, sigma, nr, alpha, lambd], [0.5, 1.2, 2.0, 1.5, -0.05])
 
@@ -81,14 +81,11 @@ plot_pdf("before fit")
 result = minimizer.minimize(nll).update_params()
 # do the error calculations, here with hesse, than with minos
 
-param_hesse = result.hesse()
-(
-    param_errors,
-    _,
-) = result.errors()  # this returns a new FitResult if a new minimum was found
 
+param_hesse = result.hesse()
 # this returns a new FitResult if a new minimum was found
 param_errors, _ = result.errors()
+print(result)
 # plot the data and pdf
 plot_pdf("after fit")
 # uncomment to display plots

--- a/tests/data/test_binneddata_sampler.py
+++ b/tests/data/test_binneddata_sampler.py
@@ -59,3 +59,44 @@ def test_binnedsampler_update_data(variances):
         assert np.allclose(sampler.variances(), variances)
     else:
         assert sampler.variances() is None
+
+@pytest.mark.parametrize("variances", [None, lambda size: np.random.uniform(size=size) * 10000], ids=['no_variances', 'variances'])
+def test_binnedsamplerdata_from_hist(variances):
+
+    bins1 = 51
+    bins2 = 55
+    bins3 = 64
+    size = (bins1, bins2, bins3)
+    if variances is not None:
+        variances = variances(size)
+    space1 = zfit.Space('obs1', limits=(-100, 100), binning=bins1)
+    space2 = zfit.Space('obs2', limits=(-200, 100), binning=bins2)
+    space3 = zfit.Space('obs3', limits=(-150, 350), binning=bins3)
+    obs = space1 * space2 * space3
+    sample1 = np.random.uniform(100, 10000, size=size)
+    sample2 = np.random.uniform(100, 10000, size=size)
+    sample3 = np.random.uniform(100, 10000, size=size)
+    hist1 = zfit.data.BinnedData.from_tensor(space=obs, values=sample1, variances=variances)
+    hist2 = zfit.data.BinnedData.from_tensor(space=obs, values=sample2, variances=variances)
+
+    data1 = zfit.data.BinnedSamplerData(hist1)
+    assert np.allclose(data1.values(), hist1.values())
+    if variances is not None:
+        assert np.allclose(data1.variances(), hist1.variances())
+    else:
+        assert data1.variances() is None
+
+    data1.update_data(hist2)
+    np.testing.assert_allclose(data1.values(), hist2.values())
+
+    data1 = zfit.data.BinnedSamplerData(hist1.to_hist())
+    assert np.allclose(data1.values(), hist1.values())
+    if variances is not None:
+        np.testing.assert_allclose(data1.variances(), hist1.variances())
+    else:
+        assert data1.variances() is None
+
+    data1.update_data(hist2)
+    np.testing.assert_allclose(data1.values(), hist2.values())
+    data1.update_data(hist2.to_hist())
+    np.testing.assert_allclose(data1.values(), hist2.values())

--- a/zfit/core/interfaces.py
+++ b/zfit/core/interfaces.py
@@ -229,12 +229,9 @@ class ZfitData(ZfitDimensional):
     def weights(self):
         raise NotImplementedError
 
-
-class ZfitUnbinnedData(ZfitData):
     @property
-    @abstractmethod
-    def num_entries(self) -> int:
-        raise NotImplementedError
+    def shape(self) -> tuple:
+        return self.num_entries, self.n_obs
 
     @property
     @abstractmethod
@@ -242,9 +239,12 @@ class ZfitUnbinnedData(ZfitData):
         raise NotImplementedError
 
     @property
-    def shape(self) -> tuple:
-        return self.num_entries, self.n_obs
+    @abstractmethod
+    def num_entries(self) -> int:
+        raise NotImplementedError
 
+
+class ZfitUnbinnedData(ZfitData):
     @property
     @abstractmethod
     def has_weights(self):

--- a/zfit/core/loss.py
+++ b/zfit/core/loss.py
@@ -394,7 +394,7 @@ class BaseLoss(ZfitLoss, BaseNumeric):
                 log_offset = self._options.get("subtr_const_value")
                 if log_offset is None:
                     run.assert_executing_eagerly()  # first time subtr
-                    nevents_tot = znp.sum([d._approx_nevents for d in self.data])
+                    nevents_tot = znp.sum([d.num_entries for d in self.data])
                     log_offset_sum = (
                         self._call_value(
                             data=self.data,


### PR DESCRIPTION
Allows `BinnedSamplerData` to be constructed from hist
Fixes stability in BinnedNLL


## Checklist

- [x] change approved
- [x] implementation finished
- [x]  docs updated
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
- [x] (if large change) tutorial added/updated?
