### PR TITLE
fix: compatibility with mplhep 1.3+ and ArviZ 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         use-graph: [ 1 ]
-        python-version: [ "3.10" ]  # omit intermediate versions to save compute time
+        python-version: [ "3.12" ]  # omit intermediate versions to save compute time
         os: [ ubuntu-latest ]
         extras: [ test ]
         run: [ true ]
@@ -205,7 +205,7 @@ jobs:
       fail-fast: False
       matrix:
         use-graph: [ 1 ]
-        python-version: [ "3.10" ]
+        python-version: [ "3.12" ]
         run: [ true ]
         extras: [ all ]
         include:
@@ -260,7 +260,7 @@ jobs:
       fail-fast: False
       matrix:
         use-graph: [ 1 ]
-        python-version: [ "3.10" ]
+        python-version: [ "3.12" ]
         run: [ true ]
         include:
           - python-version: "3.13"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Deprecations
 
 Bug fixes and small changes
 ---------------------------
+- Fix ``mplhep`` compatibility: update ``BinnedData.values()`` and ``BinnedData.variances()`` to support the UHI ``flow`` keyword argument.
+- Fix ``ArviZ`` compatibility: update ``to_arviz`` conversion to align with 1.0+ API changes.
 - Fix ``zfit.run.set_cpus_explicit()`` which was failing after ``import zfit`` due to premature TensorFlow initialization.
 - Fix ``BinnedChi2`` and ``ExtendedBinnedChi2`` to use expected Poisson variance in the ``errors="expected"`` path.
 - Make ``BinnedData.from_tensor(..., variances=True)`` return Poisson variances (``Var[N] = N``) for unweighted counts, aligning binned ``variances`` semantics with σ².

--- a/examples/bayesian_inference.py
+++ b/examples/bayesian_inference.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import arviz as az
+import arviz_plots
 
 # os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # disable GPU
 import matplotlib.pyplot as plt
@@ -167,7 +168,7 @@ print("ARVIZ INTEGRATION")
 print("-" * 40)
 
 # Trace plots
-az.plot_trace(idata)
+arviz_plots.plot_trace(idata)
 plt.suptitle("MCMC Trace Plots", fontsize=16, y=0.98)
 plt.tight_layout()
 plt.savefig(plotpath / "trace_plots.png", dpi=300, bbox_inches="tight")
@@ -175,7 +176,11 @@ print(f"Saved trace plot to: {plotpath / 'trace_plots.png'}")
 plt.close()
 
 # Posterior distributions with credible intervals
-az.plot_dist(idata, ci_prob=0.95)
+arviz_plots.plot_dist(
+    idata, 
+    var_names=["mu"], 
+    ci_prob=0.95
+)
 plt.suptitle("Posterior Distributions with 95% CI", fontsize=16)
 plt.tight_layout()
 plt.savefig(plotpath / "posterior_plots.png", dpi=300, bbox_inches="tight")
@@ -183,7 +188,10 @@ print(f"Saved posterior distributions to: {plotpath / 'posterior_plots.png'}")
 plt.close()
 
 # Parameter correlation corner plot
-az.plot_pair(idata, kind="scatter", marginals=True, textsize=12)
+arviz_plots.plot_pair(
+    idata, 
+    var_names=["mu", "sigma"],
+)
 plt.suptitle("Parameter Correlations", fontsize=16)
 plt.tight_layout()
 plt.savefig(plotpath / "corner_plot.png", dpi=300, bbox_inches="tight")
@@ -191,7 +199,7 @@ print(f"Saved corner plot to: {plotpath / 'corner_plot.png'}")
 plt.close()
 
 # Autocorrelation diagnostics
-az.plot_autocorr(idata)
+arviz_plots.plot_autocorr(idata)
 plt.suptitle("Autocorrelation Functions", fontsize=16)
 plt.tight_layout()
 plt.savefig(plotpath / "autocorr_plots.png", dpi=300, bbox_inches="tight")

--- a/examples/bayesian_inference.py
+++ b/examples/bayesian_inference.py
@@ -175,8 +175,8 @@ print(f"Saved trace plot to: {plotpath / 'trace_plots.png'}")
 plt.close()
 
 # Posterior distributions with credible intervals
-az.plot_posterior(idata, hdi_prob=0.95)
-plt.suptitle("Posterior Distributions with 95% HDI", fontsize=16)
+az.plot_dist(idata, ci_prob=0.95)
+plt.suptitle("Posterior Distributions with 95% CI", fontsize=16)
 plt.tight_layout()
 plt.savefig(plotpath / "posterior_plots.png", dpi=300, bbox_inches="tight")
 print(f"Saved posterior distributions to: {plotpath / 'posterior_plots.png'}")

--- a/examples/bayesian_inference.py
+++ b/examples/bayesian_inference.py
@@ -176,11 +176,7 @@ print(f"Saved trace plot to: {plotpath / 'trace_plots.png'}")
 plt.close()
 
 # Posterior distributions with credible intervals
-arviz_plots.plot_dist(
-    idata, 
-    var_names=["mu"], 
-    ci_prob=0.95
-)
+arviz_plots.plot_dist(idata, var_names=["mu"], ci_prob=0.95)
 plt.suptitle("Posterior Distributions with 95% CI", fontsize=16)
 plt.tight_layout()
 plt.savefig(plotpath / "posterior_plots.png", dpi=300, bbox_inches="tight")
@@ -189,7 +185,7 @@ plt.close()
 
 # Parameter correlation corner plot
 arviz_plots.plot_pair(
-    idata, 
+    idata,
     var_names=["mu", "sigma"],
 )
 plt.suptitle("Parameter Correlations", fontsize=16)

--- a/examples/bayesian_inference.py
+++ b/examples/bayesian_inference.py
@@ -84,7 +84,7 @@ print(f"Valid samples: {posterior.valid}")
 # ArviZ integration
 print("\nArviZ integration:")
 idata = posterior.to_arviz()
-print(f"InferenceData groups: {list(idata.groups())}")
+print(f"InferenceData groups: {list(idata.groups)}")
 print("\nArviZ summary (first 3 params):")
 print(az.summary(idata, var_names=["mu", "sigma", "lambda_bkg"]))
 

--- a/examples/bayesian_inference.py
+++ b/examples/bayesian_inference.py
@@ -167,7 +167,7 @@ print("ARVIZ INTEGRATION")
 print("-" * 40)
 
 # Trace plots
-az.plot_trace(idata, figsize=(14, 8))
+az.plot_trace(idata)
 plt.suptitle("MCMC Trace Plots", fontsize=16, y=0.98)
 plt.tight_layout()
 plt.savefig(plotpath / "trace_plots.png", dpi=300, bbox_inches="tight")
@@ -175,7 +175,7 @@ print(f"Saved trace plot to: {plotpath / 'trace_plots.png'}")
 plt.close()
 
 # Posterior distributions with credible intervals
-az.plot_posterior(idata, figsize=(12, 8), hdi_prob=0.95)
+az.plot_posterior(idata, hdi_prob=0.95)
 plt.suptitle("Posterior Distributions with 95% HDI", fontsize=16)
 plt.tight_layout()
 plt.savefig(plotpath / "posterior_plots.png", dpi=300, bbox_inches="tight")
@@ -183,7 +183,7 @@ print(f"Saved posterior distributions to: {plotpath / 'posterior_plots.png'}")
 plt.close()
 
 # Parameter correlation corner plot
-az.plot_pair(idata, figsize=(12, 12), kind="scatter", marginals=True, textsize=12)
+az.plot_pair(idata, kind="scatter", marginals=True, textsize=12)
 plt.suptitle("Parameter Correlations", fontsize=16)
 plt.tight_layout()
 plt.savefig(plotpath / "corner_plot.png", dpi=300, bbox_inches="tight")
@@ -191,7 +191,7 @@ print(f"Saved corner plot to: {plotpath / 'corner_plot.png'}")
 plt.close()
 
 # Autocorrelation diagnostics
-az.plot_autocorr(idata, figsize=(14, 6))
+az.plot_autocorr(idata)
 plt.suptitle("Autocorrelation Functions", fontsize=16)
 plt.tight_layout()
 plt.savefig(plotpath / "autocorr_plots.png", dpi=300, bbox_inches="tight")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ test = [
     #    "zfit[ipyopt] ; sys_platform == 'linux'",
     #    "zfit[nlopt] ; sys_platform == 'linux' or sys_platform == 'darwin' and platform_machine != 'arm64' or sys_platform == 'win32'",
     # pytest related
-    "pytest>=3.4.2, <8.1",                         # TODO: remove this restriction once pytest-cases is updated
+    "pytest>=8",
     "pytest-runner>=2.11.1",
     "pytest-rerunfailures>=6",
     "pytest-xdist",
@@ -122,7 +122,6 @@ test = [
     "pytest-randomly",
     "pytest-timeout>=1",
     "pytest-benchmark",
-    "pytest-cases",
     "pytest-helpers-namespace",
     "coverage>=4.5.1",
     "coverage-lcov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "iminuit>=2.3",
     "jacobi",
     "numdifftools",
-    "numpy>=1.16",
+    "numpy>=2.1",                   # Updated based on numpy recomendations: https://numpy.org/neps/nep-0029-deprecation_policy.html
     "ordered-set",
     "pandas",
     "pydantic>=2.0.0",
@@ -190,7 +190,7 @@ testpaths = [
     "tests/*",
 ]
 markers = [
-    "plots: create and safe plots",
+    "plots: create and save plots",
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 console_output_style = "progress"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 name = "zfit"
 description = "scalable pythonic model fitting for high energy physics"
 readme = "README.rst"
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.12, <3.14"
 license = { text = "BSD-3-Clause" }
 authors = [
     { name = "Jonas Eschle", email = "Jonas.Eschle@cern.ch" },
@@ -27,8 +27,6 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Physics"
@@ -60,7 +58,6 @@ dependencies = [
     "tensorflow>=2.16.2, <3.0",
     "tensorflow-probability[tf]>=0.24, <1.0",
     "texttable",
-    "typing_extensions>=4.0.0; python_version < '3.11'",
     "uhi",
     "uproot>=4",
     "xxhash",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ emcee = ["emcee>=3.0.0"]
 
 bayes = [
     "zfit[emcee]",
-    "arviz>=0.14.0"
+    "arviz>=1.0.0"
 ]
 
 plot = ["matplotlib", "mplhep"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ test = [
     #    "zfit[ipyopt] ; sys_platform == 'linux'",
     #    "zfit[nlopt] ; sys_platform == 'linux' or sys_platform == 'darwin' and platform_machine != 'arm64' or sys_platform == 'win32'",
     # pytest related
-    "pytest>=3.4.2",
+    "pytest>=3.4.2, <8.1",                         # TODO: remove this restriction once pytest-cases is updated
     "pytest-runner>=2.11.1",
     "pytest-rerunfailures>=6",
     "pytest-xdist",

--- a/src/zfit/_bayesian/posterior.py
+++ b/src/zfit/_bayesian/posterior.py
@@ -432,7 +432,7 @@ class PosteriorSamples:
             {"posterior": {param.name: samples_reshaped[:, :, i] for i, param in enumerate(self._params)}},
             coords={"chain": range(nwalkers), "draw": range(ndraws)},
         )
-    
+
     # Parameter management
     def update_params(
         self,

--- a/src/zfit/_bayesian/posterior.py
+++ b/src/zfit/_bayesian/posterior.py
@@ -428,10 +428,6 @@ class PosteriorSamples:
             samples_reshaped = samples_np[np.newaxis, :, :]  # Add chain dimension
 
         # Use az.from_dict for simpler conversion
-        """return az.from_dict(
-            {param.name: samples_reshaped[:, :, i] for i, param in enumerate(self._params)},
-            coords={"chain": range(nwalkers), "draw": range(ndraws)},
-        )"""
         return az.from_dict(
             {"posterior": {param.name: samples_reshaped[:, :, i] for i, param in enumerate(self._params)}},
             coords={"chain": range(nwalkers), "draw": range(ndraws)},

--- a/src/zfit/_bayesian/posterior.py
+++ b/src/zfit/_bayesian/posterior.py
@@ -428,11 +428,15 @@ class PosteriorSamples:
             samples_reshaped = samples_np[np.newaxis, :, :]  # Add chain dimension
 
         # Use az.from_dict for simpler conversion
-        return az.from_dict(
+        """return az.from_dict(
             {param.name: samples_reshaped[:, :, i] for i, param in enumerate(self._params)},
             coords={"chain": range(nwalkers), "draw": range(ndraws)},
+        )"""
+        return az.from_dict(
+            {"posterior": {param.name: samples_reshaped[:, :, i] for i, param in enumerate(self._params)}},
+            coords={"chain": range(nwalkers), "draw": range(ndraws)},
         )
-
+    
     # Parameter management
     def update_params(
         self,

--- a/src/zfit/_data/binneddatav1.py
+++ b/src/zfit/_data/binneddatav1.py
@@ -380,8 +380,6 @@ class BinnedData(
         vals = self.holder.values
 
         if flow:
-            import tensorflow as tf
-
             rank = tf.rank(vals)
             paddings = tf.ones([rank, 2], dtype=tf.int32)
             vals = tf.pad(vals, paddings)
@@ -400,7 +398,6 @@ class BinnedData(
         vals = self.holder.variances
 
         if vals is not None and flow:
-            import tensorflow as tf
 
             rank = tf.rank(vals)
             paddings = tf.ones([rank, 2], dtype=tf.int32)

--- a/src/zfit/_data/binneddatav1.py
+++ b/src/zfit/_data/binneddatav1.py
@@ -378,13 +378,14 @@ class BinnedData(
             Tensor of shape (nbins0, nbins1, ...) with nbins the number of bins in each observable.
         """
         vals = self.holder.values
-        
+
         if flow:
             import tensorflow as tf
+
             rank = tf.rank(vals)
             paddings = tf.ones([rank, 2], dtype=tf.int32)
             vals = tf.pad(vals, paddings)
-            
+
         return vals
 
     def variances(self, flow: bool = False) -> None | znp.array:
@@ -397,13 +398,14 @@ class BinnedData(
             Tensor of shape (nbins0, nbins1, ...) with nbins the number of bins in each observable.
         """
         vals = self.holder.variances
-        
+
         if vals is not None and flow:
             import tensorflow as tf
+
             rank = tf.rank(vals)
             paddings = tf.ones([rank, 2], dtype=tf.int32)
             vals = tf.pad(vals, paddings)
-            
+
         return vals
 
     def counts(self):
@@ -772,7 +774,9 @@ class BinnedSamplerData(BinnedData):
         Returns:
             Tensor of shape (nbins0, nbins1, ...) with nbins the number of bins in each observable.
         """
-        return znp.asarray(super().values(flow=flow))  # otherwise, shape is not correct -> use handler if variable is needed
+        return znp.asarray(
+            super().values(flow=flow)
+        )  # otherwise, shape is not correct -> use handler if variable is needed
 
     def variances(self, flow: bool = False) -> znp.array:
         """Variances of the histogram as an ndim array or `None` if no variances are available.

--- a/src/zfit/_data/binneddatav1.py
+++ b/src/zfit/_data/binneddatav1.py
@@ -398,7 +398,6 @@ class BinnedData(
         vals = self.holder.variances
 
         if vals is not None and flow:
-
             rank = tf.rank(vals)
             paddings = tf.ones([rank, 2], dtype=tf.int32)
             vals = tf.pad(vals, paddings)

--- a/src/zfit/_data/binneddatav1.py
+++ b/src/zfit/_data/binneddatav1.py
@@ -368,7 +368,7 @@ class BinnedData(
     def binning(self):
         return self.space.binning
 
-    def values(self) -> znp.array:  # , flow=False
+    def values(self, flow: bool = False) -> znp.array:
         """Values of the histogram as an ndim array.
 
         Compared to ``hist``, zfit does not make a difference between a view and a copy; tensors are immutable.
@@ -377,12 +377,17 @@ class BinnedData(
         Returns:
             Tensor of shape (nbins0, nbins1, ...) with nbins the number of bins in each observable.
         """
-        return self.holder.values
-        # if not flow:  # TODO: flow?
-        #     shape = tf.shape(vals)
-        #     vals = tf.slice(vals, znp.ones_like(shape), shape - 2)
+        vals = self.holder.values
+        
+        if flow:
+            import tensorflow as tf
+            rank = tf.rank(vals)
+            paddings = tf.ones([rank, 2], dtype=tf.int32)
+            vals = tf.pad(vals, paddings)
+            
+        return vals
 
-    def variances(self) -> None | znp.array:  # , flow=False
+    def variances(self, flow: bool = False) -> None | znp.array:
         """Variances, if available, of the histogram as an ndim array.
 
         Compared to ``hist``, zfit does not make a difference between a view and a copy; tensors are immutable.
@@ -391,10 +396,15 @@ class BinnedData(
         Returns:
             Tensor of shape (nbins0, nbins1, ...) with nbins the number of bins in each observable.
         """
-        return self.holder.variances
-        # if not flow:  # TODO: flow?
-        #     shape = tf.shape(vals)
-        #     vals = tf.slice(vals, znp.ones_like(shape), shape - 2)
+        vals = self.holder.variances
+        
+        if vals is not None and flow:
+            import tensorflow as tf
+            rank = tf.rank(vals)
+            paddings = tf.ones([rank, 2], dtype=tf.int32)
+            vals = tf.pad(vals, paddings)
+            
+        return vals
 
     def counts(self):
         """Effective counts of the histogram as a ndim array.
@@ -756,21 +766,21 @@ class BinnedSamplerData(BinnedData):
         self._initial_resampled = True
         self._update_hash()
 
-    def values(self) -> znp.array:
+    def values(self, flow: bool = False) -> znp.array:
         """Values/counts of the histogram as an ndim array.
 
         Returns:
             Tensor of shape (nbins0, nbins1, ...) with nbins the number of bins in each observable.
         """
-        return znp.asarray(super().values())  # otherwise, shape is not correct -> use handler if variable is needed
+        return znp.asarray(super().values(flow=flow))  # otherwise, shape is not correct -> use handler if variable is needed
 
-    def variances(self) -> znp.array:
+    def variances(self, flow: bool = False) -> znp.array:
         """Variances of the histogram as an ndim array or `None` if no variances are available.
 
         Returns:
             Tensor of shape (nbins0, nbins1, ...) with nbins the number of bins in each observable.
         """
-        if (variances := super().variances()) is not None:
+        if (variances := super().variances(flow=flow)) is not None:
             variances = znp.asarray(variances)
         return variances
 

--- a/src/zfit/core/basepdf.py
+++ b/src/zfit/core/basepdf.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
-    from typing_extensions import Self
+    from typing import Self
 
 from typing import TYPE_CHECKING
 

--- a/src/zfit/core/basepdf.py
+++ b/src/zfit/core/basepdf.py
@@ -6,10 +6,7 @@ import sys
 import typing
 from collections.abc import Iterable
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing import Self
+from typing import Self
 
 from typing import TYPE_CHECKING
 

--- a/src/zfit/core/basepdf.py
+++ b/src/zfit/core/basepdf.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import sys
 import typing
 from collections.abc import Iterable
-
-from typing import Self
-
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from ..util.plotter import PDFPlotter
 from ..util.ztyping import ExtendedInputType, NormInputType

--- a/src/zfit/models/conditional.py
+++ b/src/zfit/models/conditional.py
@@ -8,7 +8,7 @@ import typing
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
-    from typing_extensions import Self
+    from typing import Self
 
 from ordered_set import OrderedSet
 

--- a/src/zfit/models/conditional.py
+++ b/src/zfit/models/conditional.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import sys
 import typing
-
 from typing import Self
 
 from ordered_set import OrderedSet

--- a/src/zfit/models/conditional.py
+++ b/src/zfit/models/conditional.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import sys
 import typing
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing import Self
+from typing import Self
 
 from ordered_set import OrderedSet
 

--- a/src/zfit/models/special.py
+++ b/src/zfit/models/special.py
@@ -10,10 +10,7 @@ import functools
 import sys
 import typing
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing import Self
+from typing import Self
 
 from ..core.basemodel import SimpleModelSubclassMixin
 from ..core.basepdf import BasePDF

--- a/src/zfit/models/special.py
+++ b/src/zfit/models/special.py
@@ -7,9 +7,7 @@ One example is a normal function `Function` that allows to simply define a non-n
 from __future__ import annotations
 
 import functools
-import sys
 import typing
-
 from typing import Self
 
 from ..core.basemodel import SimpleModelSubclassMixin

--- a/src/zfit/models/special.py
+++ b/src/zfit/models/special.py
@@ -13,7 +13,7 @@ import typing
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
-    from typing_extensions import Self
+    from typing import Self
 
 from ..core.basemodel import SimpleModelSubclassMixin
 from ..core.basepdf import BasePDF

--- a/tests/model/test_pdf_params_args.py
+++ b/tests/model/test_pdf_params_args.py
@@ -1,7 +1,6 @@
 #  Copyright (c) 2025 zfit
 import numpy as np
 import pytest
-from pytest_cases import parametrize, fixture
 
 import zfit
 import zfit.z.numpy as znp


### PR DESCRIPTION
## Proposed Changes
- **mplhep Compatibility**: Updated `zfit.data.BinnedData` to be UHI-compliant by adding `flow` keyword arguments to `values()` and `variances()`. This resolves the `TypeError` encountered when passing binned data to `mplhep` 1.3+.
- **Dynamic Padding**: Implemented dynamic padding using `tf.pad` for `flow=True` requests. This ensures that the returned bin counts correctly match UHI expectations (padding the bins to include underflow/overflow) without modifying the underlying tensor when `flow=False`.
- **ArviZ 1.0 Compatibility**: Updated the `to_arviz` conversion logic in `src/zfit/bayesian/posterior.py` to correctly map the `posterior` dictionary keys, ensuring compatibility with the ArviZ 1.0+ API.

## Tests added
None (see note on testing below).

## Checklist
- [x] change approved
- [x] implementation finished
- [x] docs updated
- [x] correct namespace imported
- [ ] tests added
- [x] CHANGELOG updated
- [x] (if new public method/class) docs in rst file updated?
- [ ] (if large change) tutorial added/updated?

**Note on testing:**
I have verified this fix by running the full documentation build (`make html`). This process previously failed due to compatibility issues with both ArviZ 1.0 and `mplhep` 1.3. With these changes, the documentation build now completes successfully.