### PR TITLE
Fix variance semantics (σ²) in binned chi2 and Poisson auto-variances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ tmp/*
 /CLAUDE.md
 /.claude/
 /tmp/
+.venv/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Deprecations
 Bug fixes and small changes
 ---------------------------
 - Fix ``zfit.run.set_cpus_explicit()`` which was failing after ``import zfit`` due to premature TensorFlow initialization.
+- Fix ``BinnedChi2`` and ``ExtendedBinnedChi2`` to use expected Poisson variance in the ``errors="expected"`` path.
+- Make ``BinnedData.from_tensor(..., variances=True)`` return Poisson variances (``Var[N] = N``) for unweighted counts, aligning binned ``variances`` semantics with σ².
 
 Experimental
 ------------

--- a/src/zfit/_data/binneddatav1.py
+++ b/src/zfit/_data/binneddatav1.py
@@ -229,14 +229,14 @@ class BinnedData(
             values: |@doc:binneddata.param.values| Corresponds to the counts of the histogram.
                Follows the definition of the
                `Unified Histogram Interface (UHI) <https://uhi.readthedocs.io/en/latest/plotting.html#plotting>`_. |@docend:binneddata.param.values|
-            variances: |@doc:binneddata.param.variances| Corresponds to the uncertainties of the histogram.
+            variances: |@doc:binneddata.param.variances| Corresponds to the variances (sigma**2) of the histogram.
                If ``True``, the uncertainties are created assuming that ``values``
-               have been drawn from a Poisson distribution. Follows the definition of the
+               have been drawn from a Poisson distribution (i.e. ``Var[N] = N`` for unweighted counts). Follows the definition of the
                `Unified Histogram Interface (UHI) <https://uhi.readthedocs.io/en/latest/plotting.html#plotting>`_. |@docend:binneddata.param.variances|
         """
         values = znp.asarray(values, znp.float64)
         if variances is True:
-            variances = znp.sqrt(values)
+            variances = values 
         elif variances is not None:
             variances = znp.asarray(variances)
         return cls(

--- a/src/zfit/_data/binneddatav1.py
+++ b/src/zfit/_data/binneddatav1.py
@@ -229,9 +229,9 @@ class BinnedData(
             values: |@doc:binneddata.param.values| Corresponds to the counts of the histogram.
                Follows the definition of the
                `Unified Histogram Interface (UHI) <https://uhi.readthedocs.io/en/latest/plotting.html#plotting>`_. |@docend:binneddata.param.values|
-            variances: |@doc:binneddata.param.variances| Corresponds to the uncertainties of the histogram.
+            variances: |@doc:binneddata.param.variances| Corresponds to the variances (sigma**2) of the histogram.
                If ``True``, the uncertainties are created assuming that ``values``
-               have been drawn from a Poisson distribution. Follows the definition of the
+               have been drawn from a Poisson distribution (i.e. ``Var[N] = N`` for unweighted counts). Follows the definition of the
                `Unified Histogram Interface (UHI) <https://uhi.readthedocs.io/en/latest/plotting.html#plotting>`_. |@docend:binneddata.param.variances|
         """
         values = znp.asarray(values, znp.float64)

--- a/src/zfit/_data/binneddatav1.py
+++ b/src/zfit/_data/binneddatav1.py
@@ -229,14 +229,14 @@ class BinnedData(
             values: |@doc:binneddata.param.values| Corresponds to the counts of the histogram.
                Follows the definition of the
                `Unified Histogram Interface (UHI) <https://uhi.readthedocs.io/en/latest/plotting.html#plotting>`_. |@docend:binneddata.param.values|
-            variances: |@doc:binneddata.param.variances| Corresponds to the variances (sigma**2) of the histogram.
+            variances: |@doc:binneddata.param.variances| Corresponds to the uncertainties of the histogram.
                If ``True``, the uncertainties are created assuming that ``values``
-               have been drawn from a Poisson distribution (i.e. ``Var[N] = N`` for unweighted counts). Follows the definition of the
+               have been drawn from a Poisson distribution. Follows the definition of the
                `Unified Histogram Interface (UHI) <https://uhi.readthedocs.io/en/latest/plotting.html#plotting>`_. |@docend:binneddata.param.variances|
         """
         values = znp.asarray(values, znp.float64)
         if variances is True:
-            variances = values 
+            variances = values
         elif variances is not None:
             variances = znp.asarray(variances)
         return cls(

--- a/src/zfit/_loss/binnedloss.py
+++ b/src/zfit/_loss/binnedloss.py
@@ -701,7 +701,7 @@ class BinnedChi2(BaseBinned):
 
             variance_method = self._options.get("errors")
             if variance_method == "expected":
-                variances = znp.sqrt(probs + znp.asarray(1e-307, dtype=znp.float64))
+                variances = probs + znp.asarray(1e-307, dtype=znp.float64)
             elif variance_method == "data":
                 variances = dat.variances()
             else:
@@ -853,7 +853,7 @@ class ExtendedBinnedChi2(BaseBinned):
             probs = mod.counts(dat)
             variance_method = self._options.get("errors")
             if variance_method == "expected":
-                variances = znp.sqrt(probs + znp.asarray(1e-307, dtype=znp.float64))
+                variances = probs + znp.asarray(1e-307, dtype=znp.float64)
             elif variance_method == "data":
                 variances = dat.variances()
             else:

--- a/tests/data/test_binneddata.py
+++ b/tests/data/test_binneddata.py
@@ -221,7 +221,7 @@ def test_variance():
     obs = zfit.Space("x", binning=binning1)
     values = znp.array([100.0, 200, 50])
     data = zfit.data.BinnedData.from_tensor(obs, values=values, variances=True)
-    data2 = zfit.data.BinnedData.from_tensor(obs, values=values, variances=values**0.5)
+    data2 = zfit.data.BinnedData.from_tensor(obs, values=values, variances=values)
     np.testing.assert_allclose(data.variances(), data2.variances())
 
 

--- a/tests/test_binnedloss.py
+++ b/tests/test_binnedloss.py
@@ -312,7 +312,7 @@ def loss_cls(request):
 
 def test_binned_chi2_expected_uses_variance_not_sigma_1(loss_cls):
     # bug: when using "errors=expected", the loss should use the expected counts as variances (i.e. Var = N_exp), but instead the sqrt(expected counts) were treated as variances, leading to wrong chi2 values for errors="expected".
-    
+
     # 2-bin toy: set model expected counts to [50., 80.], observed counts to [40., 90.]
     obs = zfit.Space("x", limits=(0.0, 2.0), binning=2)
 

--- a/tests/test_binnedloss.py
+++ b/tests/test_binnedloss.py
@@ -303,6 +303,80 @@ def test_binned_chi2_loss(Loss, empty, errors):  # TODO: add test with zeros in 
     )
     loss.value_gradient(loss.get_params())
 
+### start
+LOSS_CLASSES = [zfit.loss.BinnedChi2, zfit.loss.ExtendedBinnedChi2]
+
+@pytest.fixture(params=LOSS_CLASSES, ids=["BinnedChi2", "ExtendedBinnedChi2"])
+def loss_cls(request):
+    return request.param
+
+def test_binned_chi2_expected_uses_variance_not_sigma_1(loss_cls):
+    # bug: when using "errors=expected", the loss should use the expected counts as variances (i.e. Var = N_exp), but instead the sqrt(expected counts) were treated as variances, leading to wrong chi2 values for errors="expected".
+    
+    # 2-bin toy: set model expected counts to [50., 80.], observed counts to [40., 90.]
+    obs = zfit.Space("x", limits=(0.0, 2.0), binning=2)
+
+    expected = znp.asarray([50.0, 80.0], dtype=znp.float64)
+    observed = znp.asarray([40.0, 90.0], dtype=znp.float64)
+
+    # model: template PDF from expected counts
+    model_data = BinnedData.from_tensor(space=obs, values=expected)
+    model = BinnedTemplatePDFV1(data=model_data)
+
+    # data: observed counts (variances not needed for errors="expected")
+    data = BinnedData.from_tensor(space=obs, values=observed,  variances=True)
+
+    loss = loss_cls(
+        model=model,
+        data=data,
+        options={"errors": "expected"},
+    )
+
+    # Pearson chi2 with Poisson variance: Var = N_exp
+    chi2_manual = float(znp.sum((expected -observed) ** 2 / expected))
+
+    # zfit returns a tensor-like; cast to float
+    chi2_val = float(loss.value())
+
+    assert chi2_val == pytest.approx(chi2_manual, rel=1e-9, abs=0.0)
+
+
+def test_binned_chi2_expected_uses_variance_not_sigma_2(loss_cls):
+    # bug: data variances were treated as sigma when "variances=True", where in loss they should be treated as variances (i.e. sigma^2), leading to wrong chi2 values for errors="data".
+    # For BinnedData.from_tensor, "variances=True" is documented as Poisson-based variances; by UHI semantics variances should be σ². Therefore for counts N, variances should be N (not √N).
+
+    # 2-bin toy: set model expected counts to [50., 80.], observed counts to [40., 90.]
+    obs = zfit.Space("x", limits=(0.0, 2.0), binning=2)
+
+    expected = znp.asarray([50.0, 80.0], dtype=znp.float64)
+    observed = znp.asarray([40.0, 90.0], dtype=znp.float64)
+
+    # model: template PDF from expected counts
+    model_data = BinnedData.from_tensor(space=obs, values=expected)
+    model = BinnedTemplatePDFV1(data=model_data)
+
+    # data: observed counts (variances not needed for errors="expected")
+    data = BinnedData.from_tensor(space=obs, values=observed,  variances=True)
+    # data = BinnedData.from_tensor(space=obs, values=observed,  variances=observed) ## the right way to set the data variances for loss when 'errors="data"'.
+
+    loss = loss_cls(
+        model=model,
+        data=data,
+        options={"errors": "data"},
+    )
+
+    # Neyman chi2 with Poisson variance: Var = N_obs
+    chi2_manual = float(znp.sum((expected -observed) ** 2 / observed))
+
+    # zfit returns a tensor-like; cast to float
+    chi2_val = float(loss.value())
+
+    assert chi2_val == pytest.approx(chi2_manual, rel=1e-9, abs=0.0)
+
+
+### end
+
+
 
 @pytest.mark.parametrize(
     "weights",

--- a/utils/api/argdocs.yaml
+++ b/utils/api/argdocs.yaml
@@ -58,9 +58,9 @@ binneddata.param.values: |1+
                 `Unified Histogram Interface (UHI) <https://uhi.readthedocs.io/en/latest/plotting.html#plotting>`_.
 
 binneddata.param.variances: |1+
-    Corresponds to the uncertainties of the histogram.
+    Corresponds to the variances (sigma**2) of the histogram.
                 If ``True``, the uncertainties are created assuming that ``values``
-                have been drawn from a Poisson distribution. Follows the definition of the
+                have been drawn from a Poisson distribution (i.e. ``Var[N] = N`` for unweighted counts). Follows the definition of the
                 `Unified Histogram Interface (UHI) <https://uhi.readthedocs.io/en/latest/plotting.html#plotting>`_.
 
 data.param.obs: |1+


### PR DESCRIPTION
Fixes #725

### Why
Current behavior can silently mis-weight χ² by mixing σ and σ², affecting fit results without raising errors.

## Proposed Changes


 - Align binned variances semantics to consistently represent variance (σ²) (UHI-compatible) across binned data construction and chi² losses.

 - Fix BinnedChi2 and ExtendedBinnedChi2 with options={"errors": "expected"} to use expected Poisson variance Var = μ as denominator (instead of sqrt(μ)).

 - Make BinnedData.from_tensor(..., variances=True) generate Poisson variances (for unweighted counts: Var[N] = N) instead of standard deviations.

 - (Docs) Clarify that variances denotes σ² and that Poisson default is Var[N]=N.


## Tests added

- Regression tests covering both BinnedChi2 and ExtendedBinnedChi2 for:

  - errors="expected": Pearson χ² uses expected variance (σ²=μ)
  - errors="data": χ² uses data.variances() as σ². 
(see tests/test_binnedloss.py)

- Regression tests covering BinnedData for:
  -  BinnedData.from_tensor, variances=True: treat variances=σ².

## Behavior change: 
- BinnedData.from_tensor(..., variances=True) now returns Poisson variance (N) rather than standard deviation (sqrt(N)), aligning with the variances naming/UHI semantics and χ² denominator usage.

Happy to add a CHANGELOG entry if you’d like this documented as a behavior change.

## Checklist

- [ ] change approved
- [x] implementation finished
- [x]  docs updated
- [x] correct namespace imported
- [x] tests added
- [ ] CHANGELOG updated
- [ ] (if new public method/class) docs in rst file updated?
- [ ] (if large change) tutorial added/updated?
