### PR TITLE
Fix AttributeError when calling freeze() twice on FitResult

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Deprecations
 
 Bug fixes and small changes
 ---------------------------
+- Fix AttributeError when calling ``freeze()`` method twice on FitResult
 
 Experimental
 ------------

--- a/src/zfit/minimizers/fitresult.py
+++ b/src/zfit/minimizers/fitresult.py
@@ -439,6 +439,7 @@ class FitResult(ZfitResult):
             message += "parameter(s) at their limit."
 
         self._cache_minuit = None  # in case used in errors
+        self._is_frozen = False  # flag to prevent double freezing
 
         self._evaluator = evaluator  # keep private for now
         self._niter = niter  # keep private for now
@@ -1530,6 +1531,9 @@ class FitResult(ZfitResult):
 
         Parameters can be accessed by their string name.
         """
+        if self._is_frozen:
+            return
+
         self._loss = self.loss.name
         self._minimizer = self.minimizer.name
         self._criterion = self.criterion.name
@@ -1555,6 +1559,7 @@ class FitResult(ZfitResult):
         if "evaluator" in self.info:
             self.info["evaluator"] = "evaluator_frozen"
         self._cache_minuit = None
+        self._is_frozen = True
 
     def __str__(self):
         string = Style.BRIGHT + "FitResult" + Style.NORMAL + f" of\n{self.loss} \nwith\n{self.minimizer}\n\n"

--- a/tests/test_fitresult.py
+++ b/tests/test_fitresult.py
@@ -325,6 +325,23 @@ def test_result_update_params():
     np.testing.assert_allclose(initial, params)
 
 
+def test_double_freeze():
+    """Test that calling freeze() twice doesn't raise an error."""
+    loss, (param_a, param_b, param_c) = create_loss(n=5000)
+    minimizer = zfit.minimize.Minuit(gradient=True, tol=10.0)
+    result = minimizer.minimize(loss)
+
+    # First freeze should work fine
+    result.freeze()
+
+    # Second freeze should not raise an AttributeError
+    result.freeze()  # This should not fail
+
+    # Verify the result is still valid after double freeze
+    assert result.fminopt is not None
+    assert result.edm is not None
+
+
 
 
 


### PR DESCRIPTION
- Add _is_frozen flag to prevent double freezing
- Return early from freeze() if already frozen
- Add test to verify double freeze behavior
- Update changelog with fix


Fixes #632 

## Checklist

- [x] change approved
- [x] implementation finished
- [x]  docs updated
- [x] correct namespace imported
- [x] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
- [x] (if large change) tutorial added/updated?
